### PR TITLE
fix: 根据 token 类型选择正确的 Claude 认证环境变量

### DIFF
--- a/src-tauri/src/cli/commands/provider.rs
+++ b/src-tauri/src/cli/commands/provider.rs
@@ -604,10 +604,7 @@ fn extract_claude_config(settings_config: &serde_json::Value) -> ClaudeConfig {
 
     if let Some(env) = env {
         ClaudeConfig {
-            api_key: env
-                .get("ANTHROPIC_AUTH_TOKEN")
-                .or_else(|| env.get("ANTHROPIC_API_KEY"))
-                .and_then(|v| v.as_str())
+            api_key: crate::services::provider::get_claude_token_from_env(env)
                 .map(|s| mask_api_key(s)),
             base_url: env
                 .get("ANTHROPIC_BASE_URL")

--- a/src-tauri/src/cli/interactive/provider.rs
+++ b/src-tauri/src/cli/interactive/provider.rs
@@ -725,10 +725,7 @@ fn extract_claude_config(settings_config: &serde_json::Value) -> ClaudeConfig {
 
     if let Some(env) = env {
         ClaudeConfig {
-            api_key: env
-                .get("ANTHROPIC_AUTH_TOKEN")
-                .or_else(|| env.get("ANTHROPIC_API_KEY"))
-                .and_then(|v| v.as_str())
+            api_key: crate::services::provider::get_claude_token_from_env(env)
                 .map(|s| mask_api_key(s)),
             base_url: env
                 .get("ANTHROPIC_BASE_URL")

--- a/src-tauri/src/cli/tui/form.rs
+++ b/src-tauri/src/cli/tui/form.rs
@@ -402,7 +402,7 @@ impl ProviderAddFormState {
                     .get("env")
                     .and_then(|v| v.as_object())
                 {
-                    if let Some(token) = env.get("ANTHROPIC_AUTH_TOKEN").and_then(|v| v.as_str()) {
+                    if let Some(token) = crate::services::provider::get_claude_token_from_env(env) {
                         form.claude_api_key.set(token);
                     }
                     if let Some(url) = env.get("ANTHROPIC_BASE_URL").and_then(|v| v.as_str()) {
@@ -883,7 +883,9 @@ impl ProviderAddFormState {
                 let env_obj = env_value
                     .as_object_mut()
                     .expect("env must be a JSON object");
-                set_or_remove_trimmed(env_obj, "ANTHROPIC_AUTH_TOKEN", &self.claude_api_key.value);
+                let (key, old_key) = crate::services::provider::claude_auth_env_keys(&self.claude_api_key.value);
+                set_or_remove_trimmed(env_obj, key, &self.claude_api_key.value);
+                env_obj.remove(old_key);
                 set_or_remove_trimmed(env_obj, "ANTHROPIC_BASE_URL", &self.claude_base_url.value);
                 if self.claude_model_config_touched {
                     set_or_remove_trimmed(env_obj, "ANTHROPIC_MODEL", &self.claude_model.value);
@@ -2108,7 +2110,7 @@ mod tests {
         assert_eq!(provider["id"], "p1");
         assert_eq!(provider["name"], "Provider One");
         assert_eq!(
-            provider["settingsConfig"]["env"]["ANTHROPIC_AUTH_TOKEN"],
+            provider["settingsConfig"]["env"]["ANTHROPIC_API_KEY"],
             "token"
         );
         assert_eq!(
@@ -2544,7 +2546,7 @@ requires_openai_auth = true
             settings["env"]["ANTHROPIC_BASE_URL"], "https://provider.example",
             "provider field should override common snippet value"
         );
-        assert_eq!(settings["env"]["ANTHROPIC_AUTH_TOKEN"], "sk-provider");
+        assert_eq!(settings["env"]["ANTHROPIC_API_KEY"], "sk-provider");
     }
 
     #[test]
@@ -2704,7 +2706,7 @@ requires_openai_auth = true
             "common env keys should be removed"
         );
         assert_eq!(
-            env.get("ANTHROPIC_AUTH_TOKEN")
+            env.get("ANTHROPIC_API_KEY")
                 .and_then(|value| value.as_str()),
             Some("sk-provider"),
             "provider-specific env keys should be preserved"

--- a/src-tauri/src/cli/tui/ui.rs
+++ b/src-tauri/src/cli/tui/ui.rs
@@ -2717,10 +2717,7 @@ fn render_provider_detail(
             .get("env")
             .and_then(|v| v.as_object())
         {
-            let api_key = env
-                .get("ANTHROPIC_AUTH_TOKEN")
-                .or_else(|| env.get("ANTHROPIC_API_KEY"))
-                .and_then(|v| v.as_str())
+            let api_key = crate::services::provider::get_claude_token_from_env(env)
                 .map(mask_api_key)
                 .unwrap_or_else(|| texts::tui_na().to_string());
             let base_url = env

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -219,10 +219,9 @@ fn build_provider_meta(request: &DeepLinkImportRequest) -> Result<Option<Provide
 
 fn build_claude_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
     let mut env = serde_json::Map::new();
-    env.insert(
-        "ANTHROPIC_AUTH_TOKEN".to_string(),
-        json!(request.api_key.clone().unwrap_or_default()),
-    );
+    let token = request.api_key.clone().unwrap_or_default();
+    let (key, _) = crate::services::provider::claude_auth_env_keys(&token);
+    env.insert(key.to_string(), json!(token));
     env.insert(
         "ANTHROPIC_BASE_URL".to_string(),
         json!(get_primary_endpoint(request)),
@@ -358,7 +357,7 @@ fn merge_claude_config(
         })?;
 
     if request.api_key.as_ref().is_none_or(|s| s.is_empty()) {
-        if let Some(token) = env.get("ANTHROPIC_AUTH_TOKEN").and_then(|v| v.as_str()) {
+        if let Some(token) = crate::services::provider::get_claude_token_from_env(env) {
             request.api_key = Some(token.to_string());
         }
     }

--- a/src-tauri/src/services/provider/usage.rs
+++ b/src-tauri/src/services/provider/usage.rs
@@ -202,9 +202,7 @@ impl ProviderService {
                         )
                     })?;
 
-                env.get("ANTHROPIC_AUTH_TOKEN")
-                    .or_else(|| env.get("ANTHROPIC_API_KEY"))
-                    .and_then(|v| v.as_str())
+                super::get_claude_token_from_env(env)
                     .ok_or_else(|| {
                         AppError::localized(
                             "provider.claude.api_key.missing",

--- a/src-tauri/tests/deeplink_import.rs
+++ b/src-tauri/tests/deeplink_import.rs
@@ -39,7 +39,7 @@ fn deeplink_import_claude_provider_persists_to_config() {
     assert_eq!(provider.website_url.as_deref(), request.homepage.as_deref());
     let auth_token = provider
         .settings_config
-        .pointer("/env/ANTHROPIC_AUTH_TOKEN")
+        .pointer("/env/ANTHROPIC_API_KEY")
         .and_then(|v| v.as_str());
     let base_url = provider
         .settings_config


### PR DESCRIPTION
## 问题 (Closes #32)

cc-switch 将所有 Claude API 凭证统一存为 `ANTHROPIC_AUTH_TOKEN`，但 Claude Code 对两种认证方式使用**不同的 HTTP header**：

| 环境变量 | HTTP Header | 适用场景 |
|---------|-------------|---------|
| `ANTHROPIC_AUTH_TOKEN` | `Authorization: Bearer xxx` | OAuth token (`sk-ant-oat...`) |
| `ANTHROPIC_API_KEY` | `x-api-key: xxx` | 标准 API key (`sk-ant-api...`) |

当用户使用标准 API key 时，被错误地存为 `ANTHROPIC_AUTH_TOKEN`，Claude Code 将其作为 Bearer token 发送 → 服务端不认 → **401**。

## 验证过程

通过 `strings` 分析 Claude Code 二进制，确认了两种 env var 的处理逻辑：

```js
// Claude Code 内部：分别读取，走不同 header
apiKey: EyT("ANTHROPIC_API_KEY") ?? null,
authToken: EyT("ANTHROPIC_AUTH_TOKEN") ?? null

// AUTH_TOKEN → Bearer header
function JW7(T, R) {
  let A = process.env.ANTHROPIC_AUTH_TOKEN || CWT(R);
  if (A) T.Authorization = `Bearer ${A}`
}
```

## 修复方案

### 新增两个 helper（`services/provider/mod.rs`）

**`claude_auth_env_keys(token) → (primary_key, old_key)`**
- `sk-ant-oat...` → `("ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY")`
- 其他 → `("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")`

**`get_claude_token_from_env(env) → Option<&str>`**
- 统一读取逻辑，先查 `AUTH_TOKEN` 再查 `API_KEY`，兼容新旧数据

### 变更文件

**写入端（3处）** — 根据 token 前缀自动选择正确的 env var：
- `cli/tui/form.rs` — TUI 表单提交
- `cli/commands/provider_input.rs` — CLI 交互模式
- `deeplink/provider.rs` — deeplink 导入

**读取端（5处）** — 统一使用 `get_claude_token_from_env` helper：
- `cli/tui/form.rs` — 编辑时加载已有 provider
- `cli/tui/ui.rs` — TUI 详情展示
- `cli/commands/provider.rs` — CLI 展示
- `cli/interactive/provider.rs` — 交互模式展示
- `services/provider/usage.rs` — 用量检查
- `deeplink/provider.rs` — deeplink 读取

**向后兼容**：已有数据库中存储的 `ANTHROPIC_AUTH_TOKEN` 仍可正常读取，无需迁移。

## 测试

全部 237 个测试通过，包括更新了 4 个受影响的断言。