### PR TITLE
fix(claude): preserve user-defined settings on provider switch

### DIFF
--- a/src-tauri/src/services/provider/claude.rs
+++ b/src-tauri/src/services/provider/claude.rs
@@ -235,7 +235,7 @@ impl ProviderService {
         let mut provider_content = provider.settings_config.clone();
         let _ = Self::normalize_claude_models_in_value(&mut provider_content);
 
-        let content_to_write = if let Some(snippet) = common_config_snippet {
+        let new_content = if let Some(snippet) = common_config_snippet {
             let snippet = snippet.trim();
             if snippet.is_empty() {
                 provider_content
@@ -248,6 +248,35 @@ impl ProviderService {
             }
         } else {
             provider_content
+        };
+
+        // Preserve user-defined top-level fields that are not managed by cc-switch.
+        // These are Claude Code settings that users configure independently
+        // (e.g. statusLine for HUD plugins, hooks for automation).
+        const PRESERVE_KEYS: &[&str] = &["statusLine", "hooks", "permissions", "apiKeyHelper"];
+
+        let content_to_write = if settings_path.exists() {
+            if let Ok(existing) = read_json_file::<Value>(&settings_path) {
+                if let Some(existing_map) = existing.as_object() {
+                    let mut result = new_content.clone();
+                    if let Some(result_map) = result.as_object_mut() {
+                        for key in PRESERVE_KEYS {
+                            if let Some(value) = existing_map.get(*key) {
+                                if !result_map.contains_key(*key) {
+                                    result_map.insert(key.to_string(), value.clone());
+                                }
+                            }
+                        }
+                    }
+                    result
+                } else {
+                    new_content
+                }
+            } else {
+                new_content
+            }
+        } else {
+            new_content
         };
 
         write_json_file(&settings_path, &content_to_write)?;


### PR DESCRIPTION
## Summary

- When switching providers, `write_claude_live()` previously overwrote the entire `settings.json`, causing user-defined fields to be lost
- Now preserves known user-configurable top-level keys (`statusLine`, `hooks`, `permissions`, `apiKeyHelper`) from the existing file when writing new provider config
- This fixes the issue where HUD plugins (e.g. `claude-hud`) stop working after a provider switch because `statusLine` config is dropped

## Details

The root cause is in `write_claude_live()` (`src-tauri/src/services/provider/claude.rs`): it constructs the new config from the provider's `settings_config` + common config snippet, then writes it directly to `settings.json` without reading the existing file. Any fields not stored in the provider's database record are lost.

The fix reads the existing `settings.json` before writing and carries over user-defined fields that are not present in the new provider config. A whitelist approach (`PRESERVE_KEYS`) is used instead of preserving all unknown keys, to avoid conflicts with common config management (e.g. clearing a common config snippet should still remove its fields).

## Test plan

- [x] All 946+ existing tests pass (0 failures)
- [x] Manual test: switch claude-official → zhipu → claude-official, `statusLine` preserved throughout
- [x] Manual test: `env` correctly switches between providers
- [x] The previously failing test `clear_updates_live_config_even_without_apply_flag` passes (common config fields are correctly removed when cleared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)