### PR TITLE
Fix broken internal documentation links

### DIFF
--- a/docs/CODEX_MCP_RAW_TOML_PLAN.md
+++ b/docs/CODEX_MCP_RAW_TOML_PLAN.md
@@ -1285,7 +1285,7 @@ pnpm add @codemirror/lang-toml
 - [Codex 官方 MCP 文档](https://codex.dev/docs/mcp)
 - [TOML 规范](https://toml.io/en/)
 - [CodeMirror 6 文档](https://codemirror.net/docs/)
-- [项目 CLAUDE.md](../CLAUDE.md)
+- [项目 README](../README_ZH.md)
 
 ---
 

--- a/docs/release-note-v3.6.0-zh.md
+++ b/docs/release-note-v3.6.0-zh.md
@@ -2,7 +2,7 @@
 
 > 全栈架构重构，增强配置同步与数据保护
 
-**[English Version →](../release-note-v3.6.0.md)**
+**[English Version →](./release-note-v3.6.0-en.md)**
 
 ---
 

--- a/docs/release-note-v3.6.1-zh.md
+++ b/docs/release-note-v3.6.1-zh.md
@@ -2,7 +2,7 @@
 
 > 稳定性提升与用户体验优化（基于 v3.6.0）
 
-**[English Version →](../release-note-v3.6.1.md)**
+**[English Version →](./release-note-v3.6.1-en.md)**
 
 ---
 

--- a/docs/v3.7.0-unified-mcp-refactor.md
+++ b/docs/v3.7.0-unified-mcp-refactor.md
@@ -749,8 +749,7 @@ Data Layer (Config + Live Sync)
 ### 内部文档
 
 - [项目 README](../README.md)
-- [CLAUDE.md](../CLAUDE.md) - Claude Code 工作指南
-- [架构文档](../CLAUDE.md#架构概述)
+- [中文 README](../README_ZH.md) - 项目工作指南与架构说明
 
 ### 相关 Issues/PRs
 


### PR DESCRIPTION
## Summary
- point Chinese release note language links to the existing English files in docs
- replace stale CLAUDE.md references with existing README documentation

## Verification
- checked all local Markdown links
- git diff --check