### PR TITLE
Add OpenClaw provider support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "indexmap",
  "indicatif",
  "inquire",
+ "json5",
  "libc",
  "log",
  "minisign",
@@ -1769,6 +1770,17 @@ checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ test-hooks = []
 # Core dependencies
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+json5 = "0.4"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"

--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -25,6 +25,7 @@ impl McpApps {
             AppType::Codex => self.codex,
             AppType::Gemini => self.gemini,
             AppType::OpenCode => self.opencode,
+            AppType::OpenClaw => false,
         }
     }
 
@@ -35,6 +36,7 @@ impl McpApps {
             AppType::Codex => self.codex = enabled,
             AppType::Gemini => self.gemini = enabled,
             AppType::OpenCode => self.opencode = enabled,
+            AppType::OpenClaw => {}
         }
     }
 
@@ -82,6 +84,7 @@ impl SkillApps {
             AppType::Codex => self.codex,
             AppType::Gemini => self.gemini,
             AppType::OpenCode => self.opencode,
+            AppType::OpenClaw => false,
         }
     }
 
@@ -91,6 +94,7 @@ impl SkillApps {
             AppType::Codex => self.codex = enabled,
             AppType::Gemini => self.gemini = enabled,
             AppType::OpenCode => self.opencode = enabled,
+            AppType::OpenClaw => {}
         }
     }
 
@@ -250,6 +254,8 @@ pub struct PromptRoot {
     pub gemini: PromptConfig,
     #[serde(default)]
     pub opencode: PromptConfig,
+    #[serde(default)]
+    pub openclaw: PromptConfig,
 }
 
 use crate::config::{copy_file, get_app_config_dir, get_app_config_path, write_json_file};
@@ -265,6 +271,7 @@ pub enum AppType {
     Codex,
     Gemini,
     OpenCode,
+    OpenClaw,
 }
 
 impl AppType {
@@ -274,11 +281,12 @@ impl AppType {
             AppType::Codex => "codex",
             AppType::Gemini => "gemini",
             AppType::OpenCode => "opencode",
+            AppType::OpenClaw => "openclaw",
         }
     }
 
     pub fn is_additive_mode(&self) -> bool {
-        matches!(self, AppType::OpenCode)
+        matches!(self, AppType::OpenCode | AppType::OpenClaw)
     }
 
     pub fn all() -> impl Iterator<Item = AppType> {
@@ -308,10 +316,15 @@ impl FromStr for AppType {
             "codex" => Ok(AppType::Codex),
             "gemini" => Ok(AppType::Gemini),
             "opencode" => Ok(AppType::OpenCode),
+            "openclaw" => Ok(AppType::OpenClaw),
             other => Err(AppError::localized(
                 "unsupported_app",
-                format!("不支持的应用标识: '{other}'。可选值: claude, codex, gemini, opencode。"),
-                format!("Unsupported app id: '{other}'. Allowed: claude, codex, gemini, opencode."),
+                format!(
+                    "不支持的应用标识: '{other}'。可选值: claude, codex, gemini, opencode, openclaw。"
+                ),
+                format!(
+                    "Unsupported app id: '{other}'. Allowed: claude, codex, gemini, opencode, openclaw."
+                ),
             )),
         }
     }
@@ -331,6 +344,9 @@ pub struct CommonConfigSnippets {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub opencode: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub openclaw: Option<String>,
 }
 
 impl CommonConfigSnippets {
@@ -341,6 +357,7 @@ impl CommonConfigSnippets {
             AppType::Codex => self.codex.as_ref(),
             AppType::Gemini => self.gemini.as_ref(),
             AppType::OpenCode => self.opencode.as_ref(),
+            AppType::OpenClaw => self.openclaw.as_ref(),
         }
     }
 
@@ -351,6 +368,7 @@ impl CommonConfigSnippets {
             AppType::Codex => self.codex = snippet,
             AppType::Gemini => self.gemini = snippet,
             AppType::OpenCode => self.opencode = snippet,
+            AppType::OpenClaw => self.openclaw = snippet,
         }
     }
 }
