### PR TITLE
Fix duplicate common config field in provider meta serialization

### DIFF
--- a/src-tauri/src/cli/tui/form/provider_json.rs
+++ b/src-tauri/src/cli/tui/form/provider_json.rs
@@ -34,6 +34,8 @@ impl ProviderAddFormState {
             *meta_value = json!({});
         }
         if let Some(meta_obj) = meta_value.as_object_mut() {
+            // Normalize the legacy alias before inserting the upstream field name.
+            meta_obj.remove("applyCommonConfig");
             meta_obj.insert(
                 "commonConfigEnabled".to_string(),
                 json!(if matches!(self.app_type, AppType::OpenClaw) {

--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -842,7 +842,31 @@ fn provider_add_form_common_config_json_merges_into_preview_but_not_raw_submit_p
         "provider field should override common snippet value"
     );
     assert_eq!(settings["env"]["ANTHROPIC_AUTH_TOKEN"], "sk-provider");
-    assert_eq!(merged["meta"]["applyCommonConfig"], true);
+    assert_eq!(merged["meta"]["commonConfigEnabled"], true);
+}
+
+#[test]
+fn provider_add_form_removes_legacy_apply_common_config_alias_from_meta() {
+    let mut form = ProviderAddFormState::new(AppType::Claude);
+    form.id.set("p1");
+    form.name.set("Provider One");
+    form.include_common_config = true;
+    form.extra = json!({
+        "meta": {
+            "applyCommonConfig": false,
+            "endpointAutoSelect": true
+        }
+    });
+
+    let provider = form.to_provider_json_value();
+    let meta = provider["meta"].as_object().expect("meta should be object");
+
+    assert_eq!(meta.get("commonConfigEnabled"), Some(&json!(true)));
+    assert!(
+        !meta.contains_key("applyCommonConfig"),
+        "legacy alias should be removed before serializing the provider"
+    );
+    assert_eq!(meta.get("endpointAutoSelect"), Some(&json!(true)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- drop the legacy  alias before writing 
- update the existing preview assertion to the upstream field name
- add a regression test covering legacy alias cleanup

## Verification
- cargo test provider_add_form_common_config_json_merges_into_preview_but_not_raw_submit_payload --manifest-path src-tauri/Cargo.toml
- cargo test provider_add_form_removes_legacy_apply_common_config_alias_from_meta --manifest-path src-tauri/Cargo.toml
- cargo build --release --manifest-path src-tauri/Cargo.toml