### PR TITLE
Feat/issue 97 provider export

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ cc-switch
 ```bash
 cc-switch provider list              # List providers
 cc-switch provider switch <id>       # Switch provider
+cc-switch provider export <id>       # Export a Claude provider to a standalone settings file
 cc-switch provider stream-check <id> # Check provider stream health
 cc-switch config webdav show         # Inspect WebDAV sync settings
 cc-switch env tools                  # Check local CLI tools
@@ -243,7 +244,7 @@ copy target\release\cc-switch.exe C:\Windows\System32\
 
 Manage API configurations for **Claude Code**, **Codex**, **Gemini**, **OpenCode**, and **OpenClaw**.
 
-**Features:** One-click switching, multi-endpoint support, API key management, remote model discovery, and per-app diagnostics such as speed testing or stream health checks where supported.
+**Features:** One-click switching, standalone Claude settings export, multi-endpoint support, API key management, remote model discovery, and per-app diagnostics such as speed testing or stream health checks where supported.
 
 ```bash
 cc-switch provider list              # List all providers
@@ -253,9 +254,11 @@ cc-switch provider add               # Add new provider
 cc-switch provider edit <id>         # Edit existing provider
 cc-switch provider duplicate <id>    # Duplicate a provider
 cc-switch provider delete <id>       # Delete provider
+cc-switch provider export <id>       # Export a Claude provider to a standalone settings.json
 cc-switch provider speedtest <id>    # Test API latency
 cc-switch provider stream-check <id> # Run stream health check
 cc-switch provider fetch-models <id> # Fetch remote model list
+cc-switch provider export <id> --output ~/.claude/settings-demo.json # Custom export path
 ```
 
 ### 🛠️ MCP Server Management

--- a/README.md
+++ b/README.md
@@ -254,11 +254,11 @@ cc-switch provider add               # Add new provider
 cc-switch provider edit <id>         # Edit existing provider
 cc-switch provider duplicate <id>    # Duplicate a provider
 cc-switch provider delete <id>       # Delete provider
-cc-switch provider export <id>       # Export a Claude provider to a standalone settings.json
+cc-switch provider export <id>       # Export to ./.claude/settings.local.json for Claude auto-load
 cc-switch provider speedtest <id>    # Test API latency
 cc-switch provider stream-check <id> # Run stream health check
 cc-switch provider fetch-models <id> # Fetch remote model list
-cc-switch provider export <id> --output ~/.claude/settings-demo.json # Custom export path
+cc-switch provider export <id> --output ~/.claude/settings-demo.json # Custom settings file path
 ```
 
 ### 🛠️ MCP Server Management

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -255,11 +255,11 @@ cc-switch provider add               # 添加新供应商
 cc-switch provider edit <id>         # 编辑现有供应商
 cc-switch provider duplicate <id>    # 复制供应商
 cc-switch provider delete <id>       # 删除供应商
-cc-switch provider export <id>       # 导出 Claude 供应商为独立 settings.json
+cc-switch provider export <id>       # 导出到当前目录 ./.claude/settings.local.json 并供 Claude 自动加载
 cc-switch provider speedtest <id>    # 测试 API 延迟
 cc-switch provider stream-check <id> # 执行流式健康检查
 cc-switch provider fetch-models <id> # 拉取远端模型列表
-cc-switch provider export <id> --output ~/.claude/settings-demo.json # 自定义导出路径
+cc-switch provider export <id> --output ~/.claude/settings-demo.json # 自定义 settings 文件路径
 ```
 
 ### 🛠️ MCP 服务器管理

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -116,6 +116,7 @@ cc-switch
 ```bash
 cc-switch provider list              # 列出供应商
 cc-switch provider switch <id>       # 切换供应商
+cc-switch provider export <id>       # 导出 Claude 供应商为独立 settings 文件
 cc-switch provider stream-check <id> # 检查供应商流式健康
 cc-switch config webdav show         # 查看 WebDAV 同步设置
 cc-switch env tools                  # 检查本地 CLI 工具
@@ -244,7 +245,7 @@ copy target\release\cc-switch.exe C:\Windows\System32\
 
 管理 **Claude Code**、**Codex**、**Gemini**、**OpenCode** 与 **OpenClaw** 的 API 配置。
 