@@ -391,6 +409,7 @@ impl Default for MultiAppConfig {
         apps.insert("codex".to_string(), ProviderManager::default());
         apps.insert("gemini".to_string(), ProviderManager::default());
         apps.insert("opencode".to_string(), ProviderManager::default());
+        apps.insert("openclaw".to_string(), ProviderManager::default());
 
         Self {
             version: 2,
@@ -486,6 +505,13 @@ impl MultiAppConfig {
             updated = true;
         }
 
+        if !config.apps.contains_key("openclaw") {
+            config
+                .apps
+                .insert("openclaw".to_string(), ProviderManager::default());
+            updated = true;
+        }
+
         // 执行 MCP 迁移（v3.6.x → v3.7.0）
         let migrated = config.migrate_mcp_to_unified()?;
         if migrated {
@@ -557,6 +583,7 @@ impl MultiAppConfig {
             AppType::Codex => &self.mcp.codex,
             AppType::Gemini => &self.mcp.gemini,
             AppType::OpenCode => &self.mcp.opencode,
+            AppType::OpenClaw => &self.mcp.opencode,
         }
     }
 
@@ -567,6 +594,7 @@ impl MultiAppConfig {
             AppType::Codex => &mut self.mcp.codex,
             AppType::Gemini => &mut self.mcp.gemini,
             AppType::OpenCode => &mut self.mcp.opencode,
+            AppType::OpenClaw => &mut self.mcp.opencode,
         }
     }
 
@@ -581,6 +609,7 @@ impl MultiAppConfig {
         Self::auto_import_prompt_if_exists(&mut config, AppType::Codex)?;
         Self::auto_import_prompt_if_exists(&mut config, AppType::Gemini)?;
         Self::auto_import_prompt_if_exists(&mut config, AppType::OpenCode)?;
+        Self::auto_import_prompt_if_exists(&mut config, AppType::OpenClaw)?;
 
         Ok(config)
     }
@@ -601,6 +630,7 @@ impl MultiAppConfig {
             || !self.prompts.codex.prompts.is_empty()
             || !self.prompts.gemini.prompts.is_empty()
             || !self.prompts.opencode.prompts.is_empty()
+            || !self.prompts.openclaw.prompts.is_empty()
         {
             return Ok(false);
         }
@@ -613,6 +643,7 @@ impl MultiAppConfig {
             AppType::Codex,
             AppType::Gemini,
             AppType::OpenCode,
+            AppType::OpenClaw,
         ] {
             // 复用已有的单应用导入逻辑
             if Self::auto_import_prompt_if_exists(self, app)? {
@@ -680,6 +711,7 @@ impl MultiAppConfig {
             AppType::Codex => &mut config.prompts.codex.prompts,
             AppType::Gemini => &mut config.prompts.gemini.prompts,
             AppType::OpenCode => &mut config.prompts.opencode.prompts,
+            AppType::OpenClaw => &mut config.prompts.openclaw.prompts,
         };
 
         prompts.insert(id, prompt);
@@ -713,12 +745,14 @@ impl MultiAppConfig {
             AppType::Codex,
             AppType::Gemini,
             AppType::OpenCode,
+            AppType::OpenClaw,
         ] {
             let old_servers = match app {
                 AppType::Claude => &self.mcp.claude.servers,
                 AppType::Codex => &self.mcp.codex.servers,
                 AppType::Gemini => &self.mcp.gemini.servers,
                 AppType::OpenCode => &self.mcp.opencode.servers,
+                AppType::OpenClaw => &self.mcp.opencode.servers,
             };
 
             for (id, entry) in old_servers {

--- a/src-tauri/src/cli/commands/config_common.rs
+++ b/src-tauri/src/cli/commands/config_common.rs
@@ -133,7 +133,7 @@ fn set(
     };
 
     let snippet = match app_type {
-        AppType::Claude | AppType::Gemini | AppType::OpenCode => {
+        AppType::Claude | AppType::Gemini | AppType::OpenCode | AppType::OpenClaw => {
             let value: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
                 AppError::InvalidInput(texts::tui_toast_invalid_json(&e.to_string()))
             })?;

--- a/src-tauri/src/cli/commands/mcp.rs
+++ b/src-tauri/src/cli/commands/mcp.rs
@@ -265,6 +265,7 @@ fn import_servers(app_type: AppType) -> Result<(), AppError> {
         AppType::Codex => McpService::import_from_codex(&state)?,
         AppType::Gemini => McpService::import_from_gemini(&state)?,
         AppType::OpenCode => 0,
+        AppType::OpenClaw => 0,
     };
 
     if count > 0 {

--- a/src-tauri/src/cli/commands/provider.rs
+++ b/src-tauri/src/cli/commands/provider.rs
@@ -224,7 +224,7 @@ fn add_provider(app_type: AppType) -> Result<(), AppError> {
     println!("{}", info(&texts::generated_id_message(&id)));
 
     // 3. 收集配置
-    let settings_config = prompt_settings_config_for_add(&app_type, add_mode)?;
+    let settings_config = prompt_settings_config_for_add(&app_type, &id, add_mode)?;
 
     // 4. 询问是否配置可选字段
     let optional = if Confirm::new(texts::configure_optional_fields_prompt())
@@ -324,7 +324,7 @@ fn edit_provider(app_type: AppType, id: &str) -> Result<(), AppError> {
         .prompt()
         .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
     {
-        prompt_settings_config(&app_type, Some(&original.settings_config))?
+        prompt_settings_config(&app_type, id, Some(&original.settings_config))?
     } else {
         original.settings_config.clone()
     };

--- a/src-tauri/src/cli/commands/provider_input.rs
+++ b/src-tauri/src/cli/commands/provider_input.rs
@@ -385,16 +385,22 @@ fn prompt_openclaw_config(provider_id: &str, current: Option<&Value>) -> Result<
     let api_key = if let Some(current) = current_api_key.as_deref() {
         Text::new(texts::api_key_label())
             .with_initial_value(current)
-            .with_help_message("Leave blank only if this provider does not require an API key")
+            .with_help_message("API key used by OpenClaw to authenticate requests")
             .prompt()
             .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
     } else {
         Text::new(texts::api_key_label())
             .with_placeholder("sk-...")
-            .with_help_message("Leave blank only if this provider does not require an API key")
+            .with_help_message("API key used by OpenClaw to authenticate requests")
             .prompt()
             .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
     };
+    let api_key = api_key.trim().to_string();
+    if api_key.is_empty() {
+        return Err(AppError::InvalidInput(
+            "OpenClaw API key cannot be empty".to_string(),
+        ));
+    }
 
     let api_options = vec![
         "openai-responses",
@@ -492,11 +498,7 @@ fn prompt_openclaw_config(provider_id: &str, current: Option<&Value>) -> Result<
 
     let mut provider_obj = current_provider.cloned().unwrap_or_default();
     provider_obj.insert("baseUrl".to_string(), json!(base_url));
-    if api_key.trim().is_empty() {
-        provider_obj.remove("apiKey");
-    } else {
-        provider_obj.insert("apiKey".to_string(), json!(api_key.trim()));
-    }
+    provider_obj.insert("apiKey".to_string(), json!(api_key));
     provider_obj.insert("api".to_string(), json!(api));
 
     let previous_target_model_id = current_target_model_id;

--- a/src-tauri/src/cli/commands/provider_input.rs
+++ b/src-tauri/src/cli/commands/provider_input.rs
@@ -47,6 +47,7 @@ mod tests {
 
 pub fn prompt_settings_config_for_add(
     app_type: &AppType,
+    provider_id: &str,
     mode: ProviderAddMode,
 ) -> Result<Value, AppError> {
     match (app_type, mode) {
@@ -55,6 +56,7 @@ pub fn prompt_settings_config_for_add(
         (AppType::Codex, ProviderAddMode::ThirdParty) => prompt_codex_config(None),
         (AppType::Gemini, _) => prompt_gemini_config(None),
         (AppType::OpenCode, _) => Ok(json!({})),
+        (AppType::OpenClaw, _) => prompt_openclaw_config(provider_id, None),
     }
 }
 
@@ -226,6 +228,7 @@ pub fn prompt_basic_fields(
 /// 根据应用类型收集 settings_config
 pub fn prompt_settings_config(
     app_type: &AppType,
+    provider_id: &str,
     current: Option<&Value>,
 ) -> Result<Value, AppError> {
     match app_type {
@@ -275,7 +278,281 @@ pub fn prompt_settings_config(
         }
         AppType::Gemini => prompt_gemini_config(current),
         AppType::OpenCode => Ok(current.cloned().unwrap_or_else(|| json!({}))),
+        AppType::OpenClaw => prompt_openclaw_config(provider_id, current),
     }
+}
+
+fn prompt_openclaw_config(provider_id: &str, current: Option<&Value>) -> Result<Value, AppError> {
+    println!("\n{}", "OpenClaw Configuration".bright_cyan().bold());
+
+    let current_provider_config = current
+        .map(crate::openclaw_config::provider_config_from_settings)
+        .unwrap_or_else(|| json!({}));
+    let current_primary_model =
+        current.and_then(crate::openclaw_config::primary_model_from_settings);
+    let current_provider = current_provider_config.as_object();
+
+    let current_base_url = current_provider
+        .and_then(|provider| provider.get("baseUrl"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let current_api_key = current_provider
+        .and_then(|provider| provider.get("apiKey"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let current_api = current_provider
+        .and_then(|provider| provider.get("api"))
+        .and_then(|value| value.as_str())
+        .or_else(|| {
+            current_provider
+                .and_then(|provider| provider.get("models"))
+                .and_then(|value| value.as_array())
+                .and_then(|models| models.first())
+                .and_then(|model| model.get("api"))
+                .and_then(|value| value.as_str())
+        })
+        .unwrap_or("openai-responses")
+        .to_string();
+    let current_target_model_id = current_primary_model
+        .as_deref()
+        .and_then(|value| value.strip_prefix(&format!("{provider_id}/")))
+        .map(str::to_string)
+        .or_else(|| {
+            current_provider
+                .and_then(|provider| provider.get("models"))
+                .and_then(|value| value.as_array())
+                .and_then(|models| models.first())
+                .and_then(|model| model.get("id"))
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        });
+    let current_target_model = current_provider
+        .and_then(|provider| provider.get("models"))
+        .and_then(|value| value.as_array())
+        .and_then(|models| {
+            current_target_model_id.as_deref().and_then(|target_id| {
+                models.iter().find(|model| {
+                    model
+                        .get("id")
+                        .and_then(|value| value.as_str())
+                        .is_some_and(|id| id == target_id)
+                })
+            })
+        })
+        .or_else(|| {
+            current_provider
+                .and_then(|provider| provider.get("models"))
+                .and_then(|value| value.as_array())
+                .and_then(|models| models.first())
+        });
+    let current_model_id = current_target_model
+        .and_then(|model| model.get("id"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let current_model_name = current_target_model
+        .and_then(|model| model.get("name"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let current_context_window = current_target_model
+        .and_then(|model| model.get("contextWindow"))
+        .and_then(|value| value.as_u64())
+        .map(|value| value.to_string());
+    let current_max_tokens = current_target_model
+        .and_then(|model| model.get("maxTokens"))
+        .and_then(|value| value.as_u64())
+        .map(|value| value.to_string());
+
+    let base_url = if let Some(current) = current_base_url.as_deref() {
+        Text::new(&format!("{}:", texts::tui_label_base_url()))
+            .with_initial_value(current)
+            .with_help_message("API endpoint (e.g., https://api.openai.com/v1)")
+            .prompt()
+            .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
+    } else {
+        Text::new(&format!("{}:", texts::tui_label_base_url()))
+            .with_placeholder("https://api.openai.com/v1")
+            .with_help_message("API endpoint")
+            .prompt()
+            .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
+    };
+    let base_url = base_url.trim().to_string();
+    if base_url.is_empty() {
+        return Err(AppError::InvalidInput(
+            texts::base_url_empty_error().to_string(),
+        ));
+    }
+
+    let api_key = if let Some(current) = current_api_key.as_deref() {
+        Text::new(texts::api_key_label())
+            .with_initial_value(current)
+            .with_help_message("Leave blank only if this provider does not require an API key")
+            .prompt()
+            .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
+    } else {
+        Text::new(texts::api_key_label())
+            .with_placeholder("sk-...")
+            .with_help_message("Leave blank only if this provider does not require an API key")
+            .prompt()
+            .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
+    };
+
+    let api_options = vec![
+        "openai-responses",
+        "openai-completions",
+        "openai-codex-responses",
+        "anthropic-messages",
+        "google-generative-ai",
+        "ollama",
+    ];
+    let default_api_index = api_options
+        .iter()
+        .position(|candidate| *candidate == current_api)
+        .unwrap_or(0);
+    let api = Select::new("API adapter:", api_options.clone())
+        .with_starting_cursor(default_api_index)
+        .with_help_message("Choose the upstream API protocol OpenClaw should use")
+        .prompt()
+        .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?;
+
+    let model_id = if let Some(current) = current_model_id.as_deref() {
+        Text::new(&format!("{}:", texts::model_label()))
+            .with_initial_value(current)
+            .with_help_message("Model identifier exposed by the provider")
+            .prompt()
+            .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
+    } else {
+        Text::new(&format!("{}:", texts::model_label()))
+            .with_placeholder("gpt-5.2-codex")
+            .with_help_message("Model identifier exposed by the provider")
+            .prompt()
+            .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
+    };
+    let model_id = model_id.trim().to_string();
+    if model_id.is_empty() {
+        return Err(AppError::InvalidInput(
+            "OpenClaw model id cannot be empty".to_string(),
+        ));
+    }
+
+    let model_name = if let Some(current) = current_model_name.as_deref() {
+        Text::new("Model display name:")
+            .with_initial_value(current)
+            .with_help_message("Optional display name shown by OpenClaw")
+            .prompt()
+            .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
+    } else {
+        Text::new("Model display name:")
+            .with_placeholder(&model_id)
+            .with_help_message("Optional display name shown by OpenClaw")
+            .prompt()
+            .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
+    };
+
+    let context_window = if let Some(current) = current_context_window.as_deref() {
+        Text::new("Context window:")
+            .with_initial_value(current)
+            .with_help_message("Integer token limit, default 200000")
+            .prompt()
+            .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
+    } else {
+        Text::new("Context window:")
+            .with_placeholder("200000")
+            .with_help_message("Integer token limit, default 200000")
+            .prompt()
+            .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
+    };
+    let context_window = if context_window.trim().is_empty() {
+        200000
+    } else {
+        context_window.trim().parse::<u64>().map_err(|_| {
+            AppError::InvalidInput("OpenClaw context window must be a positive integer".to_string())
+        })?
+    };
+
+    let max_tokens = if let Some(current) = current_max_tokens.as_deref() {
+        Text::new("Max output tokens:")
+            .with_initial_value(current)
+            .with_help_message("Integer token limit, default 8192")
+            .prompt()
+            .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
+    } else {
+        Text::new("Max output tokens:")
+            .with_placeholder("8192")
+            .with_help_message("Integer token limit, default 8192")
+            .prompt()
+            .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?
+    };
+    let max_tokens = if max_tokens.trim().is_empty() {
+        8192
+    } else {
+        max_tokens.trim().parse::<u64>().map_err(|_| {
+            AppError::InvalidInput("OpenClaw max tokens must be a positive integer".to_string())
+        })?
+    };
+
+    let mut provider_obj = current_provider.cloned().unwrap_or_default();
+    provider_obj.insert("baseUrl".to_string(), json!(base_url));
+    if api_key.trim().is_empty() {
+        provider_obj.remove("apiKey");
+    } else {
+        provider_obj.insert("apiKey".to_string(), json!(api_key.trim()));
+    }
+    provider_obj.insert("api".to_string(), json!(api));
+
+    let previous_target_model_id = current_target_model_id;
+    let mut models = provider_obj
+        .remove("models")
+        .and_then(|value| value.as_array().cloned())
+        .unwrap_or_default();
+
+    if let Some(previous_id) = previous_target_model_id.as_deref() {
+        models.retain(|model| {
+            model
+                .get("id")
+                .and_then(|value| value.as_str())
+                .map_or(true, |id| id != previous_id)
+        });
+    }
+    models.retain(|model| {
+        model
+            .get("id")
+            .and_then(|value| value.as_str())
+            .map_or(true, |id| id != model_id)
+    });
+
+    let mut model_obj = current_target_model
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    model_obj.insert("id".to_string(), json!(model_id.clone()));
+    model_obj.insert(
+        "name".to_string(),
+        json!(if model_name.trim().is_empty() {
+            model_id.as_str()
+        } else {
+            model_name.trim()
+        }),
+    );
+    model_obj.insert("reasoning".to_string(), json!(false));
+    model_obj.insert("input".to_string(), json!(["text"]));
+    model_obj.insert(
+        "cost".to_string(),
+        json!({
+            "input": 0.0,
+            "output": 0.0,
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0
+        }),
+    );
+    model_obj.insert("contextWindow".to_string(), json!(context_window));
+    model_obj.insert("maxTokens".to_string(), json!(max_tokens));
+    models.insert(0, Value::Object(model_obj));
+    provider_obj.insert("models".to_string(), Value::Array(models));
+
+    Ok(crate::openclaw_config::build_settings_config(
+        Value::Object(provider_obj),
+        Some(format!("{provider_id}/{model_id}")),
+    ))
 }
 
 /// 提示用户输入单个模型字段
@@ -842,6 +1119,33 @@ pub fn display_provider_summary(provider: &Provider, app_type: &AppType) {
                 .and_then(|v| v.as_object())
             {
                 println!("  {}: {}", texts::model_label(), models.len());
+            }
+        }
+        AppType::OpenClaw => {
+            let provider_config =
+                crate::openclaw_config::provider_config_from_settings(&provider.settings_config);
+            if let Some(api_key) = provider_config.get("apiKey").and_then(|v| v.as_str()) {
+                println!(
+                    "  {}: {}",
+                    texts::api_key_display_label(),
+                    mask_api_key(api_key)
+                );
+            }
+            if let Some(base_url) = provider_config.get("baseUrl").and_then(|v| v.as_str()) {
+                println!("  {}: {}", texts::base_url_display_label(), base_url);
+            }
+            if let Some(primary_model) =
+                crate::openclaw_config::primary_model_from_settings(&provider.settings_config)
+            {
+                println!("  {}: {}", texts::model_label(), primary_model);
+            } else if let Some(model_id) = provider_config
+                .get("models")
+                .and_then(|v| v.as_array())
+                .and_then(|models| models.first())
+                .and_then(|model| model.get("id"))
+                .and_then(|v| v.as_str())
+            {
+                println!("  {}: {}", texts::model_label(), model_id);
             }
         }
     }

--- a/src-tauri/src/cli/commands/provider_inspect.rs
+++ b/src-tauri/src/cli/commands/provider_inspect.rs
@@ -341,6 +341,23 @@ fn model_fetch_target(
                 })?,
             strategy: ProviderModelFetchStrategy::Bearer,
         }),
+        AppType::OpenClaw => {
+            let provider_config =
+                crate::openclaw_config::provider_config_from_settings(&provider.settings_config);
+            Ok(ModelFetchTarget {
+                base_url,
+                auth_value: provider_config
+                    .get("apiKey")
+                    .and_then(|value| value.as_str())
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+                    .ok_or_else(|| {
+                        AppError::Message(format!("Missing API key for provider '{}'", provider.id))
+                    })?,
+                strategy: ProviderModelFetchStrategy::Bearer,
+            })
+        }
     }
 }
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -15,8 +15,8 @@ use crate::app_config::AppType;
 #[command(
     name = "cc-switch",
     version,
-    about = "All-in-One Assistant for Claude Code, Codex, Gemini & OpenCode CLI",
-    long_about = "Unified management for Claude Code, Codex, Gemini, and OpenCode CLI provider configurations, MCP servers, skills, prompts, local proxy routes, and environment checks.\n\nRun without arguments to enter interactive mode."
+    about = "All-in-One Assistant for Claude Code, Codex, Gemini, OpenCode & OpenClaw CLI",
+    long_about = "Unified management for Claude Code, Codex, Gemini, OpenCode, and OpenClaw CLI provider configurations, MCP servers, skills, prompts, local proxy routes, and environment checks.\n\nRun without arguments to enter interactive mode."
 )]
 pub struct Cli {
     /// Specify the application type

--- a/src-tauri/src/cli/tui/app/helpers.rs
+++ b/src-tauri/src/cli/tui/app/helpers.rs
@@ -215,10 +215,12 @@ pub(crate) fn cycle_app_type(current: &AppType, dir: i8) -> AppType {
         (AppType::Codex, 1) => AppType::Gemini,
         (AppType::Gemini, 1) => AppType::OpenCode,
         (AppType::OpenCode, 1) => AppType::Claude,
+        (AppType::OpenClaw, 1) => AppType::Claude,
         (AppType::Claude, -1) => AppType::OpenCode,
         (AppType::Codex, -1) => AppType::Claude,
         (AppType::Gemini, -1) => AppType::Codex,
         (AppType::OpenCode, -1) => AppType::Gemini,
+        (AppType::OpenClaw, -1) => AppType::Gemini,
         (other, _) => other.clone(),
     }
 }
@@ -229,6 +231,7 @@ pub(crate) fn app_type_picker_index(app_type: &AppType) -> usize {
         AppType::Codex => 1,
         AppType::Gemini => 2,
         AppType::OpenCode => 3,
+        AppType::OpenClaw => 3,
     }
 }
 

--- a/src-tauri/src/cli/tui/data.rs
+++ b/src-tauri/src/cli/tui/data.rs
@@ -99,6 +99,7 @@ impl ProxySnapshot {
             AppType::Codex => Some(self.codex_takeover),
             AppType::Gemini => Some(self.gemini_takeover),
             AppType::OpenCode => None,
+            AppType::OpenClaw => None,
         }
     }
 
@@ -218,6 +219,10 @@ fn extract_api_url(settings_config: &Value, app_type: &AppType) -> Option<String
         AppType::OpenCode => settings_config
             .get("options")?
             .get("baseURL")?
+            .as_str()
+            .map(|s| s.to_string()),
+        AppType::OpenClaw => crate::openclaw_config::provider_config_from_settings(settings_config)
+            .get("baseUrl")?
             .as_str()
             .map(|s| s.to_string()),
     }

--- a/src-tauri/src/cli/tui/form/provider_json.rs
+++ b/src-tauri/src/cli/tui/form/provider_json.rs
@@ -285,6 +285,69 @@ impl ProviderAddFormState {
                     settings_obj.insert("models".to_string(), models_value);
                 }
             }
+            AppType::OpenClaw => {
+                let mut provider_value = settings_obj
+                    .remove("provider")
+                    .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+                if !provider_value.is_object() {
+                    provider_value = Value::Object(serde_json::Map::new());
+                }
+                let provider_obj = provider_value
+                    .as_object_mut()
+                    .expect("provider must be a JSON object");
+                set_or_remove_trimmed(provider_obj, "apiKey", &self.opencode_api_key.value);
+                set_or_remove_trimmed(provider_obj, "baseUrl", &self.opencode_base_url.value);
+                provider_obj.insert("api".to_string(), json!("openai-responses"));
+
+                let mut model_obj = serde_json::Map::new();
+                let model_id = self.opencode_primary_model_id().unwrap_or_default();
+                model_obj.insert("id".to_string(), json!(model_id.clone()));
+                model_obj.insert(
+                    "name".to_string(),
+                    json!(if self.opencode_model_name.value.trim().is_empty() {
+                        self.opencode_model_id.value.trim()
+                    } else {
+                        self.opencode_model_name.value.trim()
+                    }),
+                );
+                model_obj.insert("reasoning".to_string(), json!(false));
+                model_obj.insert("input".to_string(), json!(["text"]));
+                model_obj.insert(
+                    "cost".to_string(),
+                    json!({
+                        "input": 0.0,
+                        "output": 0.0,
+                        "cacheRead": 0.0,
+                        "cacheWrite": 0.0
+                    }),
+                );
+                model_obj.insert(
+                    "contextWindow".to_string(),
+                    json!(self
+                        .opencode_model_context_limit
+                        .value
+                        .trim()
+                        .parse::<u64>()
+                        .unwrap_or(200000)),
+                );
+                model_obj.insert(
+                    "maxTokens".to_string(),
+                    json!(self
+                        .opencode_model_output_limit
+                        .value
+                        .trim()
+                        .parse::<u64>()
+                        .unwrap_or(8192)),
+                );
+                provider_obj.insert("models".to_string(), json!([model_obj]));
+                settings_obj.insert("provider".to_string(), provider_value);
+                if !model_id.is_empty() {
+                    settings_obj.insert(
+                        "primaryModel".to_string(),
+                        json!(format!("{}/{}", self.id.value.trim(), model_id)),
+                    );
+                }
+            }
         }
 
         Value::Object(provider_obj)
@@ -326,6 +389,7 @@ impl ProviderAddFormState {
                 *settings_value = common;
             }
             AppType::OpenCode => {}
+            AppType::OpenClaw => {}
             AppType::Codex => {
                 if !settings_value.is_object() {
                     *settings_value = json!({});
@@ -386,6 +450,7 @@ pub(crate) fn strip_common_config_from_settings(
             strip_common_json_values(settings_value, &common);
         }
         AppType::OpenCode => {}
+        AppType::OpenClaw => {}
         AppType::Codex => {
             if !settings_value.is_object() {
                 return Ok(());

--- a/src-tauri/src/cli/tui/form/provider_json.rs
+++ b/src-tauri/src/cli/tui/form/provider_json.rs
@@ -299,53 +299,59 @@ impl ProviderAddFormState {
                 set_or_remove_trimmed(provider_obj, "baseUrl", &self.opencode_base_url.value);
                 provider_obj.insert("api".to_string(), json!("openai-responses"));
 
-                let mut model_obj = serde_json::Map::new();
-                let model_id = self.opencode_primary_model_id().unwrap_or_default();
-                model_obj.insert("id".to_string(), json!(model_id.clone()));
-                model_obj.insert(
-                    "name".to_string(),
-                    json!(if self.opencode_model_name.value.trim().is_empty() {
-                        self.opencode_model_id.value.trim()
-                    } else {
-                        self.opencode_model_name.value.trim()
-                    }),
-                );
-                model_obj.insert("reasoning".to_string(), json!(false));
-                model_obj.insert("input".to_string(), json!(["text"]));
-                model_obj.insert(
-                    "cost".to_string(),
-                    json!({
-                        "input": 0.0,
-                        "output": 0.0,
-                        "cacheRead": 0.0,
-                        "cacheWrite": 0.0
-                    }),
-                );
-                model_obj.insert(
-                    "contextWindow".to_string(),
-                    json!(self
-                        .opencode_model_context_limit
-                        .value
-                        .trim()
-                        .parse::<u64>()
-                        .unwrap_or(200000)),
-                );
-                model_obj.insert(
-                    "maxTokens".to_string(),
-                    json!(self
-                        .opencode_model_output_limit
-                        .value
-                        .trim()
-                        .parse::<u64>()
-                        .unwrap_or(8192)),
-                );
-                provider_obj.insert("models".to_string(), json!([model_obj]));
+                let model_id = self.opencode_model_id.value.trim();
+                if !model_id.is_empty() {
+                    let mut model_obj = serde_json::Map::new();
+                    model_obj.insert("id".to_string(), json!(model_id));
+                    model_obj.insert(
+                        "name".to_string(),
+                        json!(if self.opencode_model_name.value.trim().is_empty() {
+                            model_id
+                        } else {
+                            self.opencode_model_name.value.trim()
+                        }),
+                    );
+                    model_obj.insert("reasoning".to_string(), json!(false));
+                    model_obj.insert("input".to_string(), json!(["text"]));
+                    model_obj.insert(
+                        "cost".to_string(),
+                        json!({
+                            "input": 0.0,
+                            "output": 0.0,
+                            "cacheRead": 0.0,
+                            "cacheWrite": 0.0
+                        }),
+                    );
+                    model_obj.insert(
+                        "contextWindow".to_string(),
+                        json!(self
+                            .opencode_model_context_limit
+                            .value
+                            .trim()
+                            .parse::<u64>()
+                            .unwrap_or(200000)),
+                    );
+                    model_obj.insert(
+                        "maxTokens".to_string(),
+                        json!(self
+                            .opencode_model_output_limit
+                            .value
+                            .trim()
+                            .parse::<u64>()
+                            .unwrap_or(8192)),
+                    );
+                    provider_obj.insert("models".to_string(), json!([model_obj]));
+                } else {
+                    provider_obj.remove("models");
+                }
                 settings_obj.insert("provider".to_string(), provider_value);
                 if !model_id.is_empty() {
                     settings_obj.insert(
                         "primaryModel".to_string(),
                         json!(format!("{}/{}", self.id.value.trim(), model_id)),
                     );
+                } else {
+                    settings_obj.remove("primaryModel");
                 }
             }
         }

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -104,7 +104,18 @@ impl ProviderAddFormState {
     }
 
     pub fn has_required_fields(&self) -> bool {
-        !self.name.is_blank()
+        if self.name.is_blank() {
+            return false;
+        }
+
+        match self.app_type {
+            AppType::OpenClaw => {
+                !self.opencode_api_key.is_blank()
+                    && !self.opencode_base_url.is_blank()
+                    && !self.opencode_model_id.is_blank()
+            }
+            _ => true,
+        }
     }
 
     pub fn ensure_generated_id(&mut self, existing_ids: &[String]) -> bool {

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -163,6 +163,15 @@ impl ProviderAddFormState {
                 fields.push(ProviderAddField::OpenCodeModelContextLimit);
                 fields.push(ProviderAddField::OpenCodeModelOutputLimit);
             }
+            AppType::OpenClaw => {
+                fields.push(ProviderAddField::OpenCodeNpmPackage);
+                fields.push(ProviderAddField::OpenCodeApiKey);
+                fields.push(ProviderAddField::OpenCodeBaseUrl);
+                fields.push(ProviderAddField::OpenCodeModelId);
+                fields.push(ProviderAddField::OpenCodeModelName);
+                fields.push(ProviderAddField::OpenCodeModelContextLimit);
+                fields.push(ProviderAddField::OpenCodeModelOutputLimit);
+            }
         }
 
         fields.push(ProviderAddField::CommonConfigDivider);

--- a/src-tauri/src/cli/tui/form/provider_state_loading.rs
+++ b/src-tauri/src/cli/tui/form/provider_state_loading.rs
@@ -15,6 +15,7 @@ pub(super) fn populate_form_from_provider(
         AppType::Codex => populate_codex_form(form, provider),
         AppType::Gemini => populate_gemini_form(form, provider),
         AppType::OpenCode => populate_opencode_form(form, provider),
+        AppType::OpenClaw => populate_openclaw_form(form, provider),
     }
 }
 
@@ -190,6 +191,87 @@ fn populate_opencode_form(form: &mut ProviderAddFormState, provider: &Provider) 
                 }
             }
         }
+    }
+}
+
+fn populate_openclaw_form(form: &mut ProviderAddFormState, provider: &Provider) {
+    let provider_config =
+        crate::openclaw_config::provider_config_from_settings(&provider.settings_config);
+    if let Some(api_key) = provider_config
+        .get("apiKey")
+        .and_then(|value| value.as_str())
+    {
+        form.opencode_api_key.set(api_key);
+    }
+    if let Some(base_url) = provider_config
+        .get("baseUrl")
+        .and_then(|value| value.as_str())
+    {
+        form.opencode_base_url.set(base_url);
+    }
+
+    let target_model_id =
+        crate::openclaw_config::primary_model_from_settings(&provider.settings_config)
+            .and_then(|value| {
+                value
+                    .rsplit_once('/')
+                    .map(|(_, model_id)| model_id.to_string())
+                    .or(Some(value))
+            })
+            .or_else(|| {
+                provider_config
+                    .get("models")
+                    .and_then(|value| value.as_array())
+                    .and_then(|models| models.first())
+                    .and_then(|model| model.get("id"))
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string)
+            });
+
+    let target_model = provider_config
+        .get("models")
+        .and_then(|value| value.as_array())
+        .and_then(|models| {
+            target_model_id.as_deref().and_then(|target_id| {
+                models.iter().find(|model| {
+                    model
+                        .get("id")
+                        .and_then(|value| value.as_str())
+                        .is_some_and(|id| id == target_id)
+                })
+            })
+        })
+        .or_else(|| {
+            provider_config
+                .get("models")
+                .and_then(|value| value.as_array())
+                .and_then(|models| models.first())
+        });
+
+    if let Some(model_id) = target_model
+        .and_then(|model| model.get("id"))
+        .and_then(|value| value.as_str())
+    {
+        form.opencode_model_original_id = Some(model_id.to_string());
+        form.opencode_model_id.set(model_id);
+    }
+    if let Some(name) = target_model
+        .and_then(|model| model.get("name"))
+        .and_then(|value| value.as_str())
+    {
+        form.opencode_model_name.set(name);
+    }
+    if let Some(context) = target_model
+        .and_then(|model| model.get("contextWindow"))
+        .and_then(|value| value.as_u64())
+    {
+        form.opencode_model_context_limit.set(context.to_string());
+    }
+    if let Some(output) = target_model
+        .and_then(|model| model.get("maxTokens"))
+        .and_then(|value| value.as_u64())
+    {
+        form.opencode_model_output_limit.set(output.to_string());
     }
 }
 

--- a/src-tauri/src/cli/tui/form/provider_templates.rs
+++ b/src-tauri/src/cli/tui/form/provider_templates.rs
@@ -104,12 +104,13 @@ pub(super) fn provider_builtin_template_defs(app_type: &AppType) -> &'static [Pr
         AppType::Codex => &PROVIDER_TEMPLATE_DEFS_CODEX,
         AppType::Gemini => &PROVIDER_TEMPLATE_DEFS_GEMINI,
         AppType::OpenCode => &PROVIDER_TEMPLATE_DEFS_OPENCODE,
+        AppType::OpenClaw => &PROVIDER_TEMPLATE_DEFS_OPENCODE,
     }
 }
 
 pub(super) fn provider_sponsor_presets(app_type: &AppType) -> &'static [SponsorProviderPreset] {
     match app_type {
-        AppType::OpenCode => &NO_SPONSOR_PROVIDER_PRESETS,
+        AppType::OpenCode | AppType::OpenClaw => &NO_SPONSOR_PROVIDER_PRESETS,
         _ => &SPONSOR_PROVIDER_PRESETS,
     }
 }
@@ -272,6 +273,7 @@ impl ProviderAddFormState {
                 self.gemini_base_url.set(preset.gemini_base_url);
             }
             AppType::OpenCode => {}
+            AppType::OpenClaw => {}
         }
     }
 }

