### PR TITLE
feat(tui): add vim hjkl navigation and mouse scroll support

### DIFF
--- a/src-tauri/src/cli/tui/app.rs
+++ b/src-tauri/src/cli/tui/app.rs
@@ -861,6 +861,15 @@ impl App {
             return self.on_filter_key(key);
         }
 
+        // Vim-style hjkl navigation
+        let key = match key.code {
+            KeyCode::Char('h') => KeyEvent::new(KeyCode::Left, key.modifiers),
+            KeyCode::Char('j') => KeyEvent::new(KeyCode::Down, key.modifiers),
+            KeyCode::Char('k') => KeyEvent::new(KeyCode::Up, key.modifiers),
+            KeyCode::Char('l') => KeyEvent::new(KeyCode::Right, key.modifiers),
+            _ => key,
+        };
+
         // Global actions.
         match key.code {
             KeyCode::Char('?') => {


### PR DESCRIPTION
Closes #35

## Changes

**Vim hjkl navigation** (`app.rs`, +9 lines)
- Remap `h`/`j`/`k`/`l` → `←`/`↓`/`↑`/`→` at the top of `on_key`, after filter/editor/form/overlay early returns
- One remap covers all 60+ arrow key branches automatically
- Text input modes (filter, editor, form, overlay) are unaffected — hjkl type normally there

**Mouse scroll** (`mod.rs`, +33 lines)
- Handle `ScrollUp`/`ScrollDown` in the event loop by synthesizing arrow key events
- Reuses existing `on_key` logic — zero duplication

## Design decisions

- **Remap over alias**: Instead of adding `Char('j')` at 60+ `KeyCode::Down` sites, a single remap at the top of `on_key` is minimal and future-proof
- **Scroll via key synthesis**: Converting scroll events to `KeyEvent::Up/Down` reuses all existing navigation logic without touching any route handler