-**功能：** 一键切换、多端点支持、API 密钥管理、远端模型发现，以及按应用提供的速度测试、流式健康检查等诊断能力。
+**功能：** 一键切换、Claude 独立 settings 导出、多端点支持、API 密钥管理、远端模型发现，以及按应用提供的速度测试、流式健康检查等诊断能力。
 
 ```bash
 cc-switch provider list              # 列出所有供应商
@@ -254,9 +255,11 @@ cc-switch provider add               # 添加新供应商
 cc-switch provider edit <id>         # 编辑现有供应商
 cc-switch provider duplicate <id>    # 复制供应商
 cc-switch provider delete <id>       # 删除供应商
+cc-switch provider export <id>       # 导出 Claude 供应商为独立 settings.json
 cc-switch provider speedtest <id>    # 测试 API 延迟
 cc-switch provider stream-check <id> # 执行流式健康检查
 cc-switch provider fetch-models <id> # 拉取远端模型列表
+cc-switch provider export <id> --output ~/.claude/settings-demo.json # 自定义导出路径
 ```
 
 ### 🛠️ MCP 服务器管理

--- a/src-tauri/src/cli/commands/provider.rs
+++ b/src-tauri/src/cli/commands/provider.rs
@@ -463,7 +463,7 @@ fn export_provider(app_type: AppType, id: &str, output: Option<PathBuf>) -> Resu
         None => {
             // Default: {cwd}/.claude/settings.local.json (auto-loaded by Claude CLI)
             std::env::current_dir()
-                .expect("无法获取当前工作目录")
+                .map_err(|e| AppError::Message(format!("无法获取当前工作目录: {}", e)))?
                 .join(".claude")
                 .join("settings.local.json")
         }

--- a/src-tauri/src/cli/commands/provider.rs
+++ b/src-tauri/src/cli/commands/provider.rs
@@ -1,4 +1,5 @@
 use clap::Subcommand;
+use std::path::PathBuf;
 
 use super::provider_inspect;
 use crate::app_config::AppType;
@@ -78,6 +79,15 @@ pub enum ProviderCommand {
         /// Provider ID to query
         id: String,
     },
+    /// Export a Claude provider to a standalone settings file
+    Export {
+        /// Provider ID to export
+        id: String,
+        /// Output path (default: {cwd}/.claude/settings.local.json)
+        /// If path is a directory, appends settings-{provider-name}.json
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+    },
 }
 
 pub fn execute(cmd: ProviderCommand, app: Option<AppType>) -> Result<(), AppError> {
@@ -99,6 +109,7 @@ pub fn execute(cmd: ProviderCommand, app: Option<AppType>) -> Result<(), AppErro
             provider_inspect::fetch_models_provider(app_type, &id)
         }
         ProviderCommand::Usage { id } => provider_inspect::usage_provider(app_type, &id),
+        ProviderCommand::Export { id, output } => export_provider(app_type, &id, output),
     }
 }
 
