### PR TITLE
fix(provider): remove staled meta config

### DIFF
--- a/src-tauri/src/cli/tui/form/provider_json.rs
+++ b/src-tauri/src/cli/tui/form/provider_json.rs
@@ -35,7 +35,7 @@ impl ProviderAddFormState {
         }
         if let Some(meta_obj) = meta_value.as_object_mut() {
             meta_obj.insert(
-                "applyCommonConfig".to_string(),
+                "commonConfigEnabled".to_string(),
                 json!(if matches!(self.app_type, AppType::OpenClaw) {
                     false
                 } else {


### PR DESCRIPTION
Solved https://github.com/SaladDay/cc-switch-cli/issues/68

The `applyCommonConfig` seems to have been replaced by `commonConfigEnabled` and is retained as an alias for backward compatibility. However, it still appears in the provider JSON written process, resulting in repeated keywords due to certain `serde` parsing schemes.

The fix simply replaces the deprecated meta name with the currently used one.