### PR TITLE
docs+ci: publish versionless assets and update download URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,18 +167,24 @@ jobs:
           if [ -f "artifacts/cc-switch-cli-darwin-universal/cc-switch" ]; then
             tar -czf release-assets/cc-switch-cli-${VERSION}-darwin-universal.tar.gz \
               -C artifacts/cc-switch-cli-darwin-universal cc-switch
+            cp release-assets/cc-switch-cli-${VERSION}-darwin-universal.tar.gz \
+              release-assets/cc-switch-cli-darwin-universal.tar.gz
           fi
 
           # macOS ARM64
           if [ -f "artifacts/cc-switch-cli-darwin-arm64/cc-switch" ]; then
             tar -czf release-assets/cc-switch-cli-${VERSION}-darwin-arm64.tar.gz \
               -C artifacts/cc-switch-cli-darwin-arm64 cc-switch
+            cp release-assets/cc-switch-cli-${VERSION}-darwin-arm64.tar.gz \
+              release-assets/cc-switch-cli-darwin-arm64.tar.gz
           fi
 
           # macOS x64
           if [ -f "artifacts/cc-switch-cli-darwin-x64/cc-switch" ]; then
             tar -czf release-assets/cc-switch-cli-${VERSION}-darwin-x64.tar.gz \
               -C artifacts/cc-switch-cli-darwin-x64 cc-switch
+            cp release-assets/cc-switch-cli-${VERSION}-darwin-x64.tar.gz \
+              release-assets/cc-switch-cli-darwin-x64.tar.gz
           fi
 
           # Windows
@@ -186,30 +192,40 @@ jobs:
             cd artifacts/cc-switch-cli-windows-x64
             zip ../../release-assets/cc-switch-cli-${VERSION}-windows-x64.zip cc-switch.exe
             cd ../..
+            cp release-assets/cc-switch-cli-${VERSION}-windows-x64.zip \
+              release-assets/cc-switch-cli-windows-x64.zip
           fi
 
           # Linux x64 - MUSL
           if [ -f "artifacts/cc-switch-cli-linux-x64-musl/cc-switch" ]; then
             tar -czf release-assets/cc-switch-cli-${VERSION}-linux-x64-musl.tar.gz \
               -C artifacts/cc-switch-cli-linux-x64-musl cc-switch
+            cp release-assets/cc-switch-cli-${VERSION}-linux-x64-musl.tar.gz \
+              release-assets/cc-switch-cli-linux-x64-musl.tar.gz
           fi
 
           # Linux x64 - GLIBC
           if [ -f "artifacts/cc-switch-cli-linux-x64/cc-switch" ]; then
             tar -czf release-assets/cc-switch-cli-${VERSION}-linux-x64.tar.gz \
               -C artifacts/cc-switch-cli-linux-x64 cc-switch
+            cp release-assets/cc-switch-cli-${VERSION}-linux-x64.tar.gz \
+              release-assets/cc-switch-cli-linux-x64.tar.gz
           fi
 
           # Linux ARM64 - MUSL
           if [ -f "artifacts/cc-switch-cli-linux-arm64-musl/cc-switch" ]; then
             tar -czf release-assets/cc-switch-cli-${VERSION}-linux-arm64-musl.tar.gz \
               -C artifacts/cc-switch-cli-linux-arm64-musl cc-switch
+            cp release-assets/cc-switch-cli-${VERSION}-linux-arm64-musl.tar.gz \
+              release-assets/cc-switch-cli-linux-arm64-musl.tar.gz
           fi
 
           # Linux ARM64 - GLIBC
           if [ -f "artifacts/cc-switch-cli-linux-arm64/cc-switch" ]; then
             tar -czf release-assets/cc-switch-cli-${VERSION}-linux-arm64.tar.gz \
               -C artifacts/cc-switch-cli-linux-arm64 cc-switch
+            cp release-assets/cc-switch-cli-${VERSION}-linux-arm64.tar.gz \
+              release-assets/cc-switch-cli-linux-arm64.tar.gz
           fi
 
           echo "=== Release assets ==="