@@ -407,5 +418,121 @@ fn edit_provider(app_type: AppType, id: &str) -> Result<(), AppError> {
 fn duplicate_provider(_app_type: AppType, id: &str) -> Result<(), AppError> {
     println!("{}", info(&format!("Duplicating provider '{}'...", id)));
     println!("{}", error("Provider duplication is not yet implemented."));
+    Ok(())
+}
+
+fn export_provider(app_type: AppType, id: &str, output: Option<PathBuf>) -> Result<(), AppError> {
+    if !matches!(app_type, AppType::Claude) {
+        return Err(AppError::Message(format!(
+            "Provider export currently supports only Claude standalone settings files. Use --app claude (current app: {}).",
+            app_type.as_str()
+        )));
+    }
+
+    let state = get_state()?;
+
+    // Single lock scope: get provider AND common_config_snippet together
+    let (provider, common_config_snippet) = {
+        let config = state.config.read().map_err(AppError::from)?;
+        let manager = config
+            .get_manager(&app_type)
+            .ok_or_else(|| AppError::Message(texts::app_config_not_found(app_type.as_str())))?;
+
+        let provider = manager
+            .providers
+            .get(id)
+            .ok_or_else(|| {
+                let msg = texts::provider_not_found(id);
+                AppError::localized("provider.not_found", msg.clone(), msg)
+            })?
+            .clone();
+
+        (
+            provider,
+            config.common_config_snippets.get(&app_type).cloned(),
+        )
+    };
+
+    let apply_common_config = provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.apply_common_config)
+        .unwrap_or(true);
+
+    let output_path = match output {
+        None => {
+            // Default: {cwd}/.claude/settings.local.json (auto-loaded by Claude CLI)
+            std::env::current_dir()
+                .expect("无法获取当前工作目录")
+                .join(".claude")
+                .join("settings.local.json")
+        }
+        Some(path) => {
+            // If path looks like a directory (no .json extension), append settings-{name}.json
+            let path_str = path.to_string_lossy();
+            if path_str.ends_with('/') || path_str.ends_with('\\') || !path_str.ends_with(".json") {
+                path.join(format!(
+                    "settings-{}.json",
+                    crate::config::sanitize_provider_name(&provider.name)
+                ))
+            } else {
+                path
+            }
+        }
+    };
+
+    if output_path.exists() {
+        let confirm = Confirm::new(&format!(
+            "File '{}' already exists. Overwrite?",
+            output_path.display()
+        ))
+        .with_default(false)
+        .prompt()
+        .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?;
+
+        if !confirm {
+            println!("{}", info(texts::cancelled()));
+            return Ok(());
+        }
+    }
+
+    let settings_content = ProviderService::build_live_backup_snapshot(
+        &app_type,
+        &provider,
+        common_config_snippet.as_deref(),
+        apply_common_config,
+    )?;
+
+    crate::config::write_json_file(&output_path, &settings_content)?;
+
+    println!(
+        "{}",
+        success(&format!(
+            "✓ Exported provider '{}' to {}",
+            id,
+            output_path.display()
+        ))
+    );
+
+    // If output is settings.local.json, Claude CLI will auto-load it
+    if output_path
+        .file_name()
+        .map(|n| n.to_string_lossy() == "settings.local.json")
+        .unwrap_or(false)
+    {
+        println!(
+            "{}",
+            info("Claude CLI will auto-load this config. Just run: claude")
+        );
+    } else {
+        println!(
+            "{}",
+            info(&format!(
+                "Use it with: claude --settings {}",
+                output_path.display()
+            ))
+        );
+    }
+
     Ok(())
 }

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -35,7 +35,7 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Manage providers (list, switch, speedtest, stream-check, fetch-models, usage)
+    /// Manage providers (list, switch, export, speedtest, stream-check, fetch-models, usage)
     #[command(subcommand)]
     Provider(commands::provider::ProviderCommand),
 
@@ -229,6 +229,48 @@ mod tests {
                 assert_eq!(id, "demo");
             }
             _ => panic!("expected provider fetch-models command"),
+        }
+    }
+
+    #[test]
+    fn parses_provider_export_subcommand() {
+        let cli = Cli::parse_from(["cc-switch", "provider", "export", "demo"]);
+
+        match cli.command {
+            Some(Commands::Provider(super::commands::provider::ProviderCommand::Export {
+                id,
+                output,
+            })) => {
+                assert_eq!(id, "demo");
+                assert_eq!(output, None);
+            }
+            _ => panic!("expected provider export command"),
+        }
+    }
+
+    #[test]
+    fn parses_provider_export_with_output_subcommand() {
+        let cli = Cli::parse_from([
+            "cc-switch",
+            "provider",
+            "export",
+            "demo",
+            "--output",
+            "/tmp/provider-settings.json",
+        ]);
+
+        match cli.command {
+            Some(Commands::Provider(super::commands::provider::ProviderCommand::Export {
+                id,
+                output,
+            })) => {
+                assert_eq!(id, "demo");
+                assert_eq!(
+                    output,
+                    Some(std::path::PathBuf::from("/tmp/provider-settings.json"))
+                );
+            }
+            _ => panic!("expected provider export command with output"),
         }
     }
 

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -22,6 +22,172 @@ fn find_free_port() -> u16 {
 }
 
 #[test]
