### PR TITLE
feat(cli): add hardened self-update command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,12 @@ jobs:
               release-assets/cc-switch-cli-linux-arm64.tar.gz
           fi
 
+          # Checksums for all release assets
+          (
+            cd release-assets
+            sha256sum * > checksums.txt
+          )
+
           echo "=== Release assets ==="
           ls -lh release-assets/
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ cc-switch completions <shell>        # Generate shell completions (bash/zsh/fish
 # Environment management
 cc-switch env check                  # Check for environment conflicts
 cc-switch env list                   # List environment variables
+
+# Self-update
+cc-switch update                     # Update to latest release
+cc-switch update --version v4.6.2    # Update to a specific version
 ```
 
 ---

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -252,6 +252,10 @@ cc-switch completions <shell>        # 生成 shell 补全（bash/zsh/fish/power
 # 环境管理
 cc-switch env check                  # 检查环境冲突
 cc-switch env list                   # 列出环境变量
+
+# 自更新
+cc-switch update                     # 更新到最新版本
+cc-switch update --version v4.6.2    # 更新到指定版本
 ```
 
 ---

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "dirs",
  "edit",
  "env_logger",
+ "flate2",
  "futures",
  "indexmap",
  "indicatif",
@@ -298,10 +299,14 @@ dependencies = [
  "reqwest",
  "rquickjs",
  "rusqlite",
+ "self-replace",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
  "serial_test",
+ "sha2",
+ "tar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -814,6 +819,17 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1503,6 +1519,7 @@ checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -2415,6 +2432,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2699,6 +2727,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3746,6 +3785,16 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.2",
+]
 
 [[package]]
 name = "xz2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,6 +64,10 @@ futures = "0.3"
 
 # Utilities
 regex = "1.10"
+sha2 = "0.10"
+semver = "1.0"
+flate2 = "1.0"
+tar = "0.4"
 rquickjs = { version = "0.8", features = ["array-buffer", "classes"] }
 zip = "2.2"
 url = "2.5"
@@ -72,6 +76,7 @@ unicode-width = "0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.52"
+self-replace = "1"
 
 # Optimize release binary size to help reduce AppImage footprint
 [profile.release]

--- a/src-tauri/src/cli/commands/mod.rs
+++ b/src-tauri/src/cli/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod prompts;
 pub mod provider;
 pub mod provider_input;
 pub mod skills;
+pub mod update;