--- a/README.md
+++ b/README.md
@@ -234,10 +234,10 @@ Download the latest release from [GitHub Releases](https://github.com/saladday/c
 
 ```bash
 # Download Universal Binary (recommended, supports Apple Silicon + Intel)
-curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.5.0-darwin-universal.tar.gz
+curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-darwin-universal.tar.gz
 
 # Extract
-tar -xzf cc-switch-cli-v4.5.0-darwin-universal.tar.gz
+tar -xzf cc-switch-cli-darwin-universal.tar.gz
 
 # Add execute permission
 chmod +x cc-switch
@@ -253,10 +253,10 @@ xattr -cr /usr/local/bin/cc-switch
 
 ```bash
 # Download
-curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.5.0-linux-x64-musl.tar.gz
+curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-linux-x64-musl.tar.gz
 
 # Extract
-tar -xzf cc-switch-cli-v4.5.0-linux-x64-musl.tar.gz
+tar -xzf cc-switch-cli-linux-x64-musl.tar.gz
 
 # Add execute permission
 chmod +x cc-switch
@@ -269,8 +269,8 @@ sudo mv cc-switch /usr/local/bin/
 
 ```bash
 # For Raspberry Pi or ARM servers
-curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.5.0-linux-arm64-musl.tar.gz
-tar -xzf cc-switch-cli-v4.5.0-linux-arm64-musl.tar.gz
+curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-linux-arm64-musl.tar.gz
+tar -xzf cc-switch-cli-linux-arm64-musl.tar.gz
 chmod +x cc-switch
 sudo mv cc-switch /usr/local/bin/
 ```
@@ -279,7 +279,7 @@ sudo mv cc-switch /usr/local/bin/
 
 ```powershell
 # Download the zip file
-# https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.5.0-windows-x64.zip
+# https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-windows-x64.zip
 
 # After extracting, move cc-switch.exe to a PATH directory, e.g.:
 move cc-switch.exe C:\Windows\System32\

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -234,10 +234,10 @@ cc-switch env list                   # 列出环境变量
 
 ```bash
 # 下载 Universal Binary（推荐，支持 Apple Silicon + Intel）
-curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.4.0-darwin-universal.tar.gz
+curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-darwin-universal.tar.gz
 
 # 解压
-tar -xzf cc-switch-cli-v4.4.0-darwin-universal.tar.gz
+tar -xzf cc-switch-cli-darwin-universal.tar.gz
 
 # 添加执行权限
 chmod +x cc-switch
@@ -253,10 +253,10 @@ xattr -cr /usr/local/bin/cc-switch
 
 ```bash
 # 下载
-curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.4.0-linux-x64-musl.tar.gz
+curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-linux-x64-musl.tar.gz
 
 # 解压
-tar -xzf cc-switch-cli-v4.4.0-linux-x64-musl.tar.gz
+tar -xzf cc-switch-cli-linux-x64-musl.tar.gz
 
 # 添加执行权限
 chmod +x cc-switch
@@ -269,8 +269,8 @@ sudo mv cc-switch /usr/local/bin/
 
 ```bash
 # 适用于树莓派或 ARM 服务器
-curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.4.0-linux-arm64-musl.tar.gz
-tar -xzf cc-switch-cli-v4.4.0-linux-arm64-musl.tar.gz
+curl -LO https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-linux-arm64-musl.tar.gz
+tar -xzf cc-switch-cli-linux-arm64-musl.tar.gz
 chmod +x cc-switch
 sudo mv cc-switch /usr/local/bin/
 ```
@@ -279,7 +279,7 @@ sudo mv cc-switch /usr/local/bin/
 
 ```powershell
 # 下载 zip 文件
-# https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-v4.4.0-windows-x64.zip
+# https://github.com/saladday/cc-switch-cli/releases/latest/download/cc-switch-cli-windows-x64.zip
 
 # 解压后将 cc-switch.exe 移动到 PATH 目录，例如：
 move cc-switch.exe C:\Windows\System32\


### PR DESCRIPTION
## Summary
- Update the release workflow to publish versionless asset filenames alongside versioned ones.
- Update README/README_ZH download URLs to use those versionless assets.

## Why
Users can always download the latest assets without editing the version number.

## How to test
- N/A (docs + CI only)

## Release note
Please create and push a new tag (e.g. vX.Y.Z) to trigger the release workflow so the versionless assets are
actually generated and uploaded.