### PR TITLE
docs: update download links to v4.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,10 +234,10 @@ Download the latest release from [GitHub Releases](https://github.com/saladday/c
 
 ```bash
 # Download Universal Binary (recommended, supports Apple Silicon + Intel)
-curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.4.0-darwin-universal.tar.gz
+curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.5.0-darwin-universal.tar.gz
 
 # Extract
-tar -xzf cc-switch-cli-v4.4.0-darwin-universal.tar.gz
+tar -xzf cc-switch-cli-v4.5.0-darwin-universal.tar.gz
 
 # Add execute permission
 chmod +x cc-switch
@@ -253,10 +253,10 @@ xattr -cr /usr/local/bin/cc-switch
 
 ```bash
 # Download
-curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.4.0-linux-x64-musl.tar.gz
+curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.5.0-linux-x64-musl.tar.gz
 
 # Extract
-tar -xzf cc-switch-cli-v4.4.0-linux-x64-musl.tar.gz
+tar -xzf cc-switch-cli-v4.5.0-linux-x64-musl.tar.gz
 
 # Add execute permission
 chmod +x cc-switch
@@ -269,8 +269,8 @@ sudo mv cc-switch /usr/local/bin/
 
 ```bash
 # For Raspberry Pi or ARM servers
-curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.4.0-linux-arm64-musl.tar.gz
-tar -xzf cc-switch-cli-v4.4.0-linux-arm64-musl.tar.gz
+curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.5.0-linux-arm64-musl.tar.gz
+tar -xzf cc-switch-cli-v4.5.0-linux-arm64-musl.tar.gz
 chmod +x cc-switch
 sudo mv cc-switch /usr/local/bin/
 ```
@@ -279,7 +279,7 @@ sudo mv cc-switch /usr/local/bin/
 
 ```powershell
 # Download the zip file
-# https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.4.0-windows-x64.zip
+# https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.5.0-windows-x64.zip
 
 # After extracting, move cc-switch.exe to a PATH directory, e.g.:
 move cc-switch.exe C:\Windows\System32\


### PR DESCRIPTION
## Summary
- Update download links in README.md from v4.4.0 to v4.5.0
- Affected links: macOS, Linux x64, Linux ARM64, Windows

## Changes
All 7 occurrences of `v4.4.0` in download commands have been replaced with `v4.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)