--- a/src-tauri/src/cli/commands/update.rs
+++ b/src-tauri/src/cli/commands/update.rs
@@ -1,0 +1,827 @@
+use clap::Args;
+use flate2::read::GzDecoder;
+use semver::Version;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tar::Archive;
+use tempfile::TempDir;
+use url::Url;
+
+use crate::cli::ui::{highlight, info, success};
+use crate::error::AppError;
+
+const REPO_URL: &str = env!("CARGO_PKG_REPOSITORY");
+const BINARY_NAME: &str = "cc-switch";
+const CHECKSUMS_FILE_NAME: &str = "checksums.txt";
+const HTTP_REQUEST_TIMEOUT_SECS: u64 = 30;
+const MAX_RELEASE_ASSET_SIZE_BYTES: u64 = 100 * 1024 * 1024;
+const USER_AGENT: &str = concat!(
+    env!("CARGO_PKG_NAME"),
+    "-updater/",
+    env!("CARGO_PKG_VERSION")
+);
+
+#[derive(Args, Debug, Clone)]
+pub struct UpdateCommand {
+    /// Target version (example: v4.6.2). Defaults to latest release.
+    #[arg(long)]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseInfo {
+    tag_name: String,
+    #[serde(default)]
+    assets: Vec<ReleaseAsset>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct ReleaseAsset {
+    name: String,
+    browser_download_url: String,
+    #[serde(default)]
+    digest: Option<String>,
+}
+
+struct DownloadedAsset {
+    _temp_dir: TempDir,
+    archive_path: PathBuf,
+}
+
+pub fn execute(cmd: UpdateCommand) -> Result<(), AppError> {
+    let runtime = create_runtime()?;
+    runtime.block_on(execute_async(cmd))
+}
+
+async fn execute_async(cmd: UpdateCommand) -> Result<(), AppError> {
+    let current_version = env!("CARGO_PKG_VERSION");
+    let explicit_version = cmd.version.as_deref().is_some_and(|v| !v.trim().is_empty());
+    let client = create_http_client()?;
+    let target_tag = resolve_target_tag(&client, cmd.version.as_deref()).await?;
+    let target_version = target_tag.trim_start_matches('v');
+
+    if target_version == current_version {
+        println!(
+            "{}",
+            info(&format!("Already on latest version: v{current_version}"))
+        );
+        return Ok(());
+    }
+
+    if should_skip_implicit_downgrade(current_version, target_version, explicit_version) {
+        println!(
+            "{}",
+            info(&format!(
+                "Current version v{current_version} is newer than target {target_tag}; skipping automatic downgrade. Use `cc-switch update --version {target_tag}` to force."
+            ))
+        );
+        return Ok(());
+    }
+
+    let expected_asset_name = release_asset_name()?;
+    let release = fetch_release_by_tag(&client, &target_tag).await?;
+    let release_asset = select_release_asset(&release.assets, &target_tag, &expected_asset_name)
+        .ok_or_else(|| {
+            AppError::Message(format!(
+                "Release {target_tag} does not include expected asset '{expected_asset_name}' (or compatible tagged variant)."
+            ))
+        })?;
+    let download_url = release_asset.browser_download_url.as_str();
+
+    println!(
+        "{}",
+        highlight(&format!("Current version: v{current_version}"))
+    );
+    println!("{}", highlight(&format!("Updating to: {target_tag}")));
+    println!("{}", info(&format!("Downloading: {download_url}")));
+    if release_asset.digest.is_some() {
+        println!(
+            "{}",
+            info("Verifying checksum from release metadata digest.")
+        );
+    } else {
+        let checksum_url =
+            format!("{REPO_URL}/releases/download/{target_tag}/{CHECKSUMS_FILE_NAME}");
+        println!("{}", info(&format!("Verifying checksum: {checksum_url}")));
+    }
+
+    let downloaded_asset =
+        download_release_asset(&client, download_url, release_asset.name.as_str()).await?;
+    verify_asset_checksum(
+        &client,
+        &downloaded_asset.archive_path,
+        &target_tag,
+        release_asset,
+    )
+    .await?;
+    let extracted_binary = extract_binary(&downloaded_asset.archive_path)?;
+    replace_current_binary(&extracted_binary)?;
+
+    println!(
+        "{}",
+        success(&format!("Updated successfully to {target_tag}"))
+    );
+    println!(
+        "{}",
+        info("Run `cc-switch --version` to verify the installed version.")
+    );
+    Ok(())
+}
+
+fn create_runtime() -> Result<tokio::runtime::Runtime, AppError> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| AppError::Message(format!("Failed to create runtime: {e}")))
+}
+
+fn create_http_client() -> Result<reqwest::Client, AppError> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(HTTP_REQUEST_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| AppError::Message(format!("Failed to initialize HTTP client: {e}")))
+}
+
+async fn resolve_target_tag(
+    client: &reqwest::Client,
+    version: Option<&str>,
+) -> Result<String, AppError> {
+    let tag = match version.map(str::trim).filter(|v| !v.is_empty()) {
+        Some(version) => normalize_tag(version),
+        None => fetch_latest_release_tag(client).await?,
+    };
+    validate_target_tag(&tag)?;
+    Ok(tag)
+}
+
+fn validate_target_tag(tag: &str) -> Result<(), AppError> {
+    if !tag.starts_with('v') {
+        return Err(AppError::Message(format!(
+            "Invalid version tag '{tag}': must start with 'v'."
+        )));
+    }
+    if tag.len() > 64 {
+        return Err(AppError::Message(format!(
+            "Invalid version tag '{tag}': too long."
+        )));
+    }
+    if tag.contains('/') || tag.contains('\\') || tag.contains("..") {
+        return Err(AppError::Message(format!(
+            "Invalid version tag '{tag}': contains forbidden path characters."
+        )));
+    }
+    if !tag
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '.' || ch == '-' || ch == '_')
+    {
+        return Err(AppError::Message(format!(
+            "Invalid version tag '{tag}': only [A-Za-z0-9._-] allowed."
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_tag(version: &str) -> String {
+    if version.starts_with('v') {
+        version.to_string()
+    } else {
+        format!("v{version}")
+    }
+}
+
+async fn fetch_latest_release_tag(client: &reqwest::Client) -> Result<String, AppError> {
+    let api_url = release_api_url(REPO_URL, "latest")?;
+    let release = client
+        .get(api_url)
+        .header(reqwest::header::USER_AGENT, USER_AGENT)
+        .send()
+        .await
+        .map_err(|e| AppError::Message(format!("Failed to query latest release: {e}")))?
+        .error_for_status()
+        .map_err(|e| AppError::Message(format!("Release API returned error: {e}")))?
+        .json::<ReleaseInfo>()
+        .await
+        .map_err(|e| AppError::Message(format!("Failed to parse latest release response: {e}")))?;
+    Ok(release.tag_name)
+}
+
+async fn fetch_release_by_tag(
+    client: &reqwest::Client,
+    tag: &str,
+) -> Result<ReleaseInfo, AppError> {
+    let api_url = release_api_url(REPO_URL, &format!("tags/{tag}"))?;
+    client
+        .get(api_url)
+        .header(reqwest::header::USER_AGENT, USER_AGENT)
+        .send()
+        .await
+        .map_err(|e| AppError::Message(format!("Failed to query release {tag}: {e}")))?
+        .error_for_status()
+        .map_err(|e| AppError::Message(format!("Release API returned error for {tag}: {e}")))?
+        .json::<ReleaseInfo>()
+        .await
+        .map_err(|e| AppError::Message(format!("Failed to parse release response for {tag}: {e}")))
+}
+
+fn release_api_url(repo_url: &str, suffix: &str) -> Result<Url, AppError> {
+    let repo_url = Url::parse(repo_url)
+        .map_err(|e| AppError::Message(format!("Invalid repository URL '{repo_url}': {e}")))?;
+    let host = repo_url
+        .host_str()
+        .ok_or_else(|| AppError::Message(format!("Repository URL is missing host: {repo_url}")))?;
+
+    let path = repo_url.path().trim_matches('/');
+    let mut parts = path.split('/');
+    let owner = parts.next().filter(|s| !s.is_empty()).ok_or_else(|| {
+        AppError::Message(format!(
+            "Repository URL must include owner and repo: {repo_url}"
+        ))
+    })?;
+    let repo = parts.next().filter(|s| !s.is_empty()).ok_or_else(|| {
+        AppError::Message(format!(
+            "Repository URL must include owner and repo: {repo_url}"
+        ))
+    })?;
+    if parts.next().is_some() {
+        return Err(AppError::Message(format!(
+            "Repository URL must be in '<host>/<owner>/<repo>' format: {repo_url}"
+        )));
+    }
+    let repo = repo.strip_suffix(".git").unwrap_or(repo);
+
+    let api_path = if host == "github.com" {
+        format!("/repos/{owner}/{repo}/releases/{suffix}")
+    } else {
+        format!("/api/v3/repos/{owner}/{repo}/releases/{suffix}")
+    };
+
+    let mut api_url = repo_url.clone();
+    if host == "github.com" {
+        api_url
+            .set_host(Some("api.github.com"))
+            .map_err(|_| AppError::Message("Failed to set GitHub API host.".to_string()))?;
+    }
+    api_url.set_path(&api_path);
+    api_url.set_query(None);
+    api_url.set_fragment(None);
+
+    Ok(api_url)
+}
+
+fn select_release_asset<'a>(
+    assets: &'a [ReleaseAsset],
+    target_tag: &str,
+    expected_asset_name: &str,
+) -> Option<&'a ReleaseAsset> {
+    let tagged_variant = tagged_asset_name(target_tag, expected_asset_name);
+
+    assets
+        .iter()
+        .find(|asset| asset.name == expected_asset_name)
+        .or_else(|| assets.iter().find(|asset| asset.name == tagged_variant))
+}
+
+fn tagged_asset_name(tag: &str, asset_name: &str) -> String {
+    if let Some(suffix) = asset_name.strip_prefix("cc-switch-cli-") {
+        return format!("cc-switch-cli-{tag}-{suffix}");
+    }
+    asset_name.to_string()
+}
+
+fn release_asset_name() -> Result<String, AppError> {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+
+    let name = match (os, arch) {
+        ("macos", "x86_64") | ("macos", "aarch64") => "cc-switch-cli-darwin-universal.tar.gz",
+        ("linux", "x86_64") => "cc-switch-cli-linux-x64-musl.tar.gz",
+        ("linux", "aarch64") => "cc-switch-cli-linux-arm64-musl.tar.gz",
+        ("windows", "x86_64") => "cc-switch-cli-windows-x64.zip",
+        _ => {
+            return Err(AppError::Message(format!(
+                "Self-update is not supported for platform {os}/{arch}."
+            )));
+        }
+    };
+
+    Ok(name.to_string())
+}
+
+async fn download_release_asset(
+    client: &reqwest::Client,
+    url: &str,
+    asset_name: &str,
+) -> Result<DownloadedAsset, AppError> {
+    let mut response = client
+        .get(url)
+        .header(reqwest::header::USER_AGENT, USER_AGENT)
+        .send()
+        .await
+        .map_err(|e| AppError::Message(format!("Failed to download release asset: {e}")))?
+        .error_for_status()
+        .map_err(|e| AppError::Message(format!("Release asset request failed: {e}")))?;
+    if let Some(content_length) = response.content_length() {
+        validate_download_size_limit(content_length, asset_name)?;
+    }
+
+    let temp_dir = tempfile::tempdir()
+        .map_err(|e| AppError::Message(format!("Failed to create temp directory: {e}")))?;
+    let file_name = sanitized_asset_file_name(asset_name)?;
+    let archive_path = temp_dir.path().join(file_name);
+    let mut output = fs::File::create(&archive_path).map_err(|e| AppError::io(&archive_path, e))?;
+    let mut downloaded_bytes = 0_u64;
+
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| AppError::Message(format!("Failed to read release asset chunk: {e}")))?
+    {
+        downloaded_bytes = downloaded_bytes.saturating_add(chunk.len() as u64);
+        validate_download_size_limit(downloaded_bytes, asset_name)?;
+        output
+            .write_all(&chunk)
+            .map_err(|e| AppError::io(&archive_path, e))?;
+    }
+
+    Ok(DownloadedAsset {
+        _temp_dir: temp_dir,
+        archive_path,
+    })
+}
+
+fn sanitized_asset_file_name(asset_name: &str) -> Result<&str, AppError> {
+    Path::new(asset_name)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| AppError::Message(format!("Invalid asset name: {asset_name}")))
+}
+
+fn validate_download_size_limit(size_bytes: u64, asset_name: &str) -> Result<(), AppError> {
+    if size_bytes <= MAX_RELEASE_ASSET_SIZE_BYTES {
+        return Ok(());
+    }
+    let max_mb = MAX_RELEASE_ASSET_SIZE_BYTES / (1024 * 1024);
+    let size_mb = size_bytes / (1024 * 1024);
+    Err(AppError::Message(format!(
+        "Release asset '{asset_name}' is too large ({size_mb} MB). Maximum allowed size is {max_mb} MB."
+    )))
+}
+
+async fn verify_asset_checksum(
+    client: &reqwest::Client,
+    archive_path: &Path,
+    target_tag: &str,
+    release_asset: &ReleaseAsset,
+) -> Result<(), AppError> {
+    let actual = compute_sha256_hex(archive_path)?;
+
+    let expected = if let Some(expected) = release_asset
+        .digest
+        .as_deref()
+        .and_then(parse_sha256_digest)
+    {
+        expected
+    } else {
+        let checksum_url =
+            format!("{REPO_URL}/releases/download/{target_tag}/{CHECKSUMS_FILE_NAME}");
+        let checksum_content = download_text(client, &checksum_url).await?;
+        parse_checksum_for_asset(&checksum_content, release_asset.name.as_str())?
+    };
+
+    if actual != expected {
+        return Err(AppError::Message(format!(
+            "Checksum mismatch for {}: expected {expected}, got {actual}.",
+            release_asset.name
+        )));
+    }
+
+    Ok(())
+}
+
+fn compute_sha256_hex(path: &Path) -> Result<String, AppError> {
+    let mut file = fs::File::open(path).map_err(|e| AppError::io(path, e))?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher).map_err(|e| AppError::io(path, e))?;
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn should_skip_implicit_downgrade(
+    current_version: &str,
+    target_version: &str,
+    explicit_version: bool,
+) -> bool {
+    if explicit_version {
+        return false;
+    }
+    let Ok(current) = Version::parse(current_version) else {
+        return false;
+    };
+    let Ok(target) = Version::parse(target_version) else {
+        return false;
+    };
+    target < current
+}
+
+async fn download_text(client: &reqwest::Client, url: &str) -> Result<String, AppError> {
+    client
+        .get(url)
+        .header(reqwest::header::USER_AGENT, USER_AGENT)
+        .send()
+        .await
+        .map_err(|e| AppError::Message(format!("Failed to download checksum file: {e}")))?
+        .error_for_status()
+        .map_err(|e| AppError::Message(format!("Checksum file request failed: {e}")))?
+        .text()
+        .await
+        .map_err(|e| AppError::Message(format!("Failed to read checksum file body: {e}")))
+}
+
+fn parse_checksum_for_asset(checksum_content: &str, asset_name: &str) -> Result<String, AppError> {
+    let expected = checksum_content
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim_end();
+            if line.is_empty() {
+                return None;
+            }
+
+            let (hash, file) = parse_sha256sum_line(line)?;
+
+            if file == asset_name {
+                Some(hash.to_ascii_lowercase())
+            } else {
+                None
+            }
+        })
+        .next();
+
+    expected.ok_or_else(|| {
+        AppError::Message(format!(
+            "Unable to find SHA256 for {asset_name} in {CHECKSUMS_FILE_NAME}."
+        ))
+    })
+}
+
+fn parse_sha256sum_line(line: &str) -> Option<(&str, &str)> {
+    // sha256sum output format:
+    // - text mode:   "<64-hex>  <filename>"
+    // - binary mode: "<64-hex> *<filename>"
+    if line.len() < 66 {
+        return None;
+    }
+
+    let (hash, remainder) = line.split_at(64);
+    if !hash.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return None;
+    }
+
+    if let Some(file) = remainder
+        .strip_prefix("  ")
+        .or_else(|| remainder.strip_prefix(" *"))
+    {
+        return Some((hash, file));
+    }
+
+    None
+}
+
+fn parse_sha256_digest(digest: &str) -> Option<String> {
+    let digest = digest.strip_prefix("sha256:")?;
+    if digest.len() != 64 || !digest.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(digest.to_ascii_lowercase())
+}
+
+fn extract_binary(archive_path: &Path) -> Result<PathBuf, AppError> {
+    let extract_dir = archive_path
+        .parent()
+        .ok_or_else(|| AppError::Message("Invalid archive path".to_string()))?
+        .join("extracted");
+    fs::create_dir_all(&extract_dir).map_err(|e| AppError::io(&extract_dir, e))?;
+
+    if cfg!(windows) {
+        extract_zip_binary(archive_path, &extract_dir)
+    } else {
+        extract_tar_binary(archive_path, &extract_dir)
+    }
+}
+
+#[cfg(not(windows))]
+fn extract_tar_binary(archive_path: &Path, extract_dir: &Path) -> Result<PathBuf, AppError> {
+    let file = fs::File::open(archive_path).map_err(|e| AppError::io(archive_path, e))?;
+    let decoder = GzDecoder::new(file);
+    let mut archive = Archive::new(decoder);
+    let entries = archive
+        .entries()
+        .map_err(|e| AppError::Message(format!("Failed to read archive entries: {e}")))?;
+
+    for entry in entries {
+        let mut entry =
+            entry.map_err(|e| AppError::Message(format!("Failed to read archive entry: {e}")))?;
+
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+
+        let entry_path = entry
+            .path()
+            .map_err(|e| AppError::Message(format!("Failed to inspect archive entry path: {e}")))?;
+        if entry_path.file_name().and_then(|name| name.to_str()) != Some(BINARY_NAME) {
+            continue;
+        }
+
+        let binary_path = extract_dir.join(BINARY_NAME);
+        let mut output =
+            fs::File::create(&binary_path).map_err(|e| AppError::io(&binary_path, e))?;
+        std::io::copy(&mut entry, &mut output)
+            .map_err(|e| AppError::Message(format!("Failed to unpack binary from TAR: {e}")))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = fs::Permissions::from_mode(0o755);
+            fs::set_permissions(&binary_path, perms).map_err(|e| AppError::io(&binary_path, e))?;
+        }
+
+        return Ok(binary_path);
+    }
+
+    Err(AppError::Message(format!(
+        "Extracted archive does not contain expected binary: {BINARY_NAME}"
+    )))
+}
+
+#[cfg(not(windows))]
+fn extract_zip_binary(_archive_path: &Path, _extract_dir: &Path) -> Result<PathBuf, AppError> {
+    Err(AppError::Message(
+        "ZIP extraction is only supported on Windows.".to_string(),
+    ))
+}
+
+#[cfg(windows)]
+fn extract_zip_binary(archive_path: &Path, extract_dir: &Path) -> Result<PathBuf, AppError> {
+    let file = fs::File::open(archive_path).map_err(|e| AppError::io(archive_path, e))?;
+    let mut zip = zip::ZipArchive::new(file)
+        .map_err(|e| AppError::Message(format!("Failed to open ZIP archive: {e}")))?;
+    let binary_filename = format!("{BINARY_NAME}.exe");
+
+    let mut entry = zip.by_name(&binary_filename).map_err(|_| {
+        AppError::Message(format!("ZIP archive does not contain {binary_filename}"))
+    })?;
+
+    let binary_path = extract_dir.join(binary_filename);
+    let mut output = fs::File::create(&binary_path).map_err(|e| AppError::io(&binary_path, e))?;
+    std::io::copy(&mut entry, &mut output)
+        .map_err(|e| AppError::Message(format!("Failed to extract binary from ZIP: {e}")))?;
+
+    Ok(binary_path)
+}
+
+#[cfg(windows)]
+fn extract_tar_binary(_archive_path: &Path, _extract_dir: &Path) -> Result<PathBuf, AppError> {
+    Err(AppError::Message(
+        "TAR extraction is not supported on Windows.".to_string(),
+    ))
+}
+
+fn replace_current_binary(new_binary_path: &Path) -> Result<(), AppError> {
+    #[cfg(windows)]
+    {
+        return self_replace::self_replace(new_binary_path).map_err(|e| {
+            AppError::Message(format!(
+                "Failed to replace running executable on Windows: {e}"
+            ))
+        });
+    }
+
+    #[cfg(not(windows))]
+    {
+        let current_binary = std::env::current_exe().map_err(|e| {
+            AppError::Message(format!("Failed to resolve current executable path: {e}"))
+        })?;
+        let parent = current_binary.parent().ok_or_else(|| {
+            AppError::Message("Current executable path has no parent directory.".to_string())
+        })?;
+
+        let staged_binary = parent.join(format!("{BINARY_NAME}.new"));
+        remove_file_if_present(&staged_binary)?;
+
+        fs::copy(new_binary_path, &staged_binary)
+            .map_err(|e| map_update_permission_error(&staged_binary, e))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = fs::Permissions::from_mode(0o755);
+            fs::set_permissions(&staged_binary, perms)
+                .map_err(|e| map_update_permission_error(&staged_binary, e))?;
+        }
+
+        fs::rename(&staged_binary, &current_binary)
+            .map_err(|e| map_update_permission_error(&current_binary, e))?;
+        Ok(())
+    }
+}
+
+fn remove_file_if_present(path: &Path) -> Result<(), AppError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(AppError::io(path, err)),
+    }
+}
+
+fn map_update_permission_error(target: &Path, err: std::io::Error) -> AppError {
+    if err.kind() == std::io::ErrorKind::PermissionDenied {
+        return AppError::Message(format!(
+            "Permission denied while updating {}. Re-run with elevated privileges (for example: sudo cc-switch update), or use your package manager update command.",
+            target.display()
+        ));
+    }
+    AppError::io(target, err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_tag_adds_prefix_when_missing() {
+        assert_eq!(normalize_tag("4.6.2"), "v4.6.2");
+    }
+
+    #[test]
+    fn normalize_tag_keeps_existing_prefix() {
+        assert_eq!(normalize_tag("v4.6.2"), "v4.6.2");
+    }
+
+    #[test]
+    fn parse_checksum_for_asset_finds_plain_filename() {
+        let checksums =
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  cc-switch-cli-linux-x64-musl.tar.gz\n";
+        let got = parse_checksum_for_asset(checksums, "cc-switch-cli-linux-x64-musl.tar.gz")
+            .expect("checksum should exist");
+        assert_eq!(
+            got,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+    }
+
+    #[test]
+    fn parse_checksum_for_asset_supports_star_prefix() {
+        let checksums =
+            "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB *cc-switch-cli-linux-x64-musl.tar.gz\n";
+        let got = parse_checksum_for_asset(checksums, "cc-switch-cli-linux-x64-musl.tar.gz")
+            .expect("checksum should exist");
+        assert_eq!(
+            got,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+    }
+
+    #[test]
+    fn parse_checksum_for_asset_supports_spaces_in_filename() {
+        let checksums =
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  file with spaces.tar.gz\n";
+        let got = parse_checksum_for_asset(checksums, "file with spaces.tar.gz")
+            .expect("checksum should exist");
+        assert_eq!(
+            got,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        );
+    }
+
+    #[test]
+    fn release_api_url_for_github_com() {
+        let url = release_api_url("https://github.com/saladday/cc-switch-cli", "latest")
+            .expect("api url should be built");
+        assert_eq!(
+            url.as_str(),
+            "https://api.github.com/repos/saladday/cc-switch-cli/releases/latest"
+        );
+    }
+
+    #[test]
+    fn release_api_url_for_github_enterprise() {
+        let url = release_api_url(
+            "https://github.enterprise.local/team/cc-switch-cli.git",
+            "tags/v4.6.2",
+        )
+        .expect("api url should be built");
+        assert_eq!(
+            url.as_str(),
+            "https://github.enterprise.local/api/v3/repos/team/cc-switch-cli/releases/tags/v4.6.2"
+        );
+    }
+
+    #[test]
+    fn select_release_asset_prefers_unprefixed_name() {
+        let assets = vec![
+            ReleaseAsset {
+                name: "cc-switch-cli-v4.6.2-linux-x64-musl.tar.gz".to_string(),
+                browser_download_url: "https://example.com/tagged".to_string(),
+                digest: None,
+            },
+            ReleaseAsset {
+                name: "cc-switch-cli-linux-x64-musl.tar.gz".to_string(),
+                browser_download_url: "https://example.com/plain".to_string(),
+                digest: None,
+            },
+        ];
+        let selected =
+            select_release_asset(&assets, "v4.6.2", "cc-switch-cli-linux-x64-musl.tar.gz")
+                .expect("asset should be selected");
+        assert_eq!(selected.browser_download_url, "https://example.com/plain");
+    }
+
+    #[test]
+    fn select_release_asset_falls_back_to_tagged_variant() {
+        let assets = vec![ReleaseAsset {
+            name: "cc-switch-cli-v4.6.2-linux-x64-musl.tar.gz".to_string(),
+            browser_download_url: "https://example.com/tagged".to_string(),
+            digest: None,
+        }];
+        let selected =
+            select_release_asset(&assets, "v4.6.2", "cc-switch-cli-linux-x64-musl.tar.gz")
+                .expect("asset should be selected");
+        assert_eq!(selected.browser_download_url, "https://example.com/tagged");
+    }
+
+    #[test]
+    fn parse_sha256_digest_accepts_valid_value() {
+        let digest = parse_sha256_digest(
+            "sha256:ABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD",
+        )
+        .expect("digest should parse");
+        assert_eq!(
+            digest,
+            "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        );
+    }
+
+    #[test]
+    fn should_skip_implicit_downgrade_for_prerelease_current() {
+        assert!(should_skip_implicit_downgrade(
+            "4.7.0-alpha.1",
+            "4.6.2",
+            false
+        ));
+    }
+
+    #[test]
+    fn should_not_skip_when_version_explicitly_requested() {
+        assert!(!should_skip_implicit_downgrade(
+            "4.7.0-alpha.1",
+            "4.6.2",
+            true
+        ));
+    }
+
+    #[test]
+    fn sanitized_asset_file_name_strips_path_segments() {
+        let name = sanitized_asset_file_name("nested/path/cc-switch-cli-linux-x64-musl.tar.gz")
+            .expect("file name should be extracted");
+        assert_eq!(name, "cc-switch-cli-linux-x64-musl.tar.gz");
+    }
+
+    #[test]
+    fn sanitized_asset_file_name_rejects_invalid_value() {
+        let err = sanitized_asset_file_name("").expect_err("empty name should fail");
+        assert!(err.to_string().contains("Invalid asset name"));
+    }
+
+    #[test]
+    fn validate_target_tag_accepts_normal_value() {
+        validate_target_tag("v4.6.3-rc1").expect("valid tag should pass");
+    }
+
+    #[test]
+    fn validate_target_tag_rejects_path_content() {
+        let err = validate_target_tag("v4.6.3/../../evil").expect_err("must reject traversal");
+        assert!(err.to_string().contains("forbidden"));
+    }
+
+    #[test]
+    fn validate_download_size_limit_accepts_limit_boundary() {
+        validate_download_size_limit(
+            MAX_RELEASE_ASSET_SIZE_BYTES,
+            "cc-switch-cli-linux-x64-musl.tar.gz",
+        )
+        .expect("size at limit should pass");
+    }
+
+    #[test]
+    fn validate_download_size_limit_rejects_oversized_asset() {
+        let err = validate_download_size_limit(
+            MAX_RELEASE_ASSET_SIZE_BYTES + 1,
+            "cc-switch-cli-linux-x64-musl.tar.gz",
+        )
+        .expect_err("size over limit should fail");
+        assert!(err.to_string().contains("too large"));
+    }
+}

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -60,6 +60,9 @@ pub enum Commands {
     #[command(subcommand)]
     Env(commands::env::EnvCommand),
 
+    /// Update cc-switch binary to latest release
+    Update(commands::update::UpdateCommand),
+
     /// Enter interactive mode
     #[command(alias = "ui")]
     Interactive,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -36,6 +36,7 @@ fn run(cli: Cli) -> Result<(), AppError> {
         Some(Commands::Skills(cmd)) => cc_switch_lib::cli::commands::skills::execute(cmd, cli.app),
         Some(Commands::Config(cmd)) => cc_switch_lib::cli::commands::config::execute(cmd, cli.app),
         Some(Commands::Env(cmd)) => cc_switch_lib::cli::commands::env::execute(cmd, cli.app),
+        Some(Commands::Update(cmd)) => cc_switch_lib::cli::commands::update::execute(cmd),
         Some(Commands::Completions { shell }) => {
             cc_switch_lib::cli::generate_completions(shell);
             Ok(())


### PR DESCRIPTION
## Summary
This PR adds a hardened self-update command to `cc-switch`:
- `cc-switch update`
- `cc-switch update --version <tag>`

The update flow now supports fetching release metadata, selecting the correct platform asset, downloading/verifying integrity, extracting the binary, and replacing the running executable safely.

## What changed
### CLI integration
- Added new `Update` command wiring into CLI command dispatch.
- Added user-facing docs for update usage in both English and Chinese READMEs.

### Update implementation
- Added `src-tauri/src/cli/commands/update.rs` with:
  - target tag resolution (`latest` or explicit `--version`)
  - strict tag validation
  - GitHub/GHE release API URL resolution
  - platform-specific asset resolution
  - archive extraction (`tar.gz` on Unix-like, `zip` on Windows)
  - executable replacement logic

### Security and reliability hardening
- Checksum verification:
  - uses release asset `digest` (`sha256:<hex>`) when available
  - falls back to `checksums.txt` lookup per asset when needed
- SemVer-based downgrade guard:
  - if current version is newer than resolved target, implicit update skips downgrade
  - explicit `--version` still allows intentional downgrade
- Network safety:
  - request timeout (30s)
  - max download size limit (100 MB), enforced via `Content-Length` (if present) and streamed-byte counting
- Filesystem safety:
  - sanitized asset filename handling
  - safe cleanup for staged files without `Path::exists()` dangling-symlink pitfall
  - atomic staged replacement on Unix-like systems to avoid missing-binary window

### Maintainability
- Refactored update flow to a single `runtime.block_on(execute_async(...))` entry.
- Simplified some parsing/control-flow paths while preserving behavior.

## Validation
Ran locally in `src-tauri`:
- `cargo fmt`
- `cargo test cli::commands::update::tests:: --lib`
- `cargo check`

`update` module tests include:
- tag normalization/validation
- release API URL generation (GitHub + GHE)
- asset selection behavior
- checksum parsing and digest parsing
- implicit downgrade guard behavior
- filename sanitization
- download size guard boundaries

## Notes
- Existing non-update warnings in the workspace are pre-existing and unchanged by this PR.
