### PR TITLE
Preserve Claude shared live settings across provider switches

### DIFF
--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -339,9 +339,15 @@ impl ConfigService {
             fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
         }
 
-        write_json_file(&settings_path, &provider.settings_config)?;
+        let mut live_to_write = provider.settings_config.clone();
+        ProviderService::normalize_claude_models_in_value(&mut live_to_write);
+        ProviderService::preserve_claude_shared_live_settings(&mut live_to_write)?;
 
-        let live_after = read_json_file::<serde_json::Value>(&settings_path)?;
+        write_json_file(&settings_path, &live_to_write)?;
+
+        let mut live_after = read_json_file::<serde_json::Value>(&settings_path)?;
+        ProviderService::normalize_claude_models_in_value(&mut live_after);
+        ProviderService::strip_preserved_claude_shared_live_settings(&mut live_after);
         if let Some(manager) = config.get_manager_mut(&AppType::Claude) {
             if let Some(target) = manager.providers.get_mut(provider_id) {
                 target.settings_config = live_after;

--- a/src-tauri/src/services/provider/claude.rs
+++ b/src-tauri/src/services/provider/claude.rs
@@ -1,6 +1,21 @@
 use super::*;
 
 impl ProviderService {
+    const CLAUDE_PRESERVED_SHARED_LIVE_KEYS: &[&str] = &[
+        "allowedHttpHookUrls",
+        "disableAllHooks",
+        "enabledMcpjsonServers",
+        "disabledMcpjsonServers",
+        "enableAllProjectMcpServers",
+        "extraKnownMarketplaces",
+        "fileSuggestion",
+        "hooks",
+        "httpHookAllowedEnvVars",
+        "permissions",
+        "respectGitignore",
+        "statusLine",
+    ];
+
     pub(super) fn parse_common_claude_config_snippet(snippet: &str) -> Result<Value, AppError> {
         let value: Value = serde_json::from_str(snippet).map_err(|e| {
             AppError::localized(
@@ -28,7 +43,7 @@ impl ProviderService {
     }
 
     /// 归一化 Claude 模型键：读旧键(ANTHROPIC_SMALL_FAST_MODEL)，写新键(DEFAULT_*), 并删除旧键
-    pub(super) fn normalize_claude_models_in_value(settings: &mut Value) -> bool {
+    pub(crate) fn normalize_claude_models_in_value(settings: &mut Value) -> bool {
         let mut changed = false;
         let env = match settings.get_mut("env") {
             Some(v) if v.is_object() => v.as_object_mut().unwrap(),
@@ -133,6 +148,39 @@ impl ProviderService {
         Ok(())
     }
 
+    pub(crate) fn strip_preserved_claude_shared_live_settings(value: &mut Value) {
+        let Some(obj) = value.as_object_mut() else {
+            return;
+        };
+        for key in Self::CLAUDE_PRESERVED_SHARED_LIVE_KEYS {
+            obj.remove(*key);
+        }
+    }
+
+    pub(crate) fn preserve_claude_shared_live_settings(value: &mut Value) -> Result<(), AppError> {
+        let settings_path = get_claude_settings_path();
+        if !settings_path.exists() {
+            return Ok(());
+        }
+
+        let existing = read_json_file::<Value>(&settings_path)?;
+        let (Some(existing_obj), Some(target_obj)) = (existing.as_object(), value.as_object_mut())
+        else {
+            return Ok(());
+        };
+
+        for key in Self::CLAUDE_PRESERVED_SHARED_LIVE_KEYS {
+            if target_obj.contains_key(*key) {
+                continue;
+            }
+            if let Some(existing_value) = existing_obj.get(*key) {
+                target_obj.insert((*key).to_string(), existing_value.clone());
+            }
+        }
+
+        Ok(())
+    }
+
     pub(super) fn prepare_switch_claude(
         config: &mut MultiAppConfig,
         provider_id: &str,
@@ -186,6 +234,7 @@ impl ProviderService {
                 strip_common_values(&mut live, &common);
             }
         }
+        Self::strip_preserved_claude_shared_live_settings(&mut live);
         if let Some(manager) = config.get_manager_mut(&AppType::Claude) {
             if let Some(current) = manager.providers.get_mut(&current_id) {
                 current.settings_config = live;
@@ -249,6 +298,9 @@ impl ProviderService {
         } else {
             provider_content
         };
+
+        let mut content_to_write = content_to_write;
+        Self::preserve_claude_shared_live_settings(&mut content_to_write)?;
 
         write_json_file(&settings_path, &content_to_write)?;
         Ok(())

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -215,6 +215,7 @@ impl ProviderService {
                         strip_common_values(&mut live_after, &common);
                     }
                 }
+                Self::strip_preserved_claude_shared_live_settings(&mut live_after);
                 {
                     let mut guard = state.config.write().map_err(AppError::from)?;
                     if let Some(manager) = guard.get_manager_mut(app_type) {

--- a/src-tauri/src/services/provider/tests.rs
+++ b/src-tauri/src/services/provider/tests.rs
@@ -724,6 +724,130 @@ fn common_config_snippet_is_merged_into_claude_settings_on_write() {
 
 #[test]
 #[serial]
+fn switch_claude_preserves_shared_live_settings_without_persisting_them_into_provider_snapshots() {
+    let temp_home = TempDir::new().expect("create temp home");
+    let _env = EnvGuard::set_home(temp_home.path());
+    std::fs::create_dir_all(crate::config::get_claude_config_dir())
+        .expect("create ~/.claude (initialized)");
+
+    let mut config = MultiAppConfig::default();
+    config.ensure_app(&AppType::Claude);
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "p1".to_string();
+        manager.providers.insert(
+            "p1".to_string(),
+            Provider::with_id(
+                "p1".to_string(),
+                "First".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_AUTH_TOKEN": "token1",
+                        "ANTHROPIC_BASE_URL": "https://claude.one"
+                    }
+                }),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "p2".to_string(),
+            Provider::with_id(
+                "p2".to_string(),
+                "Second".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_AUTH_TOKEN": "token2",
+                        "ANTHROPIC_BASE_URL": "https://claude.two"
+                    }
+                }),
+                None,
+            ),
+        );
+    }
+
+    write_json_file(
+        &get_claude_settings_path(),
+        &json!({
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": "token1",
+                "ANTHROPIC_BASE_URL": "https://claude.one"
+            },
+            "statusLine": {
+                "type": "command",
+                "command": "oh-my-claudecode statusline"
+            },
+            "hooks": {
+                "Stop": [{
+                    "type": "command",
+                    "command": "oh-my-claudecode cleanup"
+                }]
+            },
+            "permissions": {
+                "allow": ["Bash(git status)"]
+            }
+        }),
+    )
+    .expect("seed existing live settings");
+
+    let state = state_from_config(config);
+
+    ProviderService::switch(&state, AppType::Claude, "p2").expect("switch should succeed");
+
+    let live: Value = read_json_file(&get_claude_settings_path()).expect("read live settings");
+    assert_eq!(
+        live.pointer("/statusLine/command").and_then(Value::as_str),
+        Some("oh-my-claudecode statusline"),
+        "shared statusLine config should be preserved across provider switch"
+    );
+    assert_eq!(
+        live.pointer("/hooks/Stop/0/command")
+            .and_then(Value::as_str),
+        Some("oh-my-claudecode cleanup"),
+        "shared hooks config should be preserved across provider switch"
+    );
+    assert_eq!(
+        live.pointer("/permissions/allow/0").and_then(Value::as_str),
+        Some("Bash(git status)"),
+        "shared permissions config should be preserved across provider switch"
+    );
+    assert_eq!(
+        live.pointer("/env/ANTHROPIC_AUTH_TOKEN")
+            .and_then(Value::as_str),
+        Some("token2"),
+        "provider auth should still switch to the target provider"
+    );
+    assert_eq!(
+        live.pointer("/env/ANTHROPIC_BASE_URL")
+            .and_then(Value::as_str),
+        Some("https://claude.two"),
+        "provider base URL should still switch to the target provider"
+    );
+
+    let cfg = state.config.read().expect("read config");
+    let previous = cfg
+        .get_manager(&AppType::Claude)
+        .expect("claude manager")
+        .providers
+        .get("p1")
+        .expect("p1 exists");
+    assert!(
+        previous.settings_config.get("statusLine").is_none(),
+        "shared statusLine config should not be backfilled into provider snapshots"
+    );
+    assert!(
+        previous.settings_config.get("hooks").is_none(),
+        "shared hooks config should not be backfilled into provider snapshots"
+    );
+    assert!(
+        previous.settings_config.get("permissions").is_none(),
+        "shared permissions config should not be backfilled into provider snapshots"
+    );
+}
+
+#[test]
+#[serial]
 fn common_config_snippet_can_be_disabled_per_provider_for_claude() {
     let temp_home = TempDir::new().expect("create temp home");
     let _env = EnvGuard::set_home(temp_home.path());

--- a/src-tauri/tests/import_export_sync.rs
+++ b/src-tauri/tests/import_export_sync.rs
@@ -68,6 +68,97 @@ fn sync_claude_provider_writes_live_settings() {
 }
 
 #[test]
+fn sync_claude_provider_preserves_shared_live_settings() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+
+    let settings_path = get_claude_settings_path();
+    if let Some(parent) = settings_path.parent() {
+        fs::create_dir_all(parent).expect("create claude settings dir");
+    }
+    fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&json!({
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": "old-key",
+                "ANTHROPIC_BASE_URL": "https://old.example"
+            },
+            "statusLine": {
+                "type": "command",
+                "command": "oh-my-claudecode statusline"
+            },
+            "hooks": {
+                "Stop": [{
+                    "type": "command",
+                    "command": "oh-my-claudecode cleanup"
+                }]
+            }
+        }))
+        .expect("serialize existing live settings"),
+    )
+    .expect("seed existing live settings");
+
+    let mut config = MultiAppConfig::default();
+    let provider_config = json!({
+        "env": {
+            "ANTHROPIC_AUTH_TOKEN": "new-key",
+            "ANTHROPIC_BASE_URL": "https://new.example"
+        },
+        "ui": {
+            "displayName": "Test Provider"
+        }
+    });
+
+    let provider = Provider::with_id(
+        "prov-1".to_string(),
+        "Test Claude".to_string(),
+        provider_config.clone(),
+        None,
+    );
+
+    let manager = config
+        .get_manager_mut(&AppType::Claude)
+        .expect("claude manager");
+    manager.providers.insert("prov-1".to_string(), provider);
+    manager.current = "prov-1".to_string();
+
+    ConfigService::sync_current_providers_to_live(&mut config)
+        .expect("sync live settings with preserved shared keys");
+
+    let live_value: serde_json::Value = read_json_file(&settings_path).expect("read live file");
+    assert_eq!(
+        live_value
+            .pointer("/statusLine/command")
+            .and_then(|v| v.as_str()),
+        Some("oh-my-claudecode statusline"),
+        "shared statusLine config should survive live sync"
+    );
+    assert_eq!(
+        live_value
+            .pointer("/hooks/Stop/0/command")
+            .and_then(|v| v.as_str()),
+        Some("oh-my-claudecode cleanup"),
+        "shared hooks config should survive live sync"
+    );
+    assert_eq!(
+        live_value
+            .pointer("/env/ANTHROPIC_AUTH_TOKEN")
+            .and_then(|v| v.as_str()),
+        Some("new-key"),
+        "provider auth should still refresh during live sync"
+    );
+
+    let updated = config
+        .get_manager(&AppType::Claude)
+        .and_then(|m| m.providers.get("prov-1"))
+        .expect("provider in config");
+    assert_eq!(
+        updated.settings_config, provider_config,
+        "preserved shared live settings should not leak back into the provider snapshot"
+    );
+}
+
+#[test]
 fn sync_codex_provider_writes_auth_and_config() {
     let _guard = lock_test_mutex();
     reset_test_fs();


### PR DESCRIPTION
Closes #39

## Summary
- preserve shared Claude live settings like `statusLine`, `hooks`, `permissions`, and MCP/plugin-related keys when switching providers or re-syncing live config
- keep provider-managed auth/base URL updates authoritative so the target provider still fully replaces Claude credentials
- strip preserved shared keys back out of provider snapshots so user/plugin config does not leak into stored provider entries

## Testing
- `cargo check`
- `cargo test switch_claude_preserves_shared_live_settings_without_persisting_them_into_provider_snapshots -- --nocapture`
- `cargo test sync_claude_provider_preserves_shared_live_settings -- --nocapture`
- `cargo test provider_service_switch_claude_updates_live_and_state -- --nocapture`
- `cargo test common_config_snippet_is_not_persisted_into_provider_snapshot_on_switch -- --nocapture`
- `cargo test sync_claude_provider_writes_live_settings -- --nocapture`
- `cargo test common_config_snippet_is_merged_into_claude_settings_on_write -- --nocapture`