### PR TITLE
feat:add version select support for install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ TARGET="${INSTALL_DIR}/${BIN_NAME}"
 RELEASES_URL="https://github.com/${REPO}/releases"
 FORCE_OVERWRITE="${CC_SWITCH_FORCE:-0}"
 LINUX_LIBC="${CC_SWITCH_LINUX_LIBC:-auto}"
+VERSION="${1:-latest}"
 
 TMP_DIR=""
 ASSET_NAME=""
@@ -219,7 +220,11 @@ download() {
   local asset_name url dest
 
   for asset_name in "${ASSET_CANDIDATES[@]}"; do
-    url="${RELEASES_URL}/latest/download/${asset_name}"
+    if [[ "${VERSION}" == "latest" ]]; then
+      url="${RELEASES_URL}/latest/download/${asset_name}"
+    else
+      url="${RELEASES_URL}/download/${VERSION}/${asset_name}"
+    fi
     dest="${TMP_DIR}/${asset_name}"
 
     info "Downloading ${asset_name}"


### PR DESCRIPTION
目前安装脚本默认只能下载 latest 版本，此 PR 增加了对指定版本号的支持，允许用户安装指定的的 Release 版本，便于版本回退（如当前release的最新版本 v5.1.1 的编辑已有供应商在保存时提示json重复的bug）或特定环境需求，通过在安装脚本后指定 v版本号参数使用 ./install.sh v5.1.0

实现方法：

新增了VERSION 变量，将脚本接收的第一个参数赋值给 VERSION 变量，如果未提供参数，则默认为 latest。
动态 URL：修改了 download 函数的逻辑。如果是 latest，保持原有的 URL 结构；如果是指定版本，则构造对应的 Tag 下载路径 (/download/${VERSION}/...)。

测试：
<img width="951" height="514" alt="屏幕截图 2026-03-23 105111" src="https://github.com/user-attachments/assets/bebbb76c-bfa7-4b63-bf9e-11f8505e72aa" />
