### PR TITLE
build: add Nix flake packaging for cc-switch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "Nix packaging for cc-switch-cli";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      cargoManifest = builtins.fromTOML (builtins.readFile ./src-tauri/Cargo.toml);
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs systems (system:
+          f system (import nixpkgs { inherit system; }));
+    in
+    {
+      packages = forAllSystems (system: pkgs:
+        let
+          cc_switch_cli = pkgs.rustPlatform.buildRustPackage {
+            pname = cargoManifest.package.name;
+            version = cargoManifest.package.version;
+
+            src = pkgs.lib.cleanSource ./.;
+
+            cargoRoot = "src-tauri";
+            buildAndTestSubdir = "src-tauri";
+            cargoLock = {
+              lockFile = ./src-tauri/Cargo.lock;
+            };
+
+            # The upstream repository owns the Rust test suite. The flake package is
+            # intended to build and install the CLI on NixOS without depending on
+            # host-specific assistant CLIs or live config fixtures during checkPhase.
+            doCheck = false;
+
+            meta = with pkgs.lib; {
+              description = "CLI manager for Claude Code, Codex, Gemini, OpenCode, and OpenClaw";
+              homepage = "https://github.com/saladday/cc-switch-cli";
+              license = licenses.mit;
+              mainProgram = "cc-switch";
+              platforms = platforms.unix;
+            };
+          };
+        in
+        {
+          cc-switch = cc_switch_cli;
+          cc-switch-cli = cc_switch_cli;
+          default = cc_switch_cli;
+        });
+    };
+}


### PR DESCRIPTION
## Summary

- Add Nix flake packaging for the Rust CLI under `src-tauri/`.
- Expose `cc-switch`, `cc-switch-cli`, and `default` package outputs.
- Set `meta.mainProgram = "cc-switch"` so `nix run` uses the installed binary.
- Disable the Nix package `checkPhase`; the repository test suite remains covered by the normal cargo/CI workflows, while the flake focuses on building and installing the CLI on NixOS without host-specific assistant CLI fixtures.

## Validation

- `nix build .#cc-switch --no-link`
- `nix run .#cc-switch -- --version` -> `cc-switch 5.4.0`
- `nix eval .#packages.x86_64-linux.cc-switch.meta.mainProgram --raw` -> `cc-switch`