### PR TITLE
Fix model settings not switching during temp launch

### DIFF
--- a/src-tauri/src/cli/claude_temp_launch.rs
+++ b/src-tauri/src/cli/claude_temp_launch.rs
@@ -6,6 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::AppError;
 use crate::provider::Provider;
+use crate::services::provider::ProviderService;
 use serde_json::json;
 
 #[derive(Debug, Clone)]
@@ -36,18 +37,18 @@ where
     Resolve: FnOnce() -> Result<PathBuf, AppError>,
 {
     let executable = resolve_claude_binary()?;
-    let env = provider
-        .settings_config
-        .get("env")
-        .and_then(|value| value.as_object())
-        .ok_or_else(|| {
-            AppError::localized(
-                "claude.temp_launch_missing_env",
-                format!("供应商 {} 缺少有效的 env 配置。", provider.id),
-                format!("Provider {} is missing a valid env object.", provider.id),
-            )
-        })?;
-    let settings_path = write_temp_settings_file(temp_dir, provider, &json!({ "env": env }))?;
+
+    if provider.settings_config.get("env").and_then(|v| v.as_object()).is_none() {
+        return Err(AppError::localized(
+            "claude.temp_launch_missing_env",
+            format!("供应商 {} 缺少有效的 env 配置。", provider.id),
+            format!("Provider {} is missing a valid env object.", provider.id),
+        ));
+    }
+
+    let mut settings = provider.settings_config.clone();
+    let _ = ProviderService::normalize_claude_models_in_value(&mut settings);
+    let settings_path = write_temp_settings_file(temp_dir, provider, &settings)?;
 
     Ok(PreparedClaudeLaunch {
         executable,
@@ -471,5 +472,105 @@ mod tests {
         .expect_err("missing binary should fail");
 
         assert!(err.to_string().contains("claude"));
+    }
+
+    #[test]
+    fn prepare_launch_writes_model_overrides_to_temp_file() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let provider = Provider::with_id(
+            "glm".to_string(),
+            "GLM".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "sk-glm",
+                    "ANTHROPIC_BASE_URL": "https://open.bigmodel.cn/api/paas/v4",
+                    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.1",
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.1"
+                }
+            }),
+            None,
+        );
+
+        let prepared = prepare_launch_with(&provider, temp_dir.path(), || {
+            Ok(PathBuf::from("/usr/bin/claude"))
+        })
+        .expect("prepare launch");
+
+        let written: Value = serde_json::from_str(
+            &std::fs::read_to_string(&prepared.settings_path).expect("read temp settings"),
+        )
+        .expect("parse temp settings");
+
+        let env = written.get("env").expect("env exists");
+        assert_eq!(env["ANTHROPIC_DEFAULT_SONNET_MODEL"], "glm-5.1");
+        assert_eq!(env["ANTHROPIC_DEFAULT_OPUS_MODEL"], "glm-5.1");
+    }
+
+    #[test]
+    fn prepare_launch_migrates_legacy_small_fast_model_key() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let provider = Provider::with_id(
+            "legacy".to_string(),
+            "Legacy".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "sk-legacy",
+                    "ANTHROPIC_BASE_URL": "https://api.example.com",
+                    "ANTHROPIC_SMALL_FAST_MODEL": "my-fast-model"
+                }
+            }),
+            None,
+        );
+
+        let prepared = prepare_launch_with(&provider, temp_dir.path(), || {
+            Ok(PathBuf::from("/usr/bin/claude"))
+        })
+        .expect("prepare launch");
+
+        let written: Value = serde_json::from_str(
+            &std::fs::read_to_string(&prepared.settings_path).expect("read temp settings"),
+        )
+        .expect("parse temp settings");
+
+        let env = written.get("env").expect("env exists");
+        assert!(
+            env.get("ANTHROPIC_SMALL_FAST_MODEL").is_none(),
+            "legacy key should be removed"
+        );
+        assert_eq!(env["ANTHROPIC_DEFAULT_HAIKU_MODEL"], "my-fast-model");
+    }
+
+    #[test]
+    fn prepare_launch_writes_full_settings_config_not_only_env() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let provider = Provider::with_id(
+            "full".to_string(),
+            "Full".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "sk-full"
+                },
+                "permissions": {
+                    "allow": ["Bash(git*)"]
+                }
+            }),
+            None,
+        );
+
+        let prepared = prepare_launch_with(&provider, temp_dir.path(), || {
+            Ok(PathBuf::from("/usr/bin/claude"))
+        })
+        .expect("prepare launch");
+
+        let written: Value = serde_json::from_str(
+            &std::fs::read_to_string(&prepared.settings_path).expect("read temp settings"),
+        )
+        .expect("parse temp settings");
+
+        assert_eq!(written["env"]["ANTHROPIC_AUTH_TOKEN"], "sk-full");
+        assert_eq!(
+            written["permissions"]["allow"],
+            json!(["Bash(git*)"])
+        );
     }
 }