+#[serial]
+fn provider_export_writes_merged_claude_settings_to_default_path() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    config.common_config_snippets.claude = Some(
+        r#"{
+  "env": {
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": 1
+  },
+  "includeCoAuthoredBy": false
+}"#
+        .to_string(),
+    );
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "demo".to_string();
+        manager.providers.insert(
+            "demo".to_string(),
+            Provider::with_id(
+                "demo".to_string(),
+                "demo".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_API_KEY": "sk-demo"
+                    },
+                    "permissions": {
+                        "allow": ["Bash"]
+                    }
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = state_from_config(config);
+    state.save().expect("persist test config");
+
+    cc_switch_lib::cli::commands::provider::execute(
+        cc_switch_lib::cli::commands::provider::ProviderCommand::Export {
+            id: "demo".to_string(),
+            output: None,
+        },
+        Some(AppType::Claude),
+    )
+    .expect("export command should succeed");
+
+    let export_path = home.join(".claude").join("settings-demo.json");
+    let exported: serde_json::Value = read_json_file(&export_path).expect("read exported file");
+
+    assert_eq!(
+        exported
+            .get("env")
+            .and_then(|v| v.get("ANTHROPIC_API_KEY"))
+            .and_then(|v| v.as_str()),
+        Some("sk-demo"),
+        "provider env should be preserved"
+    );
+    assert_eq!(
+        exported
+            .get("env")
+            .and_then(|v| v.get("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"))
+            .and_then(|v| v.as_i64()),
+        Some(1),
+        "common config snippet should be merged into export"
+    );
+    assert_eq!(
+        exported
+            .get("includeCoAuthoredBy")
+            .and_then(|v| v.as_bool()),
+        Some(false),
+        "top-level common config should be present in export"
+    );
+    assert_eq!(
+        exported
+            .get("permissions")
+            .and_then(|v| v.get("allow"))
+            .and_then(|v| v.as_array())
+            .map(|values| values.len()),
+        Some(1),
+        "provider-specific settings should remain in export"
+    );
+}
+
+#[test]
+#[serial]
+fn provider_export_respects_apply_common_config_flag_and_custom_output() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    config.common_config_snippets.claude =
+        Some(r#"{"env":{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":1}}"#.to_string());
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "demo".to_string();
+        let mut provider = Provider::with_id(
+            "demo".to_string(),
+            "demo".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": "sk-demo"
+                }
+            }),
+            None,
+        );
+        provider.meta = Some(cc_switch_lib::ProviderMeta {
+            apply_common_config: Some(false),
+            ..Default::default()
+        });
+        manager.providers.insert("demo".to_string(), provider);
+    }
+
+    let state = state_from_config(config);
+    state.save().expect("persist test config");
+
+    let output_path = home.join("exports").join("custom-settings.json");
+    cc_switch_lib::cli::commands::provider::execute(
+        cc_switch_lib::cli::commands::provider::ProviderCommand::Export {
+            id: "demo".to_string(),
+            output: Some(output_path.clone()),
+        },
+        Some(AppType::Claude),
+    )
+    .expect("export command should succeed");
+
+    let exported: serde_json::Value = read_json_file(&output_path).expect("read exported file");
+    assert!(
+        exported
+            .get("env")
+            .and_then(|v| v.get("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"))
+            .is_none(),
+        "common config should be skipped when applyCommonConfig=false"
+    );
+}
+
+#[test]
+#[serial]
+fn provider_export_rejects_non_claude_apps() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    ensure_test_home();
+
+    let err = cc_switch_lib::cli::commands::provider::execute(
+        cc_switch_lib::cli::commands::provider::ProviderCommand::Export {
+            id: "demo".to_string(),
+            output: None,
+        },
+        Some(AppType::Codex),
+    )
+    .expect_err("non-claude export should fail");
+
+    assert!(
+        err.to_string().contains("supports only Claude"),
+        "error should explain Claude-only support"
+    );
+}
+
+#[test]
 fn switch_provider_updates_codex_live_and_state() {
     let _guard = lock_test_mutex();
     reset_test_fs();

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -11,7 +11,9 @@ use cc_switch_lib::{
 
 #[path = "support.rs"]
 mod support;
-use support::{ensure_test_home, lock_test_mutex, reset_test_fs, state_from_config};
+use support::{
+    ensure_test_home, lock_test_mutex, reset_test_fs, state_from_config, CurrentDirGuard,
+};
 
 fn find_free_port() -> u16 {
     let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind free local port");
@@ -27,6 +29,8 @@ fn provider_export_writes_merged_claude_settings_to_default_path() {
     let _guard = lock_test_mutex();
     reset_test_fs();
     let home = ensure_test_home();
+    let project_dir = home.join("project-a");
+    let _cwd_guard = CurrentDirGuard::change_to(&project_dir);
 
     let mut config = MultiAppConfig::default();
     config.common_config_snippets.claude = Some(
@@ -64,17 +68,16 @@ fn provider_export_writes_merged_claude_settings_to_default_path() {
     let state = state_from_config(config);
     state.save().expect("persist test config");
 
-    // Use explicit output path to avoid cwd ambiguity and file-exists confirmation prompt
-    let export_path = home.join(".claude").join("settings.local.json");
     cc_switch_lib::cli::commands::provider::execute(
         cc_switch_lib::cli::commands::provider::ProviderCommand::Export {
             id: "demo".to_string(),
-            output: Some(export_path.clone()),
+            output: None,
         },
         Some(AppType::Claude),
     )
     .expect("export command should succeed");
 
+    let export_path = project_dir.join(".claude").join("settings.local.json");
     let exported: serde_json::Value = read_json_file(&export_path).expect("read exported file");
 
     assert_eq!(

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -64,16 +64,17 @@ fn provider_export_writes_merged_claude_settings_to_default_path() {
     let state = state_from_config(config);
     state.save().expect("persist test config");
 
+    // Use explicit output path to avoid cwd ambiguity and file-exists confirmation prompt
+    let export_path = home.join(".claude").join("settings.local.json");
     cc_switch_lib::cli::commands::provider::execute(
         cc_switch_lib::cli::commands::provider::ProviderCommand::Export {
             id: "demo".to_string(),
-            output: None,
+            output: Some(export_path.clone()),
         },
         Some(AppType::Claude),
     )
     .expect("export command should succeed");
 
-    let export_path = home.join(".claude").join("settings-demo.json");
     let exported: serde_json::Value = read_json_file(&export_path).expect("read exported file");
 
     assert_eq!(

--- a/src-tauri/tests/support.rs
+++ b/src-tauri/tests/support.rs
@@ -71,3 +71,24 @@ pub fn state_from_config(config: MultiAppConfig) -> AppState {
         proxy_service: ProxyService::new(db),
     }
 }
+
+#[allow(dead_code)]
+pub struct CurrentDirGuard {
+    previous: PathBuf,
+}
+
+impl CurrentDirGuard {
+    #[allow(dead_code)]
+    pub fn change_to(path: &Path) -> Self {
+        let previous = std::env::current_dir().expect("read current dir");
+        std::fs::create_dir_all(path).expect("create target cwd");
+        std::env::set_current_dir(path).expect("switch current dir");
+        Self { previous }
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.previous).expect("restore current dir");
+    }
+}


### PR DESCRIPTION
# feat: 添加 `provider export` 命令导出 Claude settings.local.json


<img width="1586" height="513" alt="image" src="https://github.com/user-attachments/assets/92cd22f0-79d2-4266-9722-b63dca2249dc" />


## Summary

添加 `cc-switch provider export <id>` 命令，将 Claude provider 配置导出为独立的 settings 文件，可被 Claude CLI 自动加载。

- **默认**：导出到 `{cwd}/.claude/settings.local.json`（Claude CLI 自动加载）
- **目录路径**：`--output .claude/` 自动追加 `settings-{provider-name}.json`
- **自定义路径**：`--output ~/custom.json` 使用指定路径

Closes #97

## Changes

- `src/cli/commands/provider.rs`：新增 `Export` 子命令和 `export_provider` 函数
- `src/cli/mod.rs`：新增 CLI 解析测试
- `tests/provider_commands.rs`：新增集成测试
- `README.md`, `README_ZH.md`：更新文档

## Usage

```bash
# 默认：导出到 settings.local.json（自动加载）
cd ~/project-a
cc-switch provider export provider-a
claude  # 自动使用 .claude/settings.local.json

# 导出到 .claude 目录，使用 provider 名称
cc-switch provider export provider-a --output .claude/
# 输出: .claude/settings-provider-a.json

# 自定义路径
cc-switch provider export my-provider --output ~/configs/custom.json
claude --settings ~/configs/custom.json
```

## Test Plan

- [x] `cargo build --release` 编译成功
- [x] `cargo fmt --check` 通过
- [x] 手动测试：
  - [x] 默认导出到 `{cwd}/.claude/settings.local.json`
  - [x] 目录路径处理（`--output .claude/`）
  - [x] 自定义文件路径（`--output ~/custom.json`）
  - [x] 不同路径类型的正确提示消息

## 设计说明

### 为什么默认使用 `settings.local.json`？

1. **Claude Code 配置优先级**（从高到低）：
   ```
   1. Managed settings（企业级，无法覆盖）
   2. CLI 参数（--settings）
   3. Local project: {cwd}/.claude/settings.local.json  ← 目标
   4. Shared project: {cwd}/.claude/settings.json
   5. User: ~/.claude/settings.json
   ```

2. **自动加载**：运行 `claude` 时无需指定 `--settings` 参数
3. **多实例隔离**：不同项目目录各自配置，互不干扰
4. **Git 友好**：可 `.gitignore` 排除或提交到仓库共享团队配置

### 为什么只支持 Claude？

其他 CLI 工具使用不同的配置格式：
- **Codex**：`auth.json` + `config.toml`（TOML 格式）
- **Gemini**：`.env` + `settings.json`（环境变量格式）

它们都不支持类似 Claude 的 `settings.local.json` 自动加载机制。