--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -1146,3 +1146,76 @@ fn provider_add_form_opencode_from_provider_backfills_and_preserves_extra_settin
         "medium"
     );
 }
+
+#[test]
+fn provider_add_form_openclaw_requires_api_key_base_url_and_model_id() {
+    let mut form = ProviderAddFormState::new(AppType::OpenClaw);
+    form.name.set("OpenClaw Provider");
+
+    assert!(
+        !form.has_required_fields(),
+        "OpenClaw form should require more than just provider name"
+    );
+
+    form.opencode_api_key.set("sk-openclaw");
+    assert!(
+        !form.has_required_fields(),
+        "OpenClaw form should still require base URL and model id"
+    );
+
+    form.opencode_base_url.set("https://api.example.com/v1");
+    assert!(
+        !form.has_required_fields(),
+        "OpenClaw form should still require model id"
+    );
+
+    form.opencode_model_id.set("gpt-5.2-codex");
+    assert!(
+        form.has_required_fields(),
+        "OpenClaw form should become submittable once api key, base URL, and model id are set"
+    );
+}
+
+#[test]
+fn provider_add_form_openclaw_builds_wrapped_settings_from_dedicated_fields() {
+    let mut form = ProviderAddFormState::new(AppType::OpenClaw);
+    form.id.set("oclaw1");
+    form.name.set("OpenClaw Provider");
+    form.opencode_api_key.set("sk-openclaw");
+    form.opencode_base_url.set("https://api.example.com/v1");
+    form.opencode_model_id.set("gpt-5.2-codex");
+    form.opencode_model_name.set("GPT-5.2 Codex");
+    form.opencode_model_context_limit.set("256000");
+    form.opencode_model_output_limit.set("16384");
+
+    let provider = form.to_provider_json_value();
+    assert_eq!(provider["id"], "oclaw1");
+    assert_eq!(
+        provider["settingsConfig"]["provider"]["apiKey"],
+        "sk-openclaw"
+    );
+    assert_eq!(
+        provider["settingsConfig"]["provider"]["baseUrl"],
+        "https://api.example.com/v1"
+    );
+    assert_eq!(
+        provider["settingsConfig"]["provider"]["models"][0]["id"],
+        "gpt-5.2-codex"
+    );
+    assert_eq!(
+        provider["settingsConfig"]["provider"]["models"][0]["name"],
+        "GPT-5.2 Codex"
+    );
+    assert_eq!(
+        provider["settingsConfig"]["provider"]["models"][0]["contextWindow"],
+        256000
+    );
+    assert_eq!(
+        provider["settingsConfig"]["provider"]["models"][0]["maxTokens"],
+        16384
+    );
+    assert_eq!(
+        provider["settingsConfig"]["primaryModel"],
+        "oclaw1/gpt-5.2-codex"
+    );
+}

--- a/src-tauri/src/cli/tui/runtime_actions/helpers.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/helpers.rs
@@ -37,6 +37,7 @@ pub(crate) fn import_mcp_for_current_app(app: &mut App, data: &mut UiData) -> Re
                 AppType::Codex => McpService::import_from_codex(&state),
                 AppType::Gemini => McpService::import_from_gemini(&state),
                 AppType::OpenCode => McpService::import_from_opencode(&state),
+                AppType::OpenClaw => Ok(0),
             }
         },
         UiData::load,
@@ -62,6 +63,7 @@ pub(crate) fn app_display_name(app_type: &AppType) -> &'static str {
         AppType::Codex => "Codex",
         AppType::Gemini => "Gemini",
         AppType::OpenCode => "OpenCode",
+        AppType::OpenClaw => "OpenClaw",
     }
 }
 

--- a/src-tauri/src/cli/tui/theme.rs
+++ b/src-tauri/src/cli/tui/theme.rs
@@ -195,6 +195,7 @@ fn accent_rgb(app: &AppType) -> (u8, u8, u8) {
         AppType::Claude => DRACULA_CYAN,
         AppType::Gemini => DRACULA_PINK,
         AppType::OpenCode => DRACULA_ORANGE,
+        AppType::OpenClaw => DRACULA_ORANGE,
     }
 }
 

--- a/src-tauri/src/cli/tui/ui/chrome.rs
+++ b/src-tauri/src/cli/tui/ui/chrome.rs
@@ -34,6 +34,7 @@ pub(super) fn render_header(
         AppType::Codex => 1,
         AppType::Gemini => 2,
         AppType::OpenCode => 3,
+        AppType::OpenClaw => 3,
     };
     let tabs_line = Line::from(vec![
         Span::styled(
@@ -64,7 +65,14 @@ pub(super) fn render_header(
         ),
         Span::raw(" "),
         Span::styled(
-            format!(" {} ", AppType::OpenCode.as_str()),
+            format!(
+                " {} ",
+                if matches!(app.app_type, AppType::OpenClaw) {
+                    AppType::OpenClaw.as_str()
+                } else {
+                    AppType::OpenCode.as_str()
+                }
+            ),
             if selected == 3 {
                 active_chip_style(theme)
             } else {

--- a/src-tauri/src/cli/ui/colors.rs
+++ b/src-tauri/src/cli/ui/colors.rs
@@ -34,6 +34,7 @@ fn inquire_color_for_app(app_type: &AppType) -> InquireColor {
         AppType::Claude => InquireColor::LightCyan,
         AppType::Gemini => InquireColor::LightMagenta,
         AppType::OpenCode => InquireColor::LightGreen,
+        AppType::OpenClaw => InquireColor::LightGreen,
     }
 }
 
@@ -84,6 +85,7 @@ fn highlight_color_for_app(app_type: &AppType) -> Color {
         AppType::Claude => Color::BrightCyan,
         AppType::Gemini => Color::BrightMagenta,
         AppType::OpenCode => Color::BrightGreen,
+        AppType::OpenClaw => Color::BrightGreen,
     }
 }
 

--- a/src-tauri/src/deeplink/parser.rs
+++ b/src-tauri/src/deeplink/parser.rs
@@ -64,9 +64,14 @@ fn parse_provider_deeplink(
         .ok_or_else(|| AppError::InvalidInput("Missing 'app' parameter".to_string()))?
         .clone();
 
-    if app != "claude" && app != "codex" && app != "gemini" && app != "opencode" {
+    if app != "claude"
+        && app != "codex"
+        && app != "gemini"
+        && app != "opencode"
+        && app != "openclaw"
+    {
         return Err(AppError::InvalidInput(format!(
-            "Invalid app type: must be 'claude', 'codex', 'gemini', or 'opencode', got '{app}'"
+            "Invalid app type: must be 'claude', 'codex', 'gemini', 'opencode', or 'openclaw', got '{app}'"
         )));
     }
 

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -67,6 +67,7 @@ pub fn import_provider_from_deeplink(
                 Some("codex") => Some("https://openai.com".to_string()),
                 Some("gemini") => Some("https://ai.google.dev".to_string()),
                 Some("opencode") => Some("https://opencode.ai".to_string()),
+                Some("openclaw") => Some("https://github.com/openclaw/openclaw".to_string()),
                 _ => None,
             };
         }
@@ -120,6 +121,16 @@ pub fn import_provider_from_deeplink(
         .to_lowercase();
     provider.id = format!("{sanitized_name}-{timestamp}");
     let provider_id = provider.id.clone();
+    if matches!(app_type, AppType::OpenClaw)
+        && crate::openclaw_config::primary_model_from_settings(&provider.settings_config).is_none()
+    {
+        let provider_config =
+            crate::openclaw_config::provider_config_from_settings(&provider.settings_config);
+        let primary_model =
+            crate::openclaw_config::infer_primary_model(&provider_id, &provider_config);
+        provider.settings_config =
+            crate::openclaw_config::build_settings_config(provider_config, primary_model);
+    }
 
     ProviderService::add(state, app_type.clone(), provider)?;
 
@@ -139,6 +150,7 @@ fn build_provider_from_request(
         AppType::Codex => build_codex_settings(request),
         AppType::Gemini => build_gemini_settings(request),
         AppType::OpenCode => build_opencode_settings(request),
+        AppType::OpenClaw => build_openclaw_settings(request),
     };
 
     let meta = build_provider_meta(request)?;
@@ -325,6 +337,48 @@ fn build_opencode_settings(request: &DeepLinkImportRequest) -> serde_json::Value
         "options": options,
         "models": models
     })
+}
+
+fn build_openclaw_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
+    let endpoint = get_primary_endpoint(request);
+    let model_id = request
+        .model
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("gpt-5.2-codex");
+
+    let mut provider = serde_json::Map::new();
+    if !endpoint.trim().is_empty() {
+        provider.insert("baseUrl".to_string(), json!(endpoint.trim()));
+    }
+    if let Some(api_key) = request
+        .api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        provider.insert("apiKey".to_string(), json!(api_key));
+    }
+    provider.insert("api".to_string(), json!("openai-responses"));
+    provider.insert(
+        "models".to_string(),
+        json!([{
+            "id": model_id,
+            "name": model_id,
+            "reasoning": false,
+            "input": ["text"],
+            "cost": {
+                "input": 0.0,
+                "output": 0.0,
+                "cacheRead": 0.0,
+                "cacheWrite": 0.0
+            },
+            "contextWindow": 200000,
+            "maxTokens": 8192
+        }]),
+    );
+
+    crate::openclaw_config::build_settings_config(serde_json::Value::Object(provider), None)
 }
 
 /// Parse and merge configuration from Base64 encoded config or remote URL.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod gemini_mcp;
 mod import_export;
 mod init_status;
 mod mcp;