--- a/src-tauri/src/cli/claude_temp_launch.rs
+++ b/src-tauri/src/cli/claude_temp_launch.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::error::AppError;
 use crate::provider::Provider;
 use crate::services::provider::ProviderService;
-use serde_json::json;
+use serde_json::Value;
 
 #[derive(Debug, Clone)]
 pub(crate) struct PreparedClaudeLaunch {
@@ -28,6 +28,14 @@ pub(crate) fn prepare_launch(
     prepare_launch_with(provider, temp_dir, resolve_claude_binary)
 }
 
+pub(crate) fn prepare_launch_from_settings(
+    provider_id: &str,
+    settings: &Value,
+    temp_dir: &Path,
+) -> Result<PreparedClaudeLaunch, AppError> {
+    prepare_launch_from_settings_with(provider_id, settings, temp_dir, resolve_claude_binary)
+}
+
 pub(crate) fn prepare_launch_with<Resolve>(
     provider: &Provider,
     temp_dir: &Path,
@@ -36,19 +44,36 @@ pub(crate) fn prepare_launch_with<Resolve>(
 where
     Resolve: FnOnce() -> Result<PathBuf, AppError>,
 {
+    prepare_launch_from_settings_with(
+        &provider.id,
+        &provider.settings_config,
+        temp_dir,
+        resolve_claude_binary,
+    )
+}
+
+pub(crate) fn prepare_launch_from_settings_with<Resolve>(
+    provider_id: &str,
+    settings: &Value,
+    temp_dir: &Path,
+    resolve_claude_binary: Resolve,
+) -> Result<PreparedClaudeLaunch, AppError>
+where
+    Resolve: FnOnce() -> Result<PathBuf, AppError>,
+{
     let executable = resolve_claude_binary()?;
 
-    if provider.settings_config.get("env").and_then(|v| v.as_object()).is_none() {
+    if settings.get("env").and_then(|v| v.as_object()).is_none() {
         return Err(AppError::localized(
             "claude.temp_launch_missing_env",
-            format!("供应商 {} 缺少有效的 env 配置。", provider.id),
-            format!("Provider {} is missing a valid env object.", provider.id),
+            format!("供应商 {} 缺少有效的 env 配置。", provider_id),
+            format!("Provider {} is missing a valid env object.", provider_id),
         ));
     }
 
-    let mut settings = provider.settings_config.clone();
-    let _ = ProviderService::normalize_claude_models_in_value(&mut settings);
-    let settings_path = write_temp_settings_file(temp_dir, provider, &settings)?;
+    let mut normalized_settings = settings.clone();
+    let _ = ProviderService::normalize_claude_models_in_value(&mut normalized_settings);
+    let settings_path = write_temp_settings_file(temp_dir, provider_id, &normalized_settings)?;
 
     Ok(PreparedClaudeLaunch {
         executable,
@@ -127,15 +152,15 @@ pub(crate) fn exec_prepared_claude(
 
 fn write_temp_settings_file(
     temp_dir: &Path,
-    provider: &Provider,
+    provider_id: &str,
     settings: &serde_json::Value,
 ) -> Result<PathBuf, AppError> {
-    write_temp_settings_file_with(temp_dir, provider, settings, finalize_temp_settings_file)
+    write_temp_settings_file_with(temp_dir, provider_id, settings, finalize_temp_settings_file)
 }
 
 fn write_temp_settings_file_with<Finalize>(
     temp_dir: &Path,
-    provider: &Provider,
+    provider_id: &str,
     settings: &serde_json::Value,
     finalize: Finalize,
 ) -> Result<PathBuf, AppError>
@@ -148,7 +173,7 @@ where
         .as_nanos();
     let filename = format!(
         "cc-switch-claude-{}-{}-{timestamp}.json",
-        sanitize_filename_fragment(&provider.id),
+        sanitize_filename_fragment(provider_id),
         std::process::id()
     );
     let path = temp_dir.join(filename);
@@ -243,6 +268,7 @@ fn sanitize_filename_fragment(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app_config::AppType;
     use crate::provider::Provider;
     use serde_json::{json, Value};
     #[cfg(unix)]
@@ -379,7 +405,7 @@ mod tests {
 
         let err = write_temp_settings_file_with(
             temp_dir.path(),
-            &provider,
+            &provider.id,
             &json!({
                 "env": {
                     "ANTHROPIC_AUTH_TOKEN": "sk-demo"
@@ -568,9 +594,49 @@ mod tests {
         .expect("parse temp settings");
 
         assert_eq!(written["env"]["ANTHROPIC_AUTH_TOKEN"], "sk-full");
+        assert_eq!(written["permissions"]["allow"], json!(["Bash(git*)"]));
+    }
+
+    #[test]
+    fn prepare_launch_from_settings_writes_exact_effective_snapshot() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let provider = Provider::with_id(
+            "demo".to_string(),
+            "Demo".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "sk-demo",
+                    "ANTHROPIC_BASE_URL": "https://provider.example"
+                },
+                "permissions": {
+                    "allow": ["Bash(git status)"]
+                },
+                "includeCoAuthoredBy": true
+            }),
+            None,
+        );
+
+        let effective = ProviderService::build_effective_live_snapshot(
+            &AppType::Claude,
+            &provider,
+            Some(
+                r#"{"env":{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":1,"ANTHROPIC_BASE_URL":"https://common.example"},"permissions":{"allow":["Bash(ls)"]},"includeCoAuthoredBy":false}"#,
+            ),
+            true,
+        )
+        .expect("build effective snapshot");
+
+        let prepared = prepare_launch_from_settings(&provider.id, &effective, temp_dir.path())
+            .expect("prepare launch from effective settings");
+
+        let written: Value = serde_json::from_str(
+            &std::fs::read_to_string(&prepared.settings_path).expect("read temp settings"),
+        )
+        .expect("parse temp settings");
+
         assert_eq!(
-            written["permissions"]["allow"],
-            json!(["Bash(git*)"])
+            written, effective,
+            "temp launch settings should exactly match the canonical effective snapshot"
         );
     }
 }

--- a/src-tauri/src/cli/commands/start.rs
+++ b/src-tauri/src/cli/commands/start.rs
@@ -5,7 +5,8 @@ use indexmap::IndexMap;
 
 use crate::app_config::AppType;
 use crate::cli::claude_temp_launch::{
-    ensure_temp_launch_supported, exec_prepared_claude, prepare_launch, PreparedClaudeLaunch,
+    ensure_temp_launch_supported, exec_prepared_claude, prepare_launch_from_settings,
+    PreparedClaudeLaunch,
 };
 use crate::cli::codex_temp_launch::{
     ensure_temp_launch_supported as ensure_codex_temp_launch_supported, exec_prepared_codex,
@@ -68,19 +69,13 @@ fn get_state() -> Result<AppState, AppError> {
 
 fn start_claude(selector: &str, native_args: &[OsString]) -> Result<(), AppError> {
     reject_reserved_native_args(native_args, "Claude", CLAUDE_RESERVED_NATIVE_ARGS)?;
-    start_with(
-        selector,
-        "Claude",
-        || {
-            let state = get_state()?;
-            ProviderService::list(&state, AppType::Claude)
-        },
-        |provider| {
-            ensure_temp_launch_supported()?;
-            let prepared = prepare_launch(provider, &std::env::temp_dir())?;
-            handoff_claude_and_cleanup(&prepared, native_args)
-        },
-    )
+    let state = get_state()?;
+    let providers = ProviderService::list(&state, AppType::Claude)?;
+    let provider = resolve_provider_selector(&providers, selector, "Claude")?;
+
+    ensure_temp_launch_supported()?;
+    let prepared = prepare_claude_launch_with(&state, &provider, &std::env::temp_dir())?;
+    handoff_claude_and_cleanup(&prepared, native_args)
 }
 
 fn start_codex(selector: &str, native_args: &[OsString]) -> Result<(), AppError> {
@@ -146,6 +141,19 @@ where
     let providers = load_providers()?;
     let provider = resolve_provider_selector(&providers, selector, app_name)?;
     launch_provider(&provider)
+}
+
+fn prepare_claude_launch_with(
+    state: &AppState,
+    provider: &Provider,
+    temp_dir: &std::path::Path,
+) -> Result<PreparedClaudeLaunch, AppError> {
+    let settings = ProviderService::build_effective_live_snapshot_from_state(
+        state,
+        AppType::Claude,
+        provider,
+    )?;
+    prepare_launch_from_settings(&provider.id, &settings, temp_dir)
 }
 
 fn handoff_claude_and_cleanup(
@@ -254,6 +262,7 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::ffi::OsString;
+    use tempfile::TempDir;
 
     fn provider(id: &str, name: &str) -> Provider {
         Provider::with_id(
@@ -266,6 +275,17 @@ mod tests {
             }),
             None,
         )
+    }
+
+    fn state_from_config(config: crate::app_config::MultiAppConfig) -> AppState {
+        let db = std::sync::Arc::new(crate::Database::memory().expect("create memory database"));
+        db.migrate_from_json(&config)
+            .expect("seed memory database from config");
+        AppState {
+            db: db.clone(),
+            config: std::sync::RwLock::new(config),
+            proxy_service: crate::ProxyService::new(db),
+        }
     }
 
     #[test]
@@ -373,6 +393,51 @@ mod tests {
         .expect("start command should launch matching provider");
 
         assert_eq!(launched.into_inner().as_deref(), Some("demo"));
+    }
+
+    #[test]
+    fn prepare_claude_launch_with_writes_effective_snapshot_from_state() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let mut config = crate::app_config::MultiAppConfig::default();
+        config.ensure_app(&AppType::Claude);
+        config.common_config_snippets.claude = Some(
+            r#"{"env":{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":1,"ANTHROPIC_BASE_URL":"https://common.example"},"includeCoAuthoredBy":false,"permissions":{"allow":["Bash(ls)"]}}"#
+                .to_string(),
+        );
+        let state = state_from_config(config);
+        let provider = Provider::with_id(
+            "demo".to_string(),
+            "Claude Demo".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "sk-demo",
+                    "ANTHROPIC_BASE_URL": "https://provider.example"
+                },
+                "includeCoAuthoredBy": true,
+                "permissions": {
+                    "allow": ["Bash(git status)"]
+                }
+            }),
+            None,
+        );
+
+        let prepared =
+            prepare_claude_launch_with(&state, &provider, temp_dir.path()).expect("prepare launch");
+        let written: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(&prepared.settings_path).expect("read temp settings"),
+        )
+        .expect("parse temp settings");
+        let expected = ProviderService::build_effective_live_snapshot_from_state(
+            &state,
+            AppType::Claude,
+            &provider,
+        )
+        .expect("build effective snapshot");
+
+        assert_eq!(
+            written, expected,
+            "CLI temp launch should write the canonical effective snapshot"
+        );
     }
 
     #[test]

--- a/src-tauri/src/cli/tui/runtime_actions/claude_temp_launch.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/claude_temp_launch.rs
@@ -3,11 +3,13 @@ use std::path::Path;
 
 use crate::app_config::AppType;
 use crate::cli::claude_temp_launch::{
-    ensure_temp_launch_supported, exec_prepared_claude, prepare_launch, PreparedClaudeLaunch,
+    ensure_temp_launch_supported, exec_prepared_claude, prepare_launch_from_settings,
+    PreparedClaudeLaunch,
 };
 use crate::cli::i18n::texts;
+use crate::cli::tui::data::load_state;
 use crate::error::AppError;
-use crate::provider::Provider;
+use crate::services::ProviderService;
 
 use super::super::app::ToastKind;
 use super::super::terminal::TuiTerminal;
@@ -19,9 +21,20 @@ pub(super) fn launch(ctx: &mut RuntimeActionContext<'_>, id: String) -> Result<(
         id,
         &std::env::temp_dir(),
         ensure_temp_launch_supported,
-        prepare_launch,
+        prepare_claude_launch,
         handoff_to_claude,
     )
+}
+
+fn prepare_claude_launch(id: &str, temp_dir: &Path) -> Result<PreparedClaudeLaunch, AppError> {
+    let state = load_state()?;
+    let provider = ProviderService::get_provider(&state, AppType::Claude, id)?;
+    let settings = ProviderService::build_effective_live_snapshot_from_state(
+        &state,
+        AppType::Claude,
+        &provider,
+    )?;
+    prepare_launch_from_settings(&provider.id, &settings, temp_dir)
 }
 
 fn launch_with<Support, Prepare, Handoff>(
@@ -34,7 +47,7 @@ fn launch_with<Support, Prepare, Handoff>(
 ) -> Result<(), AppError>
 where
     Support: FnOnce() -> Result<(), AppError>,
-    Prepare: FnOnce(&Provider, &Path) -> Result<PreparedClaudeLaunch, AppError>,
+    Prepare: FnOnce(&str, &Path) -> Result<PreparedClaudeLaunch, AppError>,
     Handoff: FnOnce(&mut TuiTerminal, &PreparedClaudeLaunch) -> Result<(), AppError>,
 {
     if !matches!(ctx.app.app_type, AppType::Claude) {
@@ -68,26 +81,12 @@ fn try_launch_with<Support, Prepare, Handoff>(
 ) -> Result<(), AppError>
 where
     Support: FnOnce() -> Result<(), AppError>,
-    Prepare: FnOnce(&Provider, &Path) -> Result<PreparedClaudeLaunch, AppError>,
+    Prepare: FnOnce(&str, &Path) -> Result<PreparedClaudeLaunch, AppError>,
     Handoff: FnOnce(&mut TuiTerminal, &PreparedClaudeLaunch) -> Result<(), AppError>,
 {
     ensure_supported()?;
 
-    let provider = ctx
-        .data
-        .providers
-        .rows
-        .iter()
-        .find(|row| row.id == id)
-        .map(|row| row.provider.clone())
-        .ok_or_else(|| {
-            AppError::localized(
-                "claude.temp_launch_provider_not_found",
-                format!("未找到选中的供应商: {id}"),
-                format!("Selected provider not found: {id}"),
-            )
-        })?;
-    let prepared = prepare(&provider, temp_dir)?;
+    let prepared = prepare(id, temp_dir)?;
     let handoff_result = handoff(ctx.terminal, &prepared);
     let cleanup_result = prepared.cleanup_settings_file();
 
@@ -114,8 +113,14 @@ mod tests {
     use crate::cli::tui::data::{ProviderRow, ProvidersSnapshot, UiData};
     use crate::cli::tui::runtime_systems::RequestTracker;
     use crate::provider::Provider;
+    use crate::test_support::{
+        lock_test_home_and_settings, set_test_home_override, TestHomeSettingsLock,
+    };
     use serde_json::{json, Value};
+    use serial_test::serial;
     use std::cell::Cell;
+    use std::ffi::OsString;
+    use std::path::Path;
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -166,6 +171,44 @@ mod tests {
         }
     }
 
+    struct EnvGuard {
+        _lock: TestHomeSettingsLock,
+        old_home: Option<OsString>,
+        old_userprofile: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set_home(home: &Path) -> Self {
+            let lock = lock_test_home_and_settings();
+            let old_home = std::env::var_os("HOME");
+            let old_userprofile = std::env::var_os("USERPROFILE");
+            std::env::set_var("HOME", home);
+            std::env::set_var("USERPROFILE", home);
+            set_test_home_override(Some(home));
+            crate::settings::reload_test_settings();
+            Self {
+                _lock: lock,
+                old_home,
+                old_userprofile,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.old_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match &self.old_userprofile {
+                Some(value) => std::env::set_var("USERPROFILE", value),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+            set_test_home_override(self.old_home.as_deref().map(Path::new));
+            crate::settings::reload_test_settings();
+        }
+    }
+
     fn provider_row(id: &str, env: Value) -> ProviderRow {
         ProviderRow {
             id: id.to_string(),
@@ -213,8 +256,18 @@ mod tests {
             "candidate".to_string(),
             temp_dir.path(),
             ensure_temp_launch_supported,
-            |provider, temp_dir| {
-                prepare_launch_with(provider, temp_dir, || Ok(PathBuf::from("/usr/bin/claude")))
+            |id, temp_dir| {
+                let provider = Provider::with_id(
+                    id.to_string(),
+                    format!("Provider {id}"),
+                    json!({
+                        "env": {
+                            "ANTHROPIC_AUTH_TOKEN": format!("sk-{id}")
+                        }
+                    }),
+                    None,
+                );
+                prepare_launch_with(&provider, temp_dir, || Ok(PathBuf::from("/usr/bin/claude")))
             },
             |_, prepared| {
                 captured_settings_path.replace(Some(prepared.settings_path.clone()));
@@ -263,8 +316,18 @@ mod tests {
             "candidate".to_string(),
             temp_dir.path(),
             ensure_temp_launch_supported,
-            |provider, temp_dir| {
-                prepare_launch_with(provider, temp_dir, || Ok(PathBuf::from("/usr/bin/claude")))
+            |id, temp_dir| {
+                let provider = Provider::with_id(
+                    id.to_string(),
+                    format!("Provider {id}"),
+                    json!({
+                        "env": {
+                            "ANTHROPIC_AUTH_TOKEN": format!("sk-{id}")
+                        }
+                    }),
+                    None,
+                );
+                prepare_launch_with(&provider, temp_dir, || Ok(PathBuf::from("/usr/bin/claude")))
             },
             |_, _| {
                 handoff_called.set(true);
@@ -310,9 +373,19 @@ mod tests {
                         .to_string(),
                 ))
             },
-            |provider, temp_dir| {
+            |id, temp_dir| {
                 prepare_called.set(true);
-                prepare_launch_with(provider, temp_dir, || Ok(PathBuf::from("/usr/bin/claude")))
+                let provider = Provider::with_id(
+                    id.to_string(),
+                    format!("Provider {id}"),
+                    json!({
+                        "env": {
+                            "ANTHROPIC_AUTH_TOKEN": format!("sk-{id}")
+                        }
+                    }),
+                    None,
+                );
+                prepare_launch_with(&provider, temp_dir, || Ok(PathBuf::from("/usr/bin/claude")))
             },
             |_, _| Ok(()),
         )
@@ -332,6 +405,87 @@ mod tests {
                 .next()
                 .is_none(),
             "unsupported platforms should not create a temp settings file"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn launch_uses_effective_snapshot_from_realtime_state() {
+        let temp_home = TempDir::new().expect("create temp home");
+        let _env = EnvGuard::set_home(temp_home.path());
+        std::fs::create_dir_all(crate::config::get_claude_config_dir())
+            .expect("create ~/.claude (initialized)");
+
+        let state = crate::store::AppState::try_new().expect("create state");
+        ProviderService::set_common_config_snippet(
+            &state,
+            AppType::Claude,
+            Some(
+                r#"{"env":{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":1},"includeCoAuthoredBy":false}"#
+                    .to_string(),
+            ),
+        )
+        .expect("set common config snippet");
+
+        let provider = Provider::with_id(
+            "candidate".to_string(),
+            "Candidate".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "sk-state",
+                    "ANTHROPIC_BASE_URL": "https://state.example"
+                },
+                "permissions": {
+                    "allow": ["Bash(git status)"]
+                }
+            }),
+            None,
+        );
+        ProviderService::add(&state, AppType::Claude, provider.clone()).expect("add provider");
+
+        let expected = ProviderService::build_effective_live_snapshot_from_state(
+            &state,
+            AppType::Claude,
+            &provider,
+        )
+        .expect("build effective snapshot");
+
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let mut fixture = LaunchFixture::new(
+            AppType::Claude,
+            "candidate",
+            vec![provider_row(
+                "candidate",
+                json!({
+                    "ANTHROPIC_AUTH_TOKEN": "sk-stale"
+                }),
+            )],
+        );
+        let captured_settings = std::cell::RefCell::new(None::<Value>);
+
+        launch_with(
+            &mut fixture.ctx(),
+            "candidate".to_string(),
+            temp_dir.path(),
+            ensure_temp_launch_supported,
+            prepare_claude_launch,
+            |_, prepared| {
+                let written: Value = serde_json::from_str(
+                    &std::fs::read_to_string(&prepared.settings_path).expect("read temp settings"),
+                )
+                .expect("parse temp settings");
+                captured_settings.replace(Some(written));
+                Err(AppError::Message("launch exploded".to_string()))
+            },
+        )
+        .expect("launch failure should stay in the TUI");
+
+        assert_eq!(
+            captured_settings
+                .into_inner()
+                .expect("capture written settings"),
+            expected,
+            "TUI temp launch should use the realtime state's effective snapshot"
         );
     }
 }

--- a/src-tauri/src/services/provider/claude.rs
+++ b/src-tauri/src/services/provider/claude.rs
@@ -28,7 +28,7 @@ impl ProviderService {
     }
 
     /// 归一化 Claude 模型键：读旧键(ANTHROPIC_SMALL_FAST_MODEL)，写新键(DEFAULT_*), 并删除旧键
-    pub(super) fn normalize_claude_models_in_value(settings: &mut Value) -> bool {
+    pub(crate) fn normalize_claude_models_in_value(settings: &mut Value) -> bool {
         let mut changed = false;
         let env = match settings.get_mut("env") {
             Some(v) if v.is_object() => v.as_object_mut().unwrap(),

--- a/src-tauri/src/services/provider/claude.rs
+++ b/src-tauri/src/services/provider/claude.rs
@@ -226,29 +226,19 @@ impl ProviderService {
     pub(super) fn write_claude_live(
         provider: &Provider,
         common_config_snippet: Option<&str>,
+        apply_common_config: bool,
     ) -> Result<(), AppError> {
         if !crate::sync_policy::should_sync_live(&AppType::Claude) {
             return Ok(());
         }
 
         let settings_path = get_claude_settings_path();
-        let mut provider_content = provider.settings_config.clone();
-        let _ = Self::normalize_claude_models_in_value(&mut provider_content);
-
-        let content_to_write = if let Some(snippet) = common_config_snippet {
-            let snippet = snippet.trim();
-            if snippet.is_empty() {
-                provider_content
-            } else {
-                let common = Self::parse_common_claude_config_snippet(snippet)?;
-                let mut merged = common;
-                merge_json_values(&mut merged, &provider_content);
-                let _ = Self::normalize_claude_models_in_value(&mut merged);
-                merged
-            }
-        } else {
-            provider_content
-        };
+        let content_to_write = Self::build_effective_live_snapshot(
+            &AppType::Claude,
+            provider,
+            common_config_snippet,
+            apply_common_config,
+        )?;
 
         write_json_file(&settings_path, &content_to_write)?;
         Ok(())

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -1638,14 +1638,9 @@ impl ProviderService {
             AppType::Codex => {
                 Self::write_codex_live(provider, common_config_snippet, apply_common_config)
             }
-            AppType::Claude => Self::write_claude_live(
-                provider,
-                if apply_common_config {
-                    common_config_snippet
-                } else {
-                    None
-                },
-            ),
+            AppType::Claude => {
+                Self::write_claude_live(provider, common_config_snippet, apply_common_config)
+            }
             AppType::Gemini => Self::write_gemini_live(
                 provider,
                 if apply_common_config {
@@ -1782,7 +1777,7 @@ impl ProviderService {
         }
     }
 
-    pub(crate) fn build_live_backup_snapshot(
+    pub(crate) fn build_effective_live_snapshot(
         app_type: &AppType,
         provider: &Provider,
         common_config_snippet: Option<&str>,
@@ -2024,6 +2019,57 @@ impl ProviderService {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn build_live_backup_snapshot(
+        app_type: &AppType,
+        provider: &Provider,
+        common_config_snippet: Option<&str>,
+        apply_common_config: bool,
+    ) -> Result<Value, AppError> {
+        Self::build_effective_live_snapshot(
+            app_type,
+            provider,
+            common_config_snippet,
+            apply_common_config,
+        )
+    }
+
+    pub(crate) fn build_effective_live_snapshot_from_state(
+        state: &AppState,
+        app_type: AppType,
+        provider: &Provider,
+    ) -> Result<Value, AppError> {
+        let common_config_snippet = {
+            let config = state.config.read().map_err(AppError::from)?;
+            config.common_config_snippets.get(&app_type).cloned()
+        };
+
+        Self::build_effective_live_snapshot(
+            &app_type,
+            provider,
+            common_config_snippet.as_deref(),
+            true,
+        )
+    }
+
+    pub(crate) fn get_provider(
+        state: &AppState,
+        app_type: AppType,
+        provider_id: &str,
+    ) -> Result<Provider, AppError> {
+        let config = state.config.read().map_err(AppError::from)?;
+        let manager = config
+            .get_manager(&app_type)
+            .ok_or_else(|| Self::app_not_found(&app_type))?;
+
+        manager.providers.get(provider_id).cloned().ok_or_else(|| {
+            AppError::localized(
+                "provider.not_found",
+                format!("供应商不存在: {provider_id}"),
+                format!("Provider not found: {provider_id}"),
+            )
+        })
     }
 
     fn app_not_found(app_type: &AppType) -> AppError {

--- a/src-tauri/src/services/provider/tests.rs
+++ b/src-tauri/src/services/provider/tests.rs
@@ -1252,6 +1252,106 @@ fn common_config_snippet_is_merged_into_claude_settings_on_write() {
 }
 
 #[test]
+fn build_effective_live_snapshot_merges_claude_common_config_with_provider_precedence() {
+    let provider = Provider::with_id(
+        "p1".to_string(),
+        "First".to_string(),
+        json!({
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": "token",
+                "ANTHROPIC_BASE_URL": "https://provider.example"
+            },
+            "includeCoAuthoredBy": true,
+            "permissions": {
+                "allow": ["Bash(git status)"]
+            }
+        }),
+        None,
+    );
+
+    let effective = ProviderService::build_effective_live_snapshot(
+        &AppType::Claude,
+        &provider,
+        Some(
+            r#"{"env":{"ANTHROPIC_BASE_URL":"https://common.example","CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":1},"includeCoAuthoredBy":false,"permissions":{"allow":["Bash(ls)"]}}"#,
+        ),
+        true,
+    )
+    .expect("build effective snapshot");
+
+    assert_eq!(
+        effective["env"]["ANTHROPIC_AUTH_TOKEN"],
+        json!("token"),
+        "provider auth token should be preserved"
+    );
+    assert_eq!(
+        effective["env"]["ANTHROPIC_BASE_URL"],
+        json!("https://provider.example"),
+        "provider env should override common config"
+    );
+    assert_eq!(
+        effective["env"]["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"],
+        json!(1),
+        "common env values should still be merged"
+    );
+    assert_eq!(
+        effective["includeCoAuthoredBy"],
+        json!(true),
+        "provider top-level settings should override common config"
+    );
+    assert_eq!(
+        effective["permissions"]["allow"],
+        json!(["Bash(git status)"]),
+        "provider top-level objects should override common config"
+    );
+}
+
+#[test]
+fn build_effective_live_snapshot_skips_claude_common_config_when_disabled() {
+    let mut provider = Provider::with_id(
+        "p1".to_string(),
+        "First".to_string(),
+        json!({
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": "token",
+                "ANTHROPIC_BASE_URL": "https://provider.example"
+            }
+        }),
+        None,
+    );
+    provider.meta = Some(crate::provider::ProviderMeta {
+        apply_common_config: Some(false),
+        ..Default::default()
+    });
+
+    let effective = ProviderService::build_effective_live_snapshot(
+        &AppType::Claude,
+        &provider,
+        Some(
+            r#"{"env":{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":1},"includeCoAuthoredBy":false}"#,
+        ),
+        true,
+    )
+    .expect("build effective snapshot");
+
+    assert!(
+        effective.get("includeCoAuthoredBy").is_none(),
+        "common top-level settings should be skipped when disabled"
+    );
+    assert!(
+        effective["env"]
+            .get("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC")
+            .is_none(),
+        "common env settings should be skipped when disabled"
+    );
+    assert_eq!(
+        effective["env"]["ANTHROPIC_BASE_URL"],
+        json!("https://provider.example"),
+        "provider settings should remain untouched"
+    );
+}
+
+#[test]
 #[serial]
 fn common_config_snippet_can_be_disabled_per_provider_for_claude() {
     let temp_home = TempDir::new().expect("create temp home");


### PR DESCRIPTION
The `start claude` command only extracted the `env` sub-object from `settings_config` when building the temporary settings file. This meant model overrides (e.g. `ANTHROPIC_DEFAULT_SONNET_MODEL`) and other top-level fields were missing from the temp file, causing stale model names from the global `~/.claude/settings.json` to bleed through when Claude CLI merged `--settings` with its default config.

Now `prepare_launch_with` writes the full `settings_config` (cloned and model-normalized via `normalize_claude_models_in_value`), matching the behavior of the `provider switch` path.