+mod openclaw_config;
 mod opencode_config;
 mod prompt;
 mod prompt_files;

--- a/src-tauri/src/openclaw_config.rs
+++ b/src-tauri/src/openclaw_config.rs
@@ -1,0 +1,268 @@
+use crate::config::write_json_file;
+use crate::error::AppError;
+use crate::settings::get_openclaw_override_dir;
+use serde_json::{json, Map, Value};
+use std::path::PathBuf;
+
+pub fn get_openclaw_dir() -> PathBuf {
+    if let Some(override_dir) = get_openclaw_override_dir() {
+        return override_dir;
+    }
+
+    dirs::home_dir()
+        .map(|home| home.join(".openclaw"))
+        .unwrap_or_else(|| PathBuf::from(".openclaw"))
+}
+
+pub fn get_openclaw_workspace_dir() -> PathBuf {
+    get_openclaw_dir().join("workspace")
+}
+
+pub fn get_openclaw_config_path() -> PathBuf {
+    get_openclaw_dir().join("openclaw.json")
+}
+
+pub fn read_openclaw_config() -> Result<Value, AppError> {
+    let path = get_openclaw_config_path();
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+
+    let content = std::fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))?;
+    json5::from_str(&content).map_err(|e| {
+        AppError::Config(format!(
+            "OpenClaw config parse error: {}: {e}",
+            path.display()
+        ))
+    })
+}
+
+pub fn write_openclaw_config(config: &Value) -> Result<(), AppError> {
+    let path = get_openclaw_config_path();
+    write_json_file(&path, config)
+}
+
+pub fn get_providers() -> Result<Map<String, Value>, AppError> {
+    let config = read_openclaw_config()?;
+    Ok(config
+        .get("models")
+        .and_then(|value| value.get("providers"))
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default())
+}
+
+pub fn set_provider(id: &str, provider: Value) -> Result<(), AppError> {
+    let mut config = read_openclaw_config()?;
+    let providers = ensure_object_path(&mut config, &["models", "providers"])?;
+    providers.insert(id.to_string(), provider);
+    write_openclaw_config(&config)
+}
+
+pub fn remove_provider(id: &str) -> Result<(), AppError> {
+    let mut config = read_openclaw_config()?;
+    if let Some(providers) = config
+        .get_mut("models")
+        .and_then(|value| value.get_mut("providers"))
+        .and_then(Value::as_object_mut)
+    {
+        providers.remove(id);
+    }
+    write_openclaw_config(&config)
+}
+
+pub fn get_primary_model() -> Result<Option<String>, AppError> {
+    let config = read_openclaw_config()?;
+    Ok(primary_model_from_config(&config))
+}
+
+pub fn set_primary_model(model: &str) -> Result<(), AppError> {
+    let mut config = read_openclaw_config()?;
+    apply_primary_model(&mut config, model);
+    write_openclaw_config(&config)
+}
+
+pub fn ensure_model_allowlist_entry(model: &str) -> Result<(), AppError> {
+    let mut config = read_openclaw_config()?;
+    ensure_model_entry_in_config(&mut config, model);
+    write_openclaw_config(&config)
+}
+
+pub fn provider_config_from_settings(settings_config: &Value) -> Value {
+    settings_config
+        .get("provider")
+        .cloned()
+        .unwrap_or_else(|| settings_config.clone())
+}
+
+pub fn primary_model_from_settings(settings_config: &Value) -> Option<String> {
+    settings_config
+        .get("primaryModel")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+pub fn build_settings_config(provider_config: Value, primary_model: Option<String>) -> Value {
+    let mut root = Map::new();
+    root.insert("provider".to_string(), provider_config);
+    if let Some(primary_model) = primary_model.filter(|value| !value.trim().is_empty()) {
+        root.insert("primaryModel".to_string(), Value::String(primary_model));
+    }
+    Value::Object(root)
+}
+
+pub fn infer_primary_model(provider_id: &str, provider_config: &Value) -> Option<String> {
+    let model_id = provider_config
+        .get("models")
+        .and_then(Value::as_array)
+        .and_then(|models| models.first())
+        .and_then(|model| model.get("id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+
+    Some(format!("{provider_id}/{model_id}"))
+}
+
+pub fn primary_model_from_config(config: &Value) -> Option<String> {
+    let model = config
+        .get("agents")
+        .and_then(|value| value.get("defaults"))
+        .and_then(|value| value.get("model"))?;
+
+    if let Some(value) = model.as_str() {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+
+    model
+        .get("primary")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+pub fn apply_provider_snapshot(provider_id: &str, settings_config: &Value) -> Result<(), AppError> {
+    let mut config = read_openclaw_config()?;
+    let provider = provider_config_from_settings(settings_config);
+    let providers = ensure_object_path(&mut config, &["models", "providers"])?;
+    providers.insert(provider_id.to_string(), provider);
+
+    if let Some(primary_model) = primary_model_from_settings(settings_config) {
+        apply_primary_model(&mut config, &primary_model);
+        ensure_model_entry_in_config(&mut config, &primary_model);
+    }
+
+    write_openclaw_config(&config)
+}
+
+fn apply_primary_model(config: &mut Value, model: &str) {
+    let model_root = ensure_object_path_mut(config, &["agents", "defaults"]);
+    if let Some(existing) = model_root.get_mut("model") {
+        if let Some(existing_obj) = existing.as_object_mut() {
+            existing_obj.insert("primary".to_string(), Value::String(model.to_string()));
+            return;
+        }
+    }
+    model_root.insert("model".to_string(), json!({ "primary": model }));
+}
+
+fn ensure_model_entry_in_config(config: &mut Value, model: &str) {
+    let models = ensure_object_path_mut(config, &["agents", "defaults", "models"]);
+    models
+        .entry(model.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+}
+
+fn ensure_object_path<'a>(
+    root: &'a mut Value,
+    path: &[&str],
+) -> Result<&'a mut Map<String, Value>, AppError> {
+    if !root.is_object() {
+        *root = Value::Object(Map::new());
+    }
+    Ok(ensure_object_path_mut(root, path))
+}
+
+fn ensure_object_path_mut<'a>(root: &'a mut Value, path: &[&str]) -> &'a mut Map<String, Value> {
+    let mut current = root;
+    for segment in path {
+        if !current.is_object() {
+            *current = Value::Object(Map::new());
+        }
+        let object = current
+            .as_object_mut()
+            .expect("object ensured before descending");
+        current = object
+            .entry((*segment).to_string())
+            .or_insert_with(|| Value::Object(Map::new()));
+    }
+    if !current.is_object() {
+        *current = Value::Object(Map::new());
+    }
+    current
+        .as_object_mut()
+        .expect("terminal object ensured before returning")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_settings_config_wraps_provider_and_primary_model() {
+        let settings = build_settings_config(
+            json!({ "baseUrl": "https://api.example.com/v1" }),
+            Some("demo/model".to_string()),
+        );
+
+        assert_eq!(
+            settings
+                .get("provider")
+                .and_then(|value| value.get("baseUrl")),
+            Some(&Value::String("https://api.example.com/v1".to_string()))
+        );
+        assert_eq!(
+            primary_model_from_settings(&settings).as_deref(),
+            Some("demo/model")
+        );
+    }
+
+    #[test]
+    fn infer_primary_model_uses_first_provider_model() {
+        let provider = json!({
+            "models": [
+                { "id": "gpt-5.4", "name": "GPT-5.4" },
+                { "id": "gpt-5.3", "name": "GPT-5.3" }
+            ]
+        });
+
+        assert_eq!(
+            infer_primary_model("demo", &provider).as_deref(),
+            Some("demo/gpt-5.4")
+        );
+    }
+
+    #[test]
+    fn primary_model_from_config_supports_object_form() {
+        let config = json!({
+            "agents": {
+                "defaults": {
+                    "model": {
+                        "primary": "demo/model"
+                    }
+                }
+            }
+        });
+
+        assert_eq!(
+            primary_model_from_config(&config).as_deref(),
+            Some("demo/model")
+        );
+    }
+}

--- a/src-tauri/src/prompt_files.rs
+++ b/src-tauri/src/prompt_files.rs
@@ -5,6 +5,7 @@ use crate::codex_config::get_codex_auth_path;
 use crate::config::get_claude_settings_path;
 use crate::error::AppError;
 use crate::gemini_config::get_gemini_dir;
+use crate::openclaw_config::get_openclaw_workspace_dir;
 use crate::opencode_config::get_opencode_dir;
 
 /// 返回指定应用所使用的提示词文件路径。
@@ -14,6 +15,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::Codex => get_base_dir_with_fallback(get_codex_auth_path(), ".codex")?,
         AppType::Gemini => get_gemini_dir(),
         AppType::OpenCode => get_opencode_dir(),
+        AppType::OpenClaw => get_openclaw_workspace_dir(),
     };
 
     let filename = match app {
@@ -21,6 +23,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::Codex => "AGENTS.md",
         AppType::Gemini => "GEMINI.md",
         AppType::OpenCode => "AGENTS.md",
+        AppType::OpenClaw => "AGENTS.md",
     };
 
     Ok(base_dir.join(filename))

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -156,9 +156,7 @@ async fn handle_claude_request(
             Ok(response) => response,
             Err(failure) => {
                 let super::forwarder::ForwardFailure { provider, error } = failure;
-                if let Some(provider) = provider
-                    .or_else(|| context.primary_provider().cloned())
-                {
+                if let Some(provider) = provider.or_else(|| context.primary_provider().cloned()) {
                     let request_log = RequestLogContext::from_handler(
                         &context,
                         provider,
@@ -255,9 +253,7 @@ async fn handle_claude_request(
         Ok(response) => response,
         Err(failure) => {
             let super::forwarder::ForwardFailure { provider, error } = failure;
-            if let Some(provider) = provider
-                .or_else(|| context.primary_provider().cloned())
-            {
+            if let Some(provider) = provider.or_else(|| context.primary_provider().cloned()) {
                 let request_log = RequestLogContext::from_handler(
                     &context,
                     provider,

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -22,5 +22,6 @@ pub fn get_adapter(app_type: &AppType) -> Box<dyn ProviderAdapter> {
         AppType::Codex => Box::new(CodexAdapter::new()),
         AppType::Gemini => Box::new(GeminiAdapter::new()),
         AppType::OpenCode => Box::new(CodexAdapter::new()),
+        AppType::OpenClaw => Box::new(CodexAdapter::new()),
     }
 }

--- a/src-tauri/src/proxy/usage/calculator.rs
+++ b/src-tauri/src/proxy/usage/calculator.rs
@@ -136,15 +136,17 @@ pub fn calculate_cost(
     let million = Decimal::from(1_000_000u32);
     let billable_input_tokens = usage.input_tokens.saturating_sub(usage.cache_read_tokens);
 
-    let input_cost = Decimal::from(billable_input_tokens) * pricing.input_cost_per_million / million;
-    let output_cost = Decimal::from(usage.output_tokens) * pricing.output_cost_per_million / million;
+    let input_cost =
+        Decimal::from(billable_input_tokens) * pricing.input_cost_per_million / million;
+    let output_cost =
+        Decimal::from(usage.output_tokens) * pricing.output_cost_per_million / million;
     let cache_read_cost =
         Decimal::from(usage.cache_read_tokens) * pricing.cache_read_cost_per_million / million;
     let cache_creation_cost = Decimal::from(usage.cache_creation_tokens)
         * pricing.cache_creation_cost_per_million
         / million;
-    let total_cost = (input_cost + output_cost + cache_read_cost + cache_creation_cost)
-        * cost_multiplier;
+    let total_cost =
+        (input_cost + output_cost + cache_read_cost + cache_creation_cost) * cost_multiplier;
 
     Some(CostBreakdown {
         input_cost,
@@ -203,7 +205,13 @@ mod tests {
 
     #[test]
     fn pricing_model_prefers_request_when_configured() {
-        assert_eq!(pricing_model("claude-3-7-sonnet", "gpt-5.2", "request"), "claude-3-7-sonnet");
-        assert_eq!(pricing_model("claude-3-7-sonnet", "gpt-5.2", "response"), "gpt-5.2");
+        assert_eq!(
+            pricing_model("claude-3-7-sonnet", "gpt-5.2", "request"),
+            "claude-3-7-sonnet"
+        );
+        assert_eq!(
+            pricing_model("claude-3-7-sonnet", "gpt-5.2", "response"),
+            "gpt-5.2"
+        );
     }
 }

--- a/src-tauri/src/proxy/usage/logger.rs
+++ b/src-tauri/src/proxy/usage/logger.rs
@@ -7,7 +7,9 @@ use crate::{
 };
 
 use super::{
-    calculator::{calculate_cost, format_decimal, lookup_model_pricing, pricing_model, resolve_pricing_config},
+    calculator::{
+        calculate_cost, format_decimal, lookup_model_pricing, pricing_model, resolve_pricing_config,
+    },
     parser::{
         error_message_from_response_bytes, fallback_model_from_response_bytes,
         parse_claude_response_usage, ParsedUsage, StreamLogCollector, TokenUsage,
@@ -180,7 +182,8 @@ async fn insert_request_log(
     status_code: u16,
     error_message: Option<String>,
 ) {
-    let pricing_config = resolve_pricing_config(state.db.as_ref(), &context.app_type, &context.provider).await;
+    let pricing_config =
+        resolve_pricing_config(state.db.as_ref(), &context.app_type, &context.provider).await;
     let pricing_model = pricing_model(
         &context.request_model,
         model,

--- a/src-tauri/src/proxy/usage/mod.rs
+++ b/src-tauri/src/proxy/usage/mod.rs
@@ -2,5 +2,8 @@ pub mod calculator;
 pub mod logger;
 pub mod parser;
 
-pub use logger::{log_buffered_response, log_error_request, log_stream_response, RequestLogContext, UsageLogPolicy};
+pub use logger::{
+    log_buffered_response, log_error_request, log_stream_response, RequestLogContext,
+    UsageLogPolicy,
+};
 pub use parser::StreamLogCollector;

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -251,6 +251,7 @@ impl ConfigService {
         Self::sync_current_provider_for_app(config, &AppType::Codex)?;
         Self::sync_current_provider_for_app(config, &AppType::Gemini)?;
         Self::sync_current_provider_for_app(config, &AppType::OpenCode)?;
+        Self::sync_current_provider_for_app(config, &AppType::OpenClaw)?;
         Ok(())
     }
 
@@ -286,6 +287,7 @@ impl ConfigService {
             AppType::Claude => Self::sync_claude_live(config, &current_id, &provider)?,
             AppType::Gemini => Self::sync_gemini_live(config, &current_id, &provider)?,
             AppType::OpenCode => {}
+            AppType::OpenClaw => Self::sync_openclaw_live(&provider)?,
         }
 
         Ok(())
@@ -381,5 +383,9 @@ impl ConfigService {
         }
 
         Ok(())
+    }
+
+    fn sync_openclaw_live(provider: &Provider) -> Result<(), AppError> {
+        crate::openclaw_config::apply_provider_snapshot(&provider.id, &provider.settings_config)
     }
 }

--- a/src-tauri/src/services/local_env_check.rs
+++ b/src-tauri/src/services/local_env_check.rs
@@ -8,6 +8,7 @@ pub enum LocalTool {
     Codex,
     Gemini,
     OpenCode,
+    OpenClaw,
 }
 
 #[derive(Debug, Clone)]
@@ -38,6 +39,12 @@ pub fn check_local_environment() -> Vec<ToolCheckResult> {
             LocalTool::OpenCode,
             "opencode",
             "OpenCode",
+            &["--version", "version"],
+        ),
+        (
+            LocalTool::OpenClaw,
+            "openclaw",
+            "OpenClaw",
             &["--version", "version"],
         ),
     ];

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -163,6 +163,7 @@ impl McpService {
             AppType::OpenCode => {
                 mcp::sync_single_server_to_opencode(cfg, &server.id, &server.server)?;
             }
+            AppType::OpenClaw => {}
         }
         Ok(())
     }
@@ -186,6 +187,7 @@ impl McpService {
             AppType::Codex => mcp::remove_server_from_codex(id)?,
             AppType::Gemini => mcp::remove_server_from_gemini(id)?,
             AppType::OpenCode => mcp::remove_server_from_opencode(id)?,
+            AppType::OpenClaw => {}
         }
         Ok(())
     }

--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -20,6 +20,7 @@ impl PromptService {
             AppType::Codex => &cfg.prompts.codex.prompts,
             AppType::Gemini => &cfg.prompts.gemini.prompts,
             AppType::OpenCode => &cfg.prompts.opencode.prompts,
+            AppType::OpenClaw => &cfg.prompts.openclaw.prompts,
         };
         Ok(prompts.clone())
     }
@@ -39,6 +40,7 @@ impl PromptService {
             AppType::Codex => &mut cfg.prompts.codex.prompts,
             AppType::Gemini => &mut cfg.prompts.gemini.prompts,
             AppType::OpenCode => &mut cfg.prompts.opencode.prompts,
+            AppType::OpenClaw => &mut cfg.prompts.openclaw.prompts,
         };
         prompts.insert(id.to_string(), prompt.clone());
         drop(cfg);
@@ -60,6 +62,7 @@ impl PromptService {
             AppType::Codex => &mut cfg.prompts.codex.prompts,
             AppType::Gemini => &mut cfg.prompts.gemini.prompts,
             AppType::OpenCode => &mut cfg.prompts.opencode.prompts,
+            AppType::OpenClaw => &mut cfg.prompts.openclaw.prompts,
         };
 
         if let Some(prompt) = prompts.get(id) {
@@ -86,6 +89,7 @@ impl PromptService {
                         AppType::Codex => &mut cfg.prompts.codex.prompts,
                         AppType::Gemini => &mut cfg.prompts.gemini.prompts,
                         AppType::OpenCode => &mut cfg.prompts.opencode.prompts,
+                        AppType::OpenClaw => &mut cfg.prompts.openclaw.prompts,
                     };
 
                     // 尝试回填到当前已启用的提示词
@@ -146,6 +150,7 @@ impl PromptService {
             AppType::Codex => &mut cfg.prompts.codex.prompts,
             AppType::Gemini => &mut cfg.prompts.gemini.prompts,
             AppType::OpenCode => &mut cfg.prompts.opencode.prompts,
+            AppType::OpenClaw => &mut cfg.prompts.openclaw.prompts,
         };
 
         for prompt in prompts.values_mut() {
@@ -171,6 +176,7 @@ impl PromptService {
             AppType::Codex => &mut cfg.prompts.codex.prompts,
             AppType::Gemini => &mut cfg.prompts.gemini.prompts,
             AppType::OpenCode => &mut cfg.prompts.opencode.prompts,
+            AppType::OpenClaw => &mut cfg.prompts.openclaw.prompts,
         };
 
         // 验证提示词是否存在且已启用

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -23,6 +23,9 @@ pub(super) enum LiveSnapshot {
     OpenCode {
         config: Option<Value>,
     },
+    OpenClaw {
+        config: Option<Value>,
+    },
 }
 
 impl LiveSnapshot {
@@ -76,6 +79,14 @@ impl LiveSnapshot {
             }
             LiveSnapshot::OpenCode { config } => {
                 let path = crate::opencode_config::get_opencode_config_path();
+                if let Some(value) = config {
+                    write_json_file(&path, value)?;
+                } else if path.exists() {
+                    delete_file(&path)?;
+                }
+            }
+            LiveSnapshot::OpenClaw { config } => {
+                let path = crate::openclaw_config::get_openclaw_config_path();
                 if let Some(value) = config {
                     write_json_file(&path, value)?;
                 } else if path.exists() {
@@ -140,6 +151,15 @@ pub(super) fn capture_live_snapshot(app_type: &AppType) -> Result<LiveSnapshot, 
                 None
             };
             Ok(LiveSnapshot::OpenCode { config })
+        }
+        AppType::OpenClaw => {
+            let path = crate::openclaw_config::get_openclaw_config_path();
+            let config = if path.exists() {
+                Some(crate::openclaw_config::read_openclaw_config()?)
+            } else {
+                None
+            };
+            Ok(LiveSnapshot::OpenClaw { config })
         }
     }
 }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -61,19 +61,33 @@ struct PostCommitAction {
 }
 
 impl ProviderService {
-    fn parse_common_opencode_config_snippet(snippet: &str) -> Result<Value, AppError> {
+    fn parse_common_additive_config_snippet(
+        snippet: &str,
+        app_key: &str,
+        app_display: &str,
+    ) -> Result<Value, AppError> {
+        let invalid_json_key = match app_key {
+            "opencode" => "common_config.opencode.invalid_json",
+            "openclaw" => "common_config.openclaw.invalid_json",
+            _ => "common_config.additive.invalid_json",
+        };
+        let not_object_key = match app_key {
+            "opencode" => "common_config.opencode.not_object",
+            "openclaw" => "common_config.openclaw.not_object",
+            _ => "common_config.additive.not_object",
+        };
         let value: Value = serde_json::from_str(snippet).map_err(|e| {
             AppError::localized(
-                "common_config.opencode.invalid_json",
-                format!("OpenCode 通用配置片段不是有效的 JSON：{e}"),
-                format!("OpenCode common config snippet is not valid JSON: {e}"),
+                invalid_json_key,
+                format!("{app_display} 通用配置片段不是有效的 JSON：{e}"),
+                format!("{app_display} common config snippet is not valid JSON: {e}"),
             )
         })?;
         if !value.is_object() {
             return Err(AppError::localized(
-                "common_config.opencode.not_object",
-                "OpenCode 通用配置片段必须是 JSON 对象",
-                "OpenCode common config snippet must be a JSON object",
+                not_object_key,
+                format!("{app_display} 通用配置片段必须是 JSON 对象"),
+                format!("{app_display} common config snippet must be a JSON object"),
             ));
         }
         Ok(value)
@@ -507,10 +521,10 @@ impl ProviderService {
                 Self::parse_common_gemini_config_snippet(snippet)?;
             }
             AppType::OpenCode => {
-                Self::parse_common_opencode_config_snippet(snippet)?;
+                Self::parse_common_additive_config_snippet(snippet, "opencode", "OpenCode")?;
             }
             AppType::OpenClaw => {
-                Self::parse_common_opencode_config_snippet(snippet)?;
+                Self::parse_common_additive_config_snippet(snippet, "openclaw", "OpenClaw")?;
             }
         }
 
@@ -1118,12 +1132,14 @@ impl ProviderService {
                 return Ok(());
             }
 
-            let current_provider_id = if matches!(app_type, AppType::OpenClaw) {
+            let current_primary_model = if matches!(app_type, AppType::OpenClaw) {
                 crate::openclaw_config::get_primary_model()?
-                    .and_then(|model| model.split('/').next().map(str::to_string))
             } else {
                 None
             };
+            let current_provider_id = current_primary_model
+                .as_deref()
+                .and_then(|model| model.split('/').next().map(str::to_string));
 
             {
                 let mut config = state.config.write().map_err(AppError::from)?;
@@ -1141,7 +1157,7 @@ impl ProviderService {
                         Self::build_openclaw_settings_config_from_live(
                             &id,
                             settings_config.clone(),
-                            current_provider_id.as_deref(),
+                            current_primary_model.as_deref(),
                         )
                     } else {
                         settings_config.clone()
@@ -1944,6 +1960,53 @@ impl ProviderService {
                         "provider.openclaw.provider.not_object",
                         "OpenClaw 供应商配置必须是 JSON 对象",
                         "OpenClaw provider config must be a JSON object",
+                    ));
+                }
+
+                let api_key = provider_config
+                    .get("apiKey")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .unwrap_or("");
+                if api_key.is_empty() {
+                    return Err(AppError::localized(
+                        "provider.openclaw.api_key.missing",
+                        "OpenClaw 供应商缺少 apiKey 配置",
+                        "OpenClaw provider is missing apiKey configuration",
+                    ));
+                }
+
+                let base_url = provider_config
+                    .get("baseUrl")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .unwrap_or("");
+                if base_url.is_empty() {
+                    return Err(AppError::localized(
+                        "provider.openclaw.base_url.missing",
+                        "OpenClaw 供应商缺少 baseUrl 配置",
+                        "OpenClaw provider is missing baseUrl configuration",
+                    ));
+                }
+
+                let has_model_id = provider_config
+                    .get("models")
+                    .and_then(Value::as_array)
+                    .map(|models| {
+                        models.iter().any(|model| {
+                            model
+                                .get("id")
+                                .and_then(Value::as_str)
+                                .map(str::trim)
+                                .is_some_and(|id| !id.is_empty())
+                        })
+                    })
+                    .unwrap_or(false);
+                if !has_model_id {
+                    return Err(AppError::localized(
+                        "provider.openclaw.model_id.missing",
+                        "OpenClaw 供应商至少需要一个带 id 的模型配置",
+                        "OpenClaw provider requires at least one model with a non-empty id",
                     ));
                 }
             }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -54,6 +54,7 @@ struct PostCommitAction {
     provider: Provider,
     backup: LiveSnapshot,
     sync_mcp: bool,
+    sync_all_additive_live: bool,
     refresh_snapshot: bool,
     common_config_snippet: Option<String>,
     takeover_active: bool,
@@ -76,6 +77,26 @@ impl ProviderService {
             ));
         }
         Ok(value)
+    }
+
+    fn build_openclaw_settings_config_from_live(
+        provider_id: &str,
+        provider_config: Value,
+        current_primary_model: Option<&str>,
+    ) -> Value {
+        let primary_model = current_primary_model
+            .map(str::trim)
+            .filter(|model| model.starts_with(&format!("{provider_id}/")))
+            .map(str::to_string)
+            .or_else(|| crate::openclaw_config::infer_primary_model(provider_id, &provider_config));
+
+        crate::openclaw_config::build_settings_config(provider_config, primary_model)
+    }
+
+    fn strip_openclaw_primary_model(settings_config: &mut Value) {
+        if let Some(settings) = settings_config.as_object_mut() {
+            settings.remove("primaryModel");
+        }
     }
 
     fn run_transaction<R, F>(state: &AppState, f: F) -> Result<R, AppError>
@@ -159,6 +180,8 @@ impl ProviderService {
                     .save_live_backup_snapshot(action.app_type.as_str(), &backup_snapshot),
             )
             .map_err(AppError::Message)?;
+        } else if action.sync_all_additive_live {
+            Self::sync_additive_app_to_live(state, &action.app_type)?;
         } else {
             Self::write_live_snapshot(
                 &action.app_type,
@@ -183,6 +206,45 @@ impl ProviderService {
         if let Err(e) = crate::services::skill::SkillService::sync_all_enabled_best_effort() {
             log::warn!("同步 Skills 失败: {e}");
         }
+        Ok(())
+    }
+
+    fn sync_additive_app_to_live(state: &AppState, app_type: &AppType) -> Result<(), AppError> {
+        let snapshots: Vec<(Provider, Option<String>)> = {
+            let guard = state.config.read().map_err(AppError::from)?;
+            let Some(manager) = guard.get_manager(app_type) else {
+                return Ok(());
+            };
+            let current_provider_id = manager.current.clone();
+            let common_config_snippet = guard.common_config_snippets.get(app_type).cloned();
+
+            manager
+                .providers
+                .values()
+                .cloned()
+                .map(|mut provider| {
+                    if matches!(app_type, AppType::OpenClaw) && provider.id != current_provider_id {
+                        Self::strip_openclaw_primary_model(&mut provider.settings_config);
+                    }
+                    (provider, common_config_snippet.clone())
+                })
+                .collect()
+        };
+
+        for (provider, common_config_snippet) in snapshots {
+            let apply_common_config = provider
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.apply_common_config)
+                .unwrap_or(true);
+            Self::write_live_snapshot(
+                app_type,
+                &provider,
+                common_config_snippet.as_deref(),
+                apply_common_config,
+            )?;
+        }
+
         Ok(())
     }
 
@@ -386,6 +448,33 @@ impl ProviderService {
                 }
                 state.save()?;
             }
+            AppType::OpenClaw => {
+                let providers = crate::openclaw_config::get_providers()?;
+                let current_primary = crate::openclaw_config::get_primary_model()?;
+                let live_after = providers.get(provider_id).cloned().ok_or_else(|| {
+                    AppError::localized(
+                        "openclaw.live.missing_provider",
+                        format!("OpenClaw live 配置中缺少供应商: {provider_id}"),
+                        format!("OpenClaw live config missing provider: {provider_id}"),
+                    )
+                })?;
+
+                let snapshot = Self::build_openclaw_settings_config_from_live(
+                    provider_id,
+                    live_after,
+                    current_primary.as_deref(),
+                );
+
+                {
+                    let mut guard = state.config.write().map_err(AppError::from)?;
+                    if let Some(manager) = guard.get_manager_mut(app_type) {
+                        if let Some(target) = manager.providers.get_mut(provider_id) {
+                            target.settings_config = snapshot;
+                        }
+                    }
+                }
+                state.save()?;
+            }
         }
         Ok(())
     }
@@ -418,6 +507,9 @@ impl ProviderService {
                 Self::parse_common_gemini_config_snippet(snippet)?;
             }
             AppType::OpenCode => {
+                Self::parse_common_opencode_config_snippet(snippet)?;
+            }
+            AppType::OpenClaw => {
                 Self::parse_common_opencode_config_snippet(snippet)?;
             }
         }
@@ -457,6 +549,7 @@ impl ProviderService {
             AppType::Codex => Self::migrate_codex_common_config_snippet(config, old_snippet),
             AppType::Gemini => Self::migrate_gemini_common_config_snippet(config, old_snippet),
             AppType::OpenCode => Ok(()),
+            AppType::OpenClaw => Ok(()),
         };
 
         match result {
@@ -476,7 +569,7 @@ impl ProviderService {
         app_type: &AppType,
         takeover_active: bool,
     ) -> Result<Option<PostCommitAction>, AppError> {
-        if app_type.is_additive_mode() {
+        if matches!(app_type, AppType::OpenCode) {
             return Ok(None);
         }
 
@@ -513,6 +606,7 @@ impl ProviderService {
             provider,
             backup: Self::capture_live_snapshot(app_type)?,
             sync_mcp: matches!(app_type, AppType::Codex) && !takeover_active,
+            sync_all_additive_live: false,
             refresh_snapshot: false,
             common_config_snippet: config.common_config_snippets.get(app_type).cloned(),
             takeover_active,
@@ -535,6 +629,7 @@ impl ProviderService {
                 Self::strip_common_gemini_config_from_provider(provider, common_config_snippet)?;
             }
             AppType::OpenCode => {}
+            AppType::OpenClaw => {}
         }
 
         Ok(())
@@ -784,7 +879,7 @@ impl ProviderService {
 
     /// 获取当前供应商 ID
     pub fn current(state: &AppState, app_type: AppType) -> Result<String, AppError> {
-        if app_type.is_additive_mode() {
+        if matches!(app_type, AppType::OpenCode) {
             return Ok(String::new());
         }
 
@@ -839,7 +934,7 @@ impl ProviderService {
                 .get_manager(&app_type_clone)
                 .map(|manager| manager.current.clone())
                 .unwrap_or_default();
-            let healed_current = if !app_type_clone.is_additive_mode() {
+            let healed_current = if !matches!(app_type_clone, AppType::OpenCode) {
                 Self::self_heal_current_provider(config, &app_type_clone, "add")
             } else {
                 None
@@ -853,28 +948,36 @@ impl ProviderService {
                 .providers
                 .insert(provider_to_store.id.clone(), provider_to_store.clone());
 
-            if !app_type_clone.is_additive_mode() && was_empty && manager.current.is_empty() {
+            if !matches!(app_type_clone, AppType::OpenCode)
+                && was_empty
+                && manager.current.is_empty()
+            {
                 manager.current = provider_to_store.id.clone();
             }
 
-            let is_current =
-                app_type_clone.is_additive_mode() || manager.current == provider_to_store.id;
-            let current_was_healed = !app_type_clone.is_additive_mode()
+            let is_current = matches!(app_type_clone, AppType::OpenCode)
+                || manager.current == provider_to_store.id;
+            let current_was_healed = !matches!(app_type_clone, AppType::OpenCode)
                 && healed_current.as_deref() != Some(previous_current.as_str());
             let current_provider_id = if current_was_healed && !is_current {
                 Some(manager.current.clone())
             } else {
                 None
             };
-            let action = if is_current {
+            let action = if is_current || matches!(app_type_clone, AppType::OpenClaw) {
                 let backup = Self::capture_live_snapshot(&app_type_clone)?;
+                let mut action_provider = provider_to_store.clone();
+                if matches!(app_type_clone, AppType::OpenClaw) && !is_current {
+                    Self::strip_openclaw_primary_model(&mut action_provider.settings_config);
+                }
                 Some(PostCommitAction {
                     app_type: app_type_clone.clone(),
-                    provider: provider_to_store.clone(),
+                    provider: action_provider,
                     backup,
                     // Codex current-provider saves rewrite live config from the stored snapshot,
                     // so managed MCP must be synced back after the write.
                     sync_mcp: matches!(&app_type_clone, AppType::Codex),
+                    sync_all_additive_live: false,
                     refresh_snapshot: false,
                     common_config_snippet,
                     takeover_active: false,
@@ -914,7 +1017,7 @@ impl ProviderService {
                 .get_manager(&app_type_clone)
                 .map(|manager| manager.current.clone())
                 .unwrap_or_default();
-            let healed_current = if !app_type_clone.is_additive_mode() {
+            let healed_current = if !matches!(app_type_clone, AppType::OpenCode) {
                 Self::self_heal_current_provider(config, &app_type_clone, "update")
             } else {
                 None
@@ -931,7 +1034,8 @@ impl ProviderService {
                 ));
             }
 
-            let is_current = app_type_clone.is_additive_mode() || manager.current == provider_id;
+            let is_current =
+                matches!(app_type_clone, AppType::OpenCode) || manager.current == provider_id;
             let mut merged = if let Some(existing) = manager.providers.get(&provider_id) {
                 let mut updated = provider_clone.clone();
                 match (existing.meta.as_ref(), updated.meta.take()) {
@@ -962,22 +1066,27 @@ impl ProviderService {
                 .providers
                 .insert(provider_id.clone(), merged.clone());
 
-            let current_was_healed = !app_type_clone.is_additive_mode()
+            let current_was_healed = !matches!(app_type_clone, AppType::OpenCode)
                 && healed_current.as_deref() != Some(previous_current.as_str());
             let current_provider_id = if current_was_healed && !is_current {
                 Some(manager.current.clone())
             } else {
                 None
             };
-            let action = if is_current {
+            let action = if is_current || matches!(app_type_clone, AppType::OpenClaw) {
                 let backup = Self::capture_live_snapshot(&app_type_clone)?;
+                let mut action_provider = merged.clone();
+                if matches!(app_type_clone, AppType::OpenClaw) && !is_current {
+                    Self::strip_openclaw_primary_model(&mut action_provider.settings_config);
+                }
                 Some(PostCommitAction {
                     app_type: app_type_clone.clone(),
-                    provider: merged,
+                    provider: action_provider,
                     backup,
                     // Codex current-provider saves rewrite live config from the stored snapshot,
                     // so managed MCP must be synced back after the write.
                     sync_mcp: matches!(&app_type_clone, AppType::Codex),
+                    sync_all_additive_live: false,
                     refresh_snapshot: false,
                     common_config_snippet,
                     takeover_active: false,
@@ -1000,10 +1109,21 @@ impl ProviderService {
     /// 导入当前 live 配置为默认供应商
     pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<(), AppError> {
         if app_type.is_additive_mode() {
-            let providers = crate::opencode_config::get_providers()?;
+            let providers = match app_type {
+                AppType::OpenCode => crate::opencode_config::get_providers()?,
+                AppType::OpenClaw => crate::openclaw_config::get_providers()?,
+                _ => serde_json::Map::new(),
+            };
             if providers.is_empty() {
                 return Ok(());
             }
+
+            let current_provider_id = if matches!(app_type, AppType::OpenClaw) {
+                crate::openclaw_config::get_primary_model()?
+                    .and_then(|model| model.split('/').next().map(str::to_string))
+            } else {
+                None
+            };
 
             {
                 let mut config = state.config.write().map_err(AppError::from)?;
@@ -1017,15 +1137,32 @@ impl ProviderService {
                 }
 
                 for (id, settings_config) in providers {
-                    let name = settings_config
+                    let snapshot = if matches!(app_type, AppType::OpenClaw) {
+                        Self::build_openclaw_settings_config_from_live(
+                            &id,
+                            settings_config.clone(),
+                            current_provider_id.as_deref(),
+                        )
+                    } else {
+                        settings_config.clone()
+                    };
+                    let provider_view = if matches!(app_type, AppType::OpenClaw) {
+                        crate::openclaw_config::provider_config_from_settings(&snapshot)
+                    } else {
+                        settings_config.clone()
+                    };
+                    let name = provider_view
                         .get("name")
                         .and_then(Value::as_str)
                         .unwrap_or(&id)
                         .to_string();
-                    manager.providers.insert(
-                        id.clone(),
-                        Provider::with_id(id, name, settings_config, None),
-                    );
+                    manager
+                        .providers
+                        .insert(id.clone(), Provider::with_id(id, name, snapshot, None));
+                }
+
+                if let Some(current_provider_id) = current_provider_id {
+                    manager.current = current_provider_id;
                 }
             }
 
@@ -1103,6 +1240,7 @@ impl ProviderService {
                 })
             }
             AppType::OpenCode => unreachable!("additive mode apps are handled earlier"),
+            AppType::OpenClaw => unreachable!("additive mode apps are handled earlier"),
         };
 
         let mut provider = Provider::with_id(
@@ -1220,6 +1358,17 @@ impl ProviderService {
                 }
                 crate::opencode_config::read_opencode_config()
             }
+            AppType::OpenClaw => {
+                let config_path = crate::openclaw_config::get_openclaw_config_path();
+                if !config_path.exists() {
+                    return Err(AppError::localized(
+                        "openclaw.config.missing",
+                        "OpenClaw 配置文件不存在",
+                        "OpenClaw configuration file not found",
+                    ));
+                }
+                crate::openclaw_config::read_openclaw_config()
+            }
         }
     }
 
@@ -1258,12 +1407,25 @@ impl ProviderService {
         let snapshots: Vec<(AppType, Provider, Option<String>)> = {
             let guard = state.config.read().map_err(AppError::from)?;
             let mut result = Vec::new();
-            for app_type in AppType::all() {
+            for app_type in [
+                AppType::Claude,
+                AppType::Codex,
+                AppType::Gemini,
+                AppType::OpenCode,
+                AppType::OpenClaw,
+            ] {
                 if let Some(manager) = guard.get_manager(&app_type) {
                     if app_type.is_additive_mode() {
                         let snippet = guard.common_config_snippets.get(&app_type).cloned();
+                        let current_provider_id = manager.current.clone();
                         for provider in manager.providers.values() {
-                            result.push((app_type.clone(), provider.clone(), snippet.clone()));
+                            let mut provider = provider.clone();
+                            if matches!(app_type, AppType::OpenClaw)
+                                && provider.id != current_provider_id
+                            {
+                                Self::strip_openclaw_primary_model(&mut provider.settings_config);
+                            }
+                            result.push((app_type.clone(), provider, snippet.clone()));
                         }
                         continue;
                     }
@@ -1343,11 +1505,18 @@ impl ProviderService {
                         )
                     })?;
 
+                if matches!(app_type_clone, AppType::OpenClaw) {
+                    if let Some(manager) = config.get_manager_mut(&app_type_clone) {
+                        manager.current = provider_id_owned.clone();
+                    }
+                }
+
                 let action = PostCommitAction {
                     app_type: app_type_clone.clone(),
                     provider,
                     backup: Self::capture_live_snapshot(&app_type_clone)?,
                     sync_mcp: true,
+                    sync_all_additive_live: matches!(app_type_clone, AppType::OpenClaw),
                     refresh_snapshot: false,
                     common_config_snippet: config
                         .common_config_snippets
@@ -1383,6 +1552,7 @@ impl ProviderService {
                     provider,
                     backup: Self::capture_live_snapshot(&app_type_clone)?,
                     sync_mcp: false,
+                    sync_all_additive_live: false,
                     refresh_snapshot: false,
                     common_config_snippet: config
                         .common_config_snippets
@@ -1400,6 +1570,7 @@ impl ProviderService {
                 AppType::Claude => Self::prepare_switch_claude(config, &provider_id_owned)?,
                 AppType::Gemini => Self::prepare_switch_gemini(config, &provider_id_owned)?,
                 AppType::OpenCode => unreachable!("additive mode handled above"),
+                AppType::OpenClaw => unreachable!("additive mode handled above"),
             };
 
             let action = PostCommitAction {
@@ -1407,6 +1578,7 @@ impl ProviderService {
                 provider,
                 backup,
                 sync_mcp: true, // v3.7.0: 所有应用切换时都同步 MCP，防止配置丢失
+                sync_all_additive_live: false,
                 refresh_snapshot: true,
                 common_config_snippet: config.common_config_snippets.get(&app_type_clone).cloned(),
                 takeover_active: false,
@@ -1463,6 +1635,10 @@ impl ProviderService {
                     Err(_) => crate::opencode_config::set_provider(&provider.id, config_to_write),
                 }
             }
+            AppType::OpenClaw => crate::openclaw_config::apply_provider_snapshot(
+                &provider.id,
+                &provider.settings_config,
+            ),
         }
     }
 
@@ -1650,6 +1826,9 @@ impl ProviderService {
             AppType::OpenCode => Err(AppError::Config(
                 "OpenCode does not support proxy takeover backups".into(),
             )),
+            AppType::OpenClaw => Err(AppError::Config(
+                "OpenClaw does not support proxy takeover backups".into(),
+            )),
         }
     }
 
@@ -1748,6 +1927,26 @@ impl ProviderService {
                     ));
                 }
             }
+            AppType::OpenClaw => {
+                if !provider.settings_config.is_object() {
+                    return Err(AppError::localized(
+                        "provider.openclaw.settings.not_object",
+                        "OpenClaw 配置必须是 JSON 对象",
+                        "OpenClaw configuration must be a JSON object",
+                    ));
+                }
+
+                let provider_config = crate::openclaw_config::provider_config_from_settings(
+                    &provider.settings_config,
+                );
+                if !provider_config.is_object() {
+                    return Err(AppError::localized(
+                        "provider.openclaw.provider.not_object",
+                        "OpenClaw 供应商配置必须是 JSON 对象",
+                        "OpenClaw provider config must be a JSON object",
+                    ));
+                }
+            }
         }
 
         // 🔧 验证并清理 UsageScript 配置（所有应用类型通用）
@@ -1775,7 +1974,7 @@ impl ProviderService {
                 .get_manager(&app_type)
                 .ok_or_else(|| Self::app_not_found(&app_type))?;
 
-            if !app_type.is_additive_mode() && manager.current == provider_id {
+            if !matches!(app_type, AppType::OpenCode) && manager.current == provider_id {
                 return Err(AppError::localized(
                     "provider.delete.current",
                     "不能删除当前正在使用的供应商",
@@ -1793,8 +1992,18 @@ impl ProviderService {
         };
 
         if app_type.is_additive_mode() {
-            if crate::opencode_config::get_opencode_dir().exists() {
-                crate::opencode_config::remove_provider(provider_id)?;
+            match app_type {
+                AppType::OpenCode => {
+                    if crate::opencode_config::get_opencode_dir().exists() {
+                        crate::opencode_config::remove_provider(provider_id)?;
+                    }
+                }
+                AppType::OpenClaw => {
+                    if crate::openclaw_config::get_openclaw_dir().exists() {
+                        crate::openclaw_config::remove_provider(provider_id)?;
+                    }
+                }
+                _ => {}
             }
 
             {
@@ -1829,6 +2038,9 @@ impl ProviderService {
             AppType::OpenCode => {
                 let _ = provider_snapshot;
             }
+            AppType::OpenClaw => {
+                let _ = provider_snapshot;
+            }
         }
 
         {
@@ -1837,7 +2049,7 @@ impl ProviderService {
                 .get_manager_mut(&app_type)
                 .ok_or_else(|| Self::app_not_found(&app_type))?;
 
-            if !app_type.is_additive_mode() && manager.current == provider_id {
+            if !matches!(app_type, AppType::OpenCode) && manager.current == provider_id {
                 return Err(AppError::localized(
                     "provider.delete.current",
                     "不能删除当前正在使用的供应商",

--- a/src-tauri/src/services/provider/usage.rs
+++ b/src-tauri/src/services/provider/usage.rs
@@ -264,6 +264,19 @@ impl ProviderService {
                     )
                 })
                 .map(|s| s.to_string()),
+            AppType::OpenClaw => {
+                crate::openclaw_config::provider_config_from_settings(&provider.settings_config)
+                    .get("apiKey")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        AppError::localized(
+                            "provider.openclaw.api_key.missing",
+                            "缺少 API Key",
+                            "API key is missing",
+                        )
+                    })
+                    .map(|s| s.to_string())
+            }
         }
     }
 
@@ -341,6 +354,19 @@ impl ProviderService {
                 .and_then(|v| v.as_str())
                 .unwrap_or_default()
                 .to_string()),
+            AppType::OpenClaw => {
+                crate::openclaw_config::provider_config_from_settings(&provider.settings_config)
+                    .get("baseUrl")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        AppError::localized(
+                            "provider.openclaw.base_url.missing",
+                            "缺少 OpenClaw baseUrl 配置",
+                            "Missing OpenClaw baseUrl configuration",
+                        )
+                    })
+                    .map(|s| s.to_string())
+            }
         }
     }
 

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -430,6 +430,11 @@ impl SkillService {
                     return Ok(custom.join("skills"));
                 }
             }
+            AppType::OpenClaw => {
+                if let Some(custom) = crate::settings::get_openclaw_override_dir() {
+                    return Ok(custom.join("workspace").join("skills"));
+                }
+            }
         }
 
         let home = dirs::home_dir().ok_or_else(|| {
@@ -445,6 +450,7 @@ impl SkillService {
             AppType::Codex => home.join(".codex").join("skills"),
             AppType::Gemini => home.join(".gemini").join("skills"),
             AppType::OpenCode => home.join(".config").join("opencode").join("skills"),
+            AppType::OpenClaw => home.join(".openclaw").join("workspace").join("skills"),
         })
     }
 

--- a/src-tauri/src/services/stream_check/provider_extract.rs
+++ b/src-tauri/src/services/stream_check/provider_extract.rs
@@ -30,6 +30,9 @@ impl StreamCheckService {
                 .and_then(|value| value.as_object())
                 .and_then(|models| models.keys().next().cloned())
                 .unwrap_or_else(|| config.codex_model.clone()),
+            AppType::OpenClaw => {
+                Self::extract_openclaw_model(provider).unwrap_or_else(|| config.codex_model.clone())
+            }
         }
     }
 
@@ -160,6 +163,13 @@ impl StreamCheckService {
                 .unwrap_or_default()
                 .trim_end_matches('/')
                 .to_string()),
+            AppType::OpenClaw => Self::extract_openclaw_base_url(provider).ok_or_else(|| {
+                AppError::localized(
+                    "provider.openclaw.base_url.missing",
+                    "缺少 OpenClaw baseUrl 配置",
+                    "Missing OpenClaw baseUrl configuration",
+                )
+            }),
         }
     }
 
@@ -203,7 +213,63 @@ impl StreamCheckService {
                         "API key is missing",
                     )
                 }),
+            AppType::OpenClaw => Self::extract_openclaw_key(provider)
+                .map(|key| AuthInfo::new(key, AuthStrategy::Bearer))
+                .ok_or_else(|| {
+                    AppError::localized(
+                        "provider.openclaw.api_key.missing",
+                        "缺少 API Key",
+                        "API key is missing",
+                    )
+                }),
         }
+    }
+
+    pub(crate) fn extract_openclaw_provider_config(provider: &Provider) -> serde_json::Value {
+        crate::openclaw_config::provider_config_from_settings(&provider.settings_config)
+    }
+
+    pub(crate) fn extract_openclaw_model(provider: &Provider) -> Option<String> {
+        if let Some(primary_model) =
+            crate::openclaw_config::primary_model_from_settings(&provider.settings_config)
+        {
+            let suffix = primary_model
+                .rsplit_once('/')
+                .map(|(_, model_id)| model_id)
+                .unwrap_or(primary_model.as_str())
+                .trim();
+            if !suffix.is_empty() {
+                return Some(suffix.to_string());
+            }
+        }
+
+        Self::extract_openclaw_provider_config(provider)
+            .get("models")
+            .and_then(|value| value.as_array())
+            .and_then(|models| models.first())
+            .and_then(|model| model.get("id"))
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    }
+
+    pub(crate) fn extract_openclaw_base_url(provider: &Provider) -> Option<String> {
+        Self::extract_openclaw_provider_config(provider)
+            .get("baseUrl")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.trim_end_matches('/').to_string())
+    }
+
+    pub(crate) fn extract_openclaw_key(provider: &Provider) -> Option<String> {
+        Self::extract_openclaw_provider_config(provider)
+            .get("apiKey")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
     }
 
     pub(crate) fn detect_claude_auth_strategy(provider: &Provider, base_url: &str) -> AuthStrategy {

--- a/src-tauri/src/services/stream_check/service.rs
+++ b/src-tauri/src/services/stream_check/service.rs
@@ -157,6 +157,17 @@ impl StreamCheckService {
                 )
                 .await
             }
+            AppType::OpenClaw => {
+                Self::check_codex_stream(
+                    &client,
+                    &base_url,
+                    &auth,
+                    &model_to_test,
+                    test_prompt,
+                    request_timeout,
+                )
+                .await
+            }
         };
 
         let response_time = start.elapsed().as_millis() as u64;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -186,6 +186,8 @@ pub struct AppSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub opencode_config_dir: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub openclaw_config_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
     /// 是否开机自启
     #[serde(default)]
@@ -226,6 +228,7 @@ impl Default for AppSettings {
             codex_config_dir: None,
             gemini_config_dir: None,
             opencode_config_dir: None,
+            openclaw_config_dir: None,
             language: None,
             launch_on_startup: false,
             skill_sync_method: crate::services::skill::SyncMethod::default(),
@@ -271,6 +274,13 @@ impl AppSettings {
 
         self.opencode_config_dir = self
             .opencode_config_dir
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        self.openclaw_config_dir = self
+            .openclaw_config_dir
             .as_ref()
             .map(|s| s.trim())
             .filter(|s| !s.is_empty())
@@ -411,6 +421,14 @@ pub fn get_opencode_override_dir() -> Option<PathBuf> {
     let settings = settings_store().read().ok()?;
     settings
         .opencode_config_dir
+        .as_ref()
+        .map(|p| resolve_override_path(p))
+}
+
+pub fn get_openclaw_override_dir() -> Option<PathBuf> {
+    let settings = settings_store().read().ok()?;
+    settings
+        .openclaw_config_dir
         .as_ref()
         .map(|p| resolve_override_path(p))
 }

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -127,6 +127,7 @@ fn export_db_to_multi_app_config(db: &Database) -> Result<MultiAppConfig, AppErr
         AppType::Codex,
         AppType::Gemini,
         AppType::OpenCode,
+        AppType::OpenClaw,
     ] {
         let app_key = app.as_str();
         let providers = db.get_all_providers(app_key)?;
@@ -141,6 +142,7 @@ fn export_db_to_multi_app_config(db: &Database) -> Result<MultiAppConfig, AppErr
             AppType::Codex => config.prompts.codex.prompts = prompts.into_iter().collect(),
             AppType::Gemini => config.prompts.gemini.prompts = prompts.into_iter().collect(),
             AppType::OpenCode => config.prompts.opencode.prompts = prompts.into_iter().collect(),
+            AppType::OpenClaw => config.prompts.openclaw.prompts = prompts.into_iter().collect(),
         }
 
         // common snippet
@@ -163,6 +165,7 @@ fn persist_multi_app_config_to_db(db: &Database, config: &MultiAppConfig) -> Res
         AppType::Codex,
         AppType::Gemini,
         AppType::OpenCode,
+        AppType::OpenClaw,
     ] {
         let app_key = app.as_str();
         let manager = config.get_manager(&app);
@@ -201,6 +204,7 @@ fn persist_multi_app_config_to_db(db: &Database, config: &MultiAppConfig) -> Res
             AppType::Codex => &config.prompts.codex.prompts,
             AppType::Gemini => &config.prompts.gemini.prompts,
             AppType::OpenCode => &config.prompts.opencode.prompts,
+            AppType::OpenClaw => &config.prompts.openclaw.prompts,
         };
         let existing_prompts = db.get_prompts(app_key)?;
         for prompt in desired_prompts.values() {

--- a/src-tauri/src/sync_policy.rs
+++ b/src-tauri/src/sync_policy.rs
@@ -20,5 +20,7 @@ pub(crate) fn should_sync_live(app_type: &AppType) -> bool {
         AppType::Gemini => crate::gemini_config::get_gemini_dir().exists(),
         // OpenCode is considered initialized if ~/.config/opencode (or override dir) exists.
         AppType::OpenCode => crate::opencode_config::get_opencode_dir().exists(),
+        // OpenClaw is considered initialized if ~/.openclaw (or override dir) exists.
+        AppType::OpenClaw => crate::openclaw_config::get_openclaw_dir().exists(),
     }
 }

--- a/src-tauri/tests/app_type_parse.rs
+++ b/src-tauri/tests/app_type_parse.rs
@@ -7,6 +7,10 @@ fn parse_known_apps_case_insensitive_and_trim() {
     assert!(matches!(AppType::from_str("claude"), Ok(AppType::Claude)));
     assert!(matches!(AppType::from_str("codex"), Ok(AppType::Codex)));
     assert!(matches!(
+        AppType::from_str("openclaw"),
+        Ok(AppType::OpenClaw)
+    ));
+    assert!(matches!(
         AppType::from_str(" ClAuDe \n"),
         Ok(AppType::Claude)
     ));
@@ -19,4 +23,5 @@ fn parse_unknown_app_returns_localized_error_message() {
     let msg = err.to_string();
     assert!(msg.contains("可选值") || msg.contains("Allowed"));
     assert!(msg.contains("unknown"));
+    assert!(msg.contains("openclaw"));
 }

--- a/src-tauri/tests/openclaw_deeplink.rs
+++ b/src-tauri/tests/openclaw_deeplink.rs
@@ -1,0 +1,104 @@
+use cc_switch_lib::{
+    import_provider_from_deeplink, AppType, DeepLinkImportRequest, MultiAppConfig,
+};
+
+#[path = "support.rs"]
+mod support;
+use support::{ensure_test_home, lock_test_mutex, reset_test_fs, state_from_config};
+
+#[test]
+fn openclaw_deeplink_import_adds_and_switches_provider_with_default_model() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let state = state_from_config(MultiAppConfig::default());
+    let request = DeepLinkImportRequest {
+        version: "v1".to_string(),
+        resource: "provider".to_string(),
+        app: Some("openclaw".to_string()),
+        name: Some("OpenClaw Demo".to_string()),
+        enabled: Some(true),
+        homepage: Some("https://provider.example".to_string()),
+        endpoint: Some("https://api.example.com/v1".to_string()),
+        api_key: Some("sk-openclaw".to_string()),
+        icon: None,
+        model: None,
+        notes: Some("imported from deeplink".to_string()),
+        haiku_model: None,
+        sonnet_model: None,
+        opus_model: None,
+        content: None,
+        description: None,
+        apps: None,
+        repo: None,
+        directory: None,
+        branch: None,
+        config: None,
+        config_format: None,
+        config_url: None,
+        usage_enabled: None,
+        usage_script: None,
+        usage_api_key: None,
+        usage_base_url: None,
+        usage_access_token: None,
+        usage_user_id: None,
+        usage_auto_interval: None,
+    };
+
+    let provider_id =
+        import_provider_from_deeplink(&state, request).expect("deeplink import should succeed");
+
+    let manager = {
+        let config = state.config.read().expect("read state config");
+        config
+            .get_manager(&AppType::OpenClaw)
+            .expect("openclaw manager should exist")
+            .clone()
+    };
+    let expected_primary = format!("{provider_id}/gpt-5.2-codex");
+
+    assert_eq!(manager.current, provider_id);
+    let provider = manager
+        .providers
+        .get(&provider_id)
+        .expect("imported provider should exist in store");
+    assert_eq!(
+        provider
+            .settings_config
+            .get("primaryModel")
+            .and_then(|value| value.as_str()),
+        Some(expected_primary.as_str())
+    );
+    assert_eq!(
+        provider
+            .settings_config
+            .get("provider")
+            .and_then(|value| value.get("apiKey"))
+            .and_then(|value| value.as_str()),
+        Some("sk-openclaw")
+    );
+
+    let openclaw_path = home.join(".openclaw").join("openclaw.json");
+    let live: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&openclaw_path).expect("read openclaw live config"),
+    )
+    .expect("parse openclaw live config");
+
+    assert_eq!(
+        live.get("agents")
+            .and_then(|value| value.get("defaults"))
+            .and_then(|value| value.get("model"))
+            .and_then(|value| value.get("primary"))
+            .and_then(|value| value.as_str()),
+        Some(expected_primary.as_str())
+    );
+    assert_eq!(
+        live.get("models")
+            .and_then(|value| value.get("providers"))
+            .and_then(|value| value.get(&provider_id))
+            .and_then(|value| value.get("baseUrl"))
+            .and_then(|value| value.as_str()),
+        Some("https://api.example.com/v1")
+    );
+}

--- a/src-tauri/tests/openclaw_provider.rs
+++ b/src-tauri/tests/openclaw_provider.rs
@@ -1,0 +1,370 @@
+use serde_json::json;
+use std::str::FromStr;
+
+use cc_switch_lib::{AppType, MultiAppConfig, Provider, ProviderService};
+
+#[path = "support.rs"]
+mod support;
+use support::{ensure_test_home, lock_test_mutex, reset_test_fs, state_from_config};
+
+fn openclaw_settings(provider_id: &str, model_id: &str, api_key: &str) -> serde_json::Value {
+    json!({
+        "provider": {
+            "baseUrl": "https://api.example.com/v1",
+            "apiKey": api_key,
+            "api": "openai-responses",
+            "models": [{
+                "id": model_id,
+                "name": model_id,
+                "reasoning": false,
+                "input": ["text"],
+                "cost": {
+                    "input": 0.0,
+                    "output": 0.0,
+                    "cacheRead": 0.0,
+                    "cacheWrite": 0.0
+                },
+                "contextWindow": 200000,
+                "maxTokens": 8192
+            }]
+        },
+        "primaryModel": format!("{provider_id}/{model_id}")
+    })
+}
+
+#[test]
+fn openclaw_add_syncs_all_providers_without_switching_non_current_primary() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let app_type = AppType::from_str("openclaw").expect("openclaw app type should parse");
+    let state = state_from_config(MultiAppConfig::default());
+
+    let first = Provider::with_id(
+        "openai".to_string(),
+        "OpenAI Compatible".to_string(),
+        openclaw_settings("openai", "gpt-4o", "sk-first"),
+        None,
+    );
+    let second = Provider::with_id(
+        "moonshot".to_string(),
+        "Moonshot".to_string(),
+        openclaw_settings("moonshot", "kimi-k2", "sk-second"),
+        None,
+    );
+
+    ProviderService::add(&state, app_type.clone(), first).expect("first add should succeed");
+    ProviderService::add(&state, app_type, second).expect("second add should succeed");
+
+    let openclaw_path = home.join(".openclaw").join("openclaw.json");
+    let live: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&openclaw_path).expect("read openclaw live config"),
+    )
+    .expect("parse openclaw live config");
+
+    let providers = live
+        .get("models")
+        .and_then(|value| value.get("providers"))
+        .and_then(|value| value.as_object())
+        .expect("openclaw config should contain provider map");
+
+    assert!(providers.contains_key("openai"));
+    assert!(providers.contains_key("moonshot"));
+    assert_eq!(
+        live.get("agents")
+            .and_then(|value| value.get("defaults"))
+            .and_then(|value| value.get("model"))
+            .and_then(|value| value.get("primary"))
+            .and_then(|value| value.as_str()),
+        Some("openai/gpt-4o")
+    );
+}
+
+#[test]
+fn openclaw_switch_updates_primary_model() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let app_type = AppType::from_str("openclaw").expect("openclaw app type should parse");
+    let state = state_from_config(MultiAppConfig::default());
+
+    let first = Provider::with_id(
+        "openai".to_string(),
+        "OpenAI Compatible".to_string(),
+        openclaw_settings("openai", "gpt-4o", "sk-first"),
+        None,
+    );
+    let second = Provider::with_id(
+        "moonshot".to_string(),
+        "Moonshot".to_string(),
+        openclaw_settings("moonshot", "kimi-k2", "sk-second"),
+        None,
+    );
+
+    ProviderService::add(&state, app_type.clone(), first).expect("first add should succeed");
+    ProviderService::add(&state, app_type.clone(), second).expect("second add should succeed");
+    ProviderService::switch(&state, app_type, "moonshot").expect("switch should succeed");
+
+    let openclaw_path = home.join(".openclaw").join("openclaw.json");
+    let live: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&openclaw_path).expect("read openclaw live config"),
+    )
+    .expect("parse openclaw live config");
+
+    assert_eq!(
+        live.get("agents")
+            .and_then(|value| value.get("defaults"))
+            .and_then(|value| value.get("model"))
+            .and_then(|value| value.get("primary"))
+            .and_then(|value| value.as_str()),
+        Some("moonshot/kimi-k2")
+    );
+}
+
+#[test]
+fn openclaw_update_non_current_provider_preserves_primary_model() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let app_type = AppType::from_str("openclaw").expect("openclaw app type should parse");
+    let state = state_from_config(MultiAppConfig::default());
+
+    let first = Provider::with_id(
+        "openai".to_string(),
+        "OpenAI Compatible".to_string(),
+        openclaw_settings("openai", "gpt-4o", "sk-first"),
+        None,
+    );
+    let second = Provider::with_id(
+        "moonshot".to_string(),
+        "Moonshot".to_string(),
+        openclaw_settings("moonshot", "kimi-k2", "sk-second"),
+        None,
+    );
+
+    ProviderService::add(&state, app_type.clone(), first).expect("first add should succeed");
+    ProviderService::add(&state, app_type.clone(), second).expect("second add should succeed");
+
+    let updated = Provider::with_id(
+        "moonshot".to_string(),
+        "Moonshot".to_string(),
+        openclaw_settings("moonshot", "kimi-k2-turbo", "sk-updated"),
+        None,
+    );
+    ProviderService::update(&state, app_type.clone(), updated).expect("update should succeed");
+
+    let manager = {
+        let config = state.config.read().expect("read state config");
+        config
+            .get_manager(&app_type)
+            .expect("openclaw manager should exist")
+            .clone()
+    };
+    let stored = manager
+        .providers
+        .get("moonshot")
+        .expect("updated provider should exist in store");
+    assert_eq!(
+        stored
+            .settings_config
+            .get("primaryModel")
+            .and_then(|value| value.as_str()),
+        Some("moonshot/kimi-k2-turbo")
+    );
+
+    let openclaw_path = home.join(".openclaw").join("openclaw.json");
+    let live: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&openclaw_path).expect("read openclaw live config"),
+    )
+    .expect("parse openclaw live config");
+
+    assert_eq!(
+        live.get("agents")
+            .and_then(|value| value.get("defaults"))
+            .and_then(|value| value.get("model"))
+            .and_then(|value| value.get("primary"))
+            .and_then(|value| value.as_str()),
+        Some("openai/gpt-4o")
+    );
+    assert_eq!(
+        live.get("models")
+            .and_then(|value| value.get("providers"))
+            .and_then(|value| value.get("moonshot"))
+            .and_then(|value| value.get("apiKey"))
+            .and_then(|value| value.as_str()),
+        Some("sk-updated")
+    );
+    assert_eq!(
+        live.get("models")
+            .and_then(|value| value.get("providers"))
+            .and_then(|value| value.get("moonshot"))
+            .and_then(|value| value.get("models"))
+            .and_then(|value| value.as_array())
+            .and_then(|models| models.first())
+            .and_then(|value| value.get("id"))
+            .and_then(|value| value.as_str()),
+        Some("kimi-k2-turbo")
+    );
+}
+
+#[test]
+fn openclaw_import_reads_live_config_and_tracks_current_provider() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let openclaw_dir = home.join(".openclaw");
+    std::fs::create_dir_all(&openclaw_dir).expect("create openclaw dir");
+    std::fs::write(
+        openclaw_dir.join("openclaw.json"),
+        serde_json::to_string_pretty(&json!({
+            "models": {
+                "providers": {
+                    "openai": {
+                        "name": "OpenAI Compatible",
+                        "baseUrl": "https://api.openai.example/v1",
+                        "apiKey": "sk-openai",
+                        "api": "openai-responses",
+                        "models": [{
+                            "id": "gpt-4o",
+                            "name": "gpt-4o",
+                            "reasoning": false,
+                            "input": ["text"],
+                            "cost": {
+                                "input": 0.0,
+                                "output": 0.0,
+                                "cacheRead": 0.0,
+                                "cacheWrite": 0.0
+                            },
+                            "contextWindow": 200000,
+                            "maxTokens": 8192
+                        }]
+                    },
+                    "moonshot": {
+                        "name": "Moonshot",
+                        "baseUrl": "https://api.moonshot.example/v1",
+                        "apiKey": "sk-moonshot",
+                        "api": "openai-responses",
+                        "models": [{
+                            "id": "kimi-k2",
+                            "name": "kimi-k2",
+                            "reasoning": false,
+                            "input": ["text"],
+                            "cost": {
+                                "input": 0.0,
+                                "output": 0.0,
+                                "cacheRead": 0.0,
+                                "cacheWrite": 0.0
+                            },
+                            "contextWindow": 128000,
+                            "maxTokens": 8192
+                        }]
+                    }
+                }
+            },
+            "agents": {
+                "defaults": {
+                    "model": {
+                        "primary": "moonshot/kimi-k2"
+                    }
+                }
+            }
+        }))
+        .expect("serialize live config"),
+    )
+    .expect("write openclaw live config");
+
+    let app_type = AppType::from_str("openclaw").expect("openclaw app type should parse");
+    let state = state_from_config(MultiAppConfig::default());
+
+    ProviderService::import_default_config(&state, app_type.clone())
+        .expect("import should succeed");
+
+    let manager = {
+        let config = state.config.read().expect("read state config");
+        config
+            .get_manager(&app_type)
+            .expect("openclaw manager should exist")
+            .clone()
+    };
+
+    assert_eq!(manager.current, "moonshot");
+    assert_eq!(manager.providers.len(), 2);
+    assert_eq!(
+        manager
+            .providers
+            .get("openai")
+            .and_then(|provider| provider.settings_config.get("primaryModel"))
+            .and_then(|value| value.as_str()),
+        Some("openai/gpt-4o")
+    );
+    assert_eq!(
+        manager
+            .providers
+            .get("moonshot")
+            .and_then(|provider| provider.settings_config.get("primaryModel"))
+            .and_then(|value| value.as_str()),
+        Some("moonshot/kimi-k2")
+    );
+}
+
+#[test]
+fn openclaw_switch_initializes_live_config_with_all_providers() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    let app_type = AppType::from_str("openclaw").expect("openclaw app type should parse");
+    let manager = config
+        .get_manager_mut(&app_type)
+        .expect("openclaw manager should exist");
+    manager.current = "openai".to_string();
+    manager.providers.insert(
+        "openai".to_string(),
+        Provider::with_id(
+            "openai".to_string(),
+            "OpenAI Compatible".to_string(),
+            openclaw_settings("openai", "gpt-4o", "sk-openai"),
+            None,
+        ),
+    );
+    manager.providers.insert(
+        "moonshot".to_string(),
+        Provider::with_id(
+            "moonshot".to_string(),
+            "Moonshot".to_string(),
+            openclaw_settings("moonshot", "kimi-k2", "sk-moonshot"),
+            None,
+        ),
+    );
+
+    let state = state_from_config(config);
+    ProviderService::switch(&state, app_type, "moonshot").expect("switch should succeed");
+
+    let openclaw_path = home.join(".openclaw").join("openclaw.json");
+    let live: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&openclaw_path).expect("read openclaw live config"),
+    )
+    .expect("parse openclaw live config");
+
+    let providers = live
+        .get("models")
+        .and_then(|value| value.get("providers"))
+        .and_then(|value| value.as_object())
+        .expect("openclaw config should contain provider map");
+
+    assert!(providers.contains_key("openai"));
+    assert!(providers.contains_key("moonshot"));
+    assert_eq!(
+        live.get("agents")
+            .and_then(|value| value.get("defaults"))
+            .and_then(|value| value.get("model"))
+            .and_then(|value| value.get("primary"))
+            .and_then(|value| value.as_str()),
+        Some("moonshot/kimi-k2")
+    );
+}

--- a/src-tauri/tests/openclaw_provider.rs
+++ b/src-tauri/tests/openclaw_provider.rs
@@ -312,6 +312,132 @@ fn openclaw_import_reads_live_config_and_tracks_current_provider() {
 }
 
 #[test]
+fn openclaw_import_preserves_non_first_live_primary_model() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let openclaw_dir = home.join(".openclaw");
+    std::fs::create_dir_all(&openclaw_dir).expect("create openclaw dir");
+    std::fs::write(
+        openclaw_dir.join("openclaw.json"),
+        serde_json::to_string_pretty(&json!({
+            "models": {
+                "providers": {
+                    "openai": {
+                        "name": "OpenAI Compatible",
+                        "baseUrl": "https://api.openai.example/v1",
+                        "apiKey": "sk-openai",
+                        "api": "openai-responses",
+                        "models": [{
+                            "id": "gpt-4o-mini",
+                            "name": "gpt-4o-mini",
+                            "reasoning": false,
+                            "input": ["text"],
+                            "cost": {
+                                "input": 0.0,
+                                "output": 0.0,
+                                "cacheRead": 0.0,
+                                "cacheWrite": 0.0
+                            },
+                            "contextWindow": 200000,
+                            "maxTokens": 8192
+                        }, {
+                            "id": "gpt-4o",
+                            "name": "gpt-4o",
+                            "reasoning": false,
+                            "input": ["text"],
+                            "cost": {
+                                "input": 0.0,
+                                "output": 0.0,
+                                "cacheRead": 0.0,
+                                "cacheWrite": 0.0
+                            },
+                            "contextWindow": 200000,
+                            "maxTokens": 8192
+                        }]
+                    }
+                }
+            },
+            "agents": {
+                "defaults": {
+                    "model": {
+                        "primary": "openai/gpt-4o"
+                    }
+                }
+            }
+        }))
+        .expect("serialize live config"),
+    )
+    .expect("write openclaw live config");
+
+    let app_type = AppType::from_str("openclaw").expect("openclaw app type should parse");
+    let state = state_from_config(MultiAppConfig::default());
+
+    ProviderService::import_default_config(&state, app_type.clone())
+        .expect("import should succeed");
+
+    let manager = {
+        let config = state.config.read().expect("read state config");
+        config
+            .get_manager(&app_type)
+            .expect("openclaw manager should exist")
+            .clone()
+    };
+
+    assert_eq!(manager.current, "openai");
+    assert_eq!(
+        manager
+            .providers
+            .get("openai")
+            .and_then(|provider| provider.settings_config.get("primaryModel"))
+            .and_then(|value| value.as_str()),
+        Some("openai/gpt-4o")
+    );
+}
+
+#[test]
+fn openclaw_add_rejects_missing_api_key() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+
+    let app_type = AppType::from_str("openclaw").expect("openclaw app type should parse");
+    let state = state_from_config(MultiAppConfig::default());
+    let invalid = Provider::with_id(
+        "openai".to_string(),
+        "OpenAI Compatible".to_string(),
+        json!({
+            "provider": {
+                "baseUrl": "https://api.example.com/v1",
+                "api": "openai-responses",
+                "models": [{
+                    "id": "gpt-4o",
+                    "name": "gpt-4o",
+                    "reasoning": false,
+                    "input": ["text"],
+                    "cost": {
+                        "input": 0.0,
+                        "output": 0.0,
+                        "cacheRead": 0.0,
+                        "cacheWrite": 0.0
+                    },
+                    "contextWindow": 200000,
+                    "maxTokens": 8192
+                }]
+            },
+            "primaryModel": "openai/gpt-4o"
+        }),
+        None,
+    );
+
+    let err = ProviderService::add(&state, app_type, invalid).expect_err("add should fail");
+    assert!(
+        err.to_string().contains("apiKey"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn openclaw_switch_initializes_live_config_with_all_providers() {
     let _guard = lock_test_mutex();
     reset_test_fs();

--- a/src-tauri/tests/support.rs
+++ b/src-tauri/tests/support.rs
@@ -9,7 +9,19 @@ use cc_switch_lib::{
 pub fn ensure_test_home() -> &'static Path {
     static HOME: OnceLock<PathBuf> = OnceLock::new();
     HOME.get_or_init(|| {
-        let base = std::env::temp_dir().join("cc-switch-test-home");
+        // Use a per-test-process home so separate integration test binaries can run in parallel.
+        let binary_name = std::env::current_exe()
+            .ok()
+            .as_deref()
+            .and_then(Path::file_stem)
+            .and_then(|value| value.to_str())
+            .unwrap_or("cc-switch-tests")
+            .to_string();
+        let base = std::env::temp_dir().join(format!(
+            "cc-switch-test-home-{}-{}",
+            binary_name,
+            std::process::id()
+        ));
         if base.exists() {
             let _ = std::fs::remove_dir_all(&base);
         }

--- a/src-tauri/tests/support.rs
+++ b/src-tauri/tests/support.rs
@@ -25,7 +25,14 @@ pub fn ensure_test_home() -> &'static Path {
 /// 清理测试目录中生成的配置文件与缓存。
 pub fn reset_test_fs() {
     let home = ensure_test_home();
-    for sub in [".claude", ".codex", ".cc-switch", ".gemini", ".config"] {
+    for sub in [
+        ".claude",
+        ".codex",
+        ".cc-switch",
+        ".gemini",
+        ".config",
+        ".openclaw",
+    ] {
         let path = home.join(sub);
         if path.exists() {
             if let Err(err) = std::fs::remove_dir_all(&path) {


### PR DESCRIPTION
Closes #61

## Summary
- add OpenClaw as a first-class app type across CLI, provider storage, live sync, deeplink, prompts, and stream-check paths
- add OpenClaw config helpers plus provider add/edit/inspect support, including primary model handling for current-provider switching
- keep OpenClaw additive provider sync correct when importing, updating non-current providers, and initializing live config from SSOT on first switch

## Testing
- cargo check
- cargo test --test openclaw_provider -- --nocapture
- cargo test --test app_type_parse -- --nocapture
- isolated CLI smoke test: `cc-switch --app open-claw provider switch moonshot` updates `openclaw.json` primary model and preserves all providers