### PR TITLE
feat: add Hermes app support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
             doCheck = false;
 
             meta = with pkgs.lib; {
-              description = "CLI manager for Claude Code, Codex, Gemini, OpenCode, and OpenClaw";
+              description = "CLI manager for Claude Code, Codex, Gemini, OpenCode, OpenClaw, and Hermes";
               homepage = "https://github.com/saladday/cc-switch-cli";
               license = licenses.mit;
               mainProgram = "cc-switch";

--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -28,6 +28,7 @@ impl McpApps {
             AppType::Gemini => self.gemini,
             AppType::OpenCode => self.opencode,
             AppType::OpenClaw => false,
+            AppType::Hermes => self.hermes,
         }
     }
 
@@ -39,6 +40,7 @@ impl McpApps {
             AppType::Gemini => self.gemini = enabled,
             AppType::OpenCode => self.opencode = enabled,
             AppType::OpenClaw => {}
+            AppType::Hermes => self.hermes = enabled,
         }
     }
 
@@ -56,6 +58,9 @@ impl McpApps {
         }
         if self.opencode {
             apps.push(AppType::OpenCode);
+        }
+        if self.hermes {
+            apps.push(AppType::Hermes);
         }
         apps
     }
@@ -77,6 +82,8 @@ pub struct SkillApps {
     pub gemini: bool,
     #[serde(default)]
     pub opencode: bool,
+    #[serde(default)]
+    pub hermes: bool,
 }
 
 impl SkillApps {
@@ -87,6 +94,7 @@ impl SkillApps {
             AppType::Gemini => self.gemini,
             AppType::OpenCode => self.opencode,
             AppType::OpenClaw => false,
+            AppType::Hermes => self.hermes,
         }
     }
 
@@ -97,11 +105,12 @@ impl SkillApps {
             AppType::Gemini => self.gemini = enabled,
             AppType::OpenCode => self.opencode = enabled,
             AppType::OpenClaw => {}
+            AppType::Hermes => self.hermes = enabled,
         }
     }
 
     pub fn is_empty(&self) -> bool {
-        !self.claude && !self.codex && !self.gemini && !self.opencode
+        !self.claude && !self.codex && !self.gemini && !self.opencode && !self.hermes
     }
 
     pub fn only(app: &AppType) -> Self {
@@ -125,6 +134,7 @@ impl SkillApps {
         self.codex |= other.codex;
         self.gemini |= other.gemini;
         self.opencode |= other.opencode;
+        self.hermes |= other.hermes;
     }
 }
 
@@ -224,6 +234,8 @@ pub struct McpRoot {
     pub opencode: McpConfig,
     #[serde(default, skip_serializing_if = "McpConfig::is_empty")]
     pub openclaw: McpConfig,
+    #[serde(default, skip_serializing_if = "McpConfig::is_empty")]
+    pub hermes: McpConfig,
 }
 
 impl Default for McpRoot {
@@ -237,6 +249,7 @@ impl Default for McpRoot {
             gemini: McpConfig::default(),
             opencode: McpConfig::default(),
             openclaw: McpConfig::default(),
+            hermes: McpConfig::default(),
         }
     }
 }
@@ -261,6 +274,8 @@ pub struct PromptRoot {
     pub opencode: PromptConfig,
     #[serde(default)]
     pub openclaw: PromptConfig,
+    #[serde(default)]
+    pub hermes: PromptConfig,
 }
 
 use crate::config::{copy_file, get_app_config_dir, get_app_config_path, write_json_file};
@@ -276,6 +291,7 @@ pub enum AppType {
     Gemini,
     OpenCode,
     OpenClaw,
+    Hermes,
 }
 
 impl AppType {
@@ -286,11 +302,15 @@ impl AppType {
             AppType::Gemini => "gemini",
             AppType::OpenCode => "opencode",
             AppType::OpenClaw => "openclaw",
+            AppType::Hermes => "hermes",
         }
     }
 
     pub fn is_additive_mode(&self) -> bool {
-        matches!(self, AppType::OpenCode | AppType::OpenClaw)
+        matches!(
+            self,
+            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes
+        )
     }
 
     pub fn supports_failover(&self) -> bool {
@@ -304,6 +324,7 @@ impl AppType {
             AppType::Gemini,
             AppType::OpenCode,
             AppType::OpenClaw,
+            AppType::Hermes,
         ]
         .into_iter()
     }
@@ -326,13 +347,14 @@ impl FromStr for AppType {
             "gemini" => Ok(AppType::Gemini),
             "opencode" => Ok(AppType::OpenCode),
             "openclaw" => Ok(AppType::OpenClaw),
+            "hermes" => Ok(AppType::Hermes),
             other => Err(AppError::localized(
                 "unsupported_app",
                 format!(
-                    "不支持的应用标识: '{other}'。可选值: claude, codex, gemini, opencode, openclaw。"
+                    "不支持的应用标识: '{other}'。可选值: claude, codex, gemini, opencode, openclaw, hermes。"
                 ),
                 format!(
-                    "Unsupported app id: '{other}'. Allowed: claude, codex, gemini, opencode, openclaw."
+                    "Unsupported app id: '{other}'. Allowed: claude, codex, gemini, opencode, openclaw, hermes."
                 ),
             )),
         }
@@ -356,6 +378,9 @@ pub struct CommonConfigSnippets {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub openclaw: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hermes: Option<String>,
 }
 
 impl CommonConfigSnippets {
@@ -367,6 +392,7 @@ impl CommonConfigSnippets {
             AppType::Gemini => self.gemini.as_ref(),
             AppType::OpenCode => self.opencode.as_ref(),
             AppType::OpenClaw => self.openclaw.as_ref(),
+            AppType::Hermes => self.hermes.as_ref(),
         }
     }
 
@@ -378,6 +404,7 @@ impl CommonConfigSnippets {
             AppType::Gemini => self.gemini = snippet,
             AppType::OpenCode => self.opencode = snippet,
             AppType::OpenClaw => self.openclaw = snippet,
+            AppType::Hermes => self.hermes = snippet,
         }
     }
 }
@@ -419,6 +446,7 @@ impl Default for MultiAppConfig {
         apps.insert("gemini".to_string(), ProviderManager::default());
         apps.insert("opencode".to_string(), ProviderManager::default());
         apps.insert("openclaw".to_string(), ProviderManager::default());
+        apps.insert("hermes".to_string(), ProviderManager::default());
 
         Self {
             version: 2,
@@ -519,6 +547,13 @@ impl MultiAppConfig {
             updated = true;
         }
 
+        if !config.apps.contains_key("hermes") {
+            config
+                .apps
+                .insert("hermes".to_string(), ProviderManager::default());
+            updated = true;
+        }
+
         // 执行 MCP 迁移（v3.6.x → v3.7.0）
         let migrated = config.migrate_mcp_to_unified()?;
         if migrated {
@@ -584,6 +619,7 @@ impl MultiAppConfig {
             AppType::Gemini => &self.mcp.gemini,
             AppType::OpenCode => &self.mcp.opencode,
             AppType::OpenClaw => &self.mcp.openclaw,
+            AppType::Hermes => &self.mcp.hermes,
         }
     }
 
@@ -595,6 +631,7 @@ impl MultiAppConfig {
             AppType::Gemini => &mut self.mcp.gemini,
             AppType::OpenCode => &mut self.mcp.opencode,
             AppType::OpenClaw => &mut self.mcp.openclaw,
+            AppType::Hermes => &mut self.mcp.hermes,
         }
     }
 
@@ -623,6 +660,7 @@ impl MultiAppConfig {
             AppType::Codex,
             AppType::Gemini,
             AppType::OpenCode,
+            AppType::Hermes,
         ] {
             let old_servers = match app {
                 AppType::Claude => &self.mcp.claude.servers,
@@ -630,6 +668,7 @@ impl MultiAppConfig {
                 AppType::Gemini => &self.mcp.gemini.servers,
                 AppType::OpenCode => &self.mcp.opencode.servers,
                 AppType::OpenClaw => continue,
+                AppType::Hermes => &self.mcp.hermes.servers,
             };
 
             for (id, entry) in old_servers {
@@ -733,6 +772,7 @@ impl MultiAppConfig {
         self.mcp.codex = McpConfig::default();
         self.mcp.gemini = McpConfig::default();
         self.mcp.opencode = McpConfig::default();
+        self.mcp.hermes = McpConfig::default();
 
         Ok(true)
     }

--- a/src-tauri/src/cli/commands/config_common.rs
+++ b/src-tauri/src/cli/commands/config_common.rs
@@ -180,7 +180,11 @@ fn canonical_common_snippet(app_type: AppType, raw: &str) -> Result<Option<Strin
     }
 
     match app_type {
-        AppType::Claude | AppType::Gemini | AppType::OpenCode | AppType::OpenClaw => {
+        AppType::Claude
+        | AppType::Gemini
+        | AppType::OpenCode
+        | AppType::OpenClaw
+        | AppType::Hermes => {
             let value: serde_json::Value = serde_json::from_str(trimmed).map_err(|e| {
                 AppError::InvalidInput(texts::tui_toast_invalid_json(&e.to_string()))
             })?;

--- a/src-tauri/src/cli/commands/env.rs
+++ b/src-tauri/src/cli/commands/env.rs
@@ -11,7 +11,7 @@ pub enum EnvCommand {
     Check,
     /// List all relevant environment variables
     List,
-    /// Check whether Claude/Codex/Gemini/OpenCode CLIs are installed locally
+    /// Check whether supported app CLIs are installed locally
     Tools,
 }
 

--- a/src-tauri/src/cli/commands/failover.rs
+++ b/src-tauri/src/cli/commands/failover.rs
@@ -409,7 +409,7 @@ fn takeover_enabled_for(takeovers: &ProxyTakeoverStatus, app_type: &AppType) -> 
         AppType::Claude => takeovers.claude,
         AppType::Codex => takeovers.codex,
         AppType::Gemini => takeovers.gemini,
-        AppType::OpenCode | AppType::OpenClaw => false,
+        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => false,
     }
 }
 

--- a/src-tauri/src/cli/commands/mcp.rs
+++ b/src-tauri/src/cli/commands/mcp.rs
@@ -266,6 +266,7 @@ fn import_servers(app_type: AppType) -> Result<(), AppError> {
         AppType::Gemini => McpService::import_from_gemini(&state)?,
         AppType::OpenCode => 0,
         AppType::OpenClaw => 0,
+        AppType::Hermes => 0,
     };
 
     if count > 0 {

--- a/src-tauri/src/cli/commands/provider_input.rs
+++ b/src-tauri/src/cli/commands/provider_input.rs
@@ -44,7 +44,7 @@ pub fn common_snippet_has_effective_config(
             .ok()
             .and_then(|value| value.as_object().cloned())
             .is_some_and(|obj| !obj.is_empty()),
-        AppType::OpenCode | AppType::OpenClaw => false,
+        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => false,
     }
 }
 
@@ -170,6 +170,7 @@ pub fn prompt_settings_config_for_add(
         (AppType::Gemini, _) => prompt_gemini_config(None),
         (AppType::OpenCode, _) => Ok(json!({})),
         (AppType::OpenClaw, _) => Ok(json!({})),
+        (AppType::Hermes, _) => prompt_hermes_config(None),
     }
 }
 
@@ -406,6 +407,7 @@ pub fn prompt_settings_config(
         AppType::Gemini => prompt_gemini_config(current),
         AppType::OpenCode => Ok(current.cloned().unwrap_or_else(|| json!({}))),
         AppType::OpenClaw => Ok(current.cloned().unwrap_or_else(|| json!({}))),
+        AppType::Hermes => prompt_hermes_config(current),
     }
 }
 
@@ -759,6 +761,65 @@ fn prompt_gemini_config(current: Option<&Value>) -> Result<Value, AppError> {
     }
 }
 
+fn prompt_hermes_config(current: Option<&Value>) -> Result<Value, AppError> {
+    println!("\n{}", "Hermes Configuration".bright_cyan().bold());
+
+    let current_api_key = current
+        .and_then(|v| v.get("api_key").or_else(|| v.get("apiKey")))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let current_base_url = current
+        .and_then(|v| v.get("base_url").or_else(|| v.get("baseUrl")))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let current_model = current
+        .and_then(|v| v.get("models"))
+        .and_then(|v| v.as_array())
+        .and_then(|models| models.first())
+        .and_then(|model| model.get("id").and_then(|id| id.as_str()))
+        .or_else(|| {
+            current
+                .and_then(|v| v.get("model"))
+                .and_then(|v| v.as_str())
+        })
+        .unwrap_or("");
+
+    let api_key = Text::new("Hermes API Key")
+        .with_initial_value(current_api_key)
+        .with_placeholder("sk-...")
+        .prompt()
+        .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?;
+    let base_url = Text::new("Hermes Base URL")
+        .with_initial_value(current_base_url)
+        .with_placeholder("https://api.example.com/v1")
+        .prompt()
+        .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?;
+    let model = Text::new("Hermes Model")
+        .with_initial_value(current_model)
+        .with_placeholder("claude-sonnet-4-6")
+        .prompt()
+        .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?;
+
+    let mut settings = serde_json::Map::new();
+    if !api_key.trim().is_empty() {
+        settings.insert("api_key".to_string(), json!(api_key.trim()));
+    }
+    if !base_url.trim().is_empty() {
+        settings.insert(
+            "base_url".to_string(),
+            json!(base_url.trim().trim_end_matches('/')),
+        );
+    }
+    if !model.trim().is_empty() {
+        settings.insert(
+            "models".to_string(),
+            json!([{ "id": model.trim(), "name": model.trim() }]),
+        );
+    }
+
+    Ok(Value::Object(settings))
+}
+
 /// 收集可选字段
 pub fn prompt_optional_fields(current: Option<&Provider>) -> Result<OptionalFields, AppError> {
     println!("\n{}", texts::optional_fields_config().bright_cyan().bold());
@@ -939,6 +1000,35 @@ pub fn display_provider_summary(provider: &Provider, app_type: &AppType) {
             if let Some(base_url) = provider
                 .settings_config
                 .get("baseUrl")
+                .and_then(|v| v.as_str())
+            {
+                println!("  {}: {}", texts::base_url_display_label(), base_url);
+            }
+            if let Some(models) = provider
+                .settings_config
+                .get("models")
+                .and_then(|v| v.as_array())
+            {
+                println!("  {}: {}", texts::model_label(), models.len());
+            }
+        }
+        AppType::Hermes => {
+            if let Some(api_key) = provider
+                .settings_config
+                .get("api_key")
+                .or_else(|| provider.settings_config.get("apiKey"))
+                .and_then(|v| v.as_str())
+            {
+                println!(
+                    "  {}: {}",
+                    texts::api_key_display_label(),
+                    mask_api_key(api_key)
+                );
+            }
+            if let Some(base_url) = provider
+                .settings_config
+                .get("base_url")
+                .or_else(|| provider.settings_config.get("baseUrl"))
                 .and_then(|v| v.as_str())
             {
                 println!("  {}: {}", texts::base_url_display_label(), base_url);

--- a/src-tauri/src/cli/commands/provider_inspect.rs
+++ b/src-tauri/src/cli/commands/provider_inspect.rs
@@ -355,6 +355,21 @@ fn model_fetch_target(
                 })?,
             strategy: ProviderModelFetchStrategy::Bearer,
         }),
+        AppType::Hermes => Ok(ModelFetchTarget {
+            base_url,
+            auth_value: provider
+                .settings_config
+                .get("api_key")
+                .or_else(|| provider.settings_config.get("apiKey"))
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .ok_or_else(|| {
+                    AppError::Message(format!("Missing API key for provider '{}'", provider.id))
+                })?,
+            strategy: ProviderModelFetchStrategy::Bearer,
+        }),
     }
 }
 

--- a/src-tauri/src/cli/failover_policy.rs
+++ b/src-tauri/src/cli/failover_policy.rs
@@ -85,6 +85,6 @@ fn takeover_enabled_for(takeover: &ProxyTakeoverStatus, app_type: &AppType) -> b
         AppType::Claude => takeover.claude,
         AppType::Codex => takeover.codex,
         AppType::Gemini => takeover.gemini,
-        AppType::OpenCode | AppType::OpenClaw => false,
+        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => false,
     }
 }

--- a/src-tauri/src/cli/tui/app/helpers.rs
+++ b/src-tauri/src/cli/tui/app/helpers.rs
@@ -1186,6 +1186,7 @@ pub(crate) fn app_type_picker_index(app_type: &AppType) -> usize {
         AppType::Gemini => 2,
         AppType::OpenCode => 3,
         AppType::OpenClaw => 4,
+        AppType::Hermes => 5,
     }
 }
 
@@ -1199,6 +1200,7 @@ pub(crate) fn app_type_for_picker_index(index: usize) -> AppType {
         2 => AppType::Gemini,
         3 => AppType::OpenCode,
         4 => AppType::OpenClaw,
+        5 => AppType::Hermes,
         _ => AppType::Claude,
     }
 }

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -623,6 +623,7 @@ mod tests {
             gemini: true,
             opencode: true,
             openclaw: true,
+            hermes: false,
         })
         .expect("save visible apps");
         let mut app = App::new(Some(AppType::Claude));
@@ -647,6 +648,7 @@ mod tests {
             gemini: true,
             opencode: true,
             openclaw: true,
+            hermes: false,
         })
         .expect("save visible apps");
         let mut app = App::new(Some(AppType::Gemini));
@@ -687,6 +689,7 @@ mod tests {
             gemini: false,
             opencode: true,
             openclaw: true,
+            hermes: false,
         })
         .expect("save visible apps");
 
@@ -709,6 +712,7 @@ mod tests {
             gemini: false,
             opencode: false,
             openclaw: false,
+            hermes: false,
         })
         .expect("save visible apps");
 
@@ -735,6 +739,7 @@ mod tests {
             gemini: false,
             opencode: false,
             openclaw: true,
+            hermes: false,
         })
         .expect("save visible apps");
 
@@ -757,6 +762,7 @@ mod tests {
             gemini: false,
             opencode: false,
             openclaw: false,
+            hermes: false,
         })
         .expect("save visible apps");
 
@@ -8178,6 +8184,7 @@ mod tests {
             gemini: false,
             opencode: false,
             openclaw: false,
+            hermes: false,
         })
         .expect("save visible apps");
 
@@ -8225,6 +8232,7 @@ mod tests {
             gemini: false,
             opencode: false,
             openclaw: false,
+            hermes: false,
         })
         .expect("save visible apps");
 

--- a/src-tauri/src/cli/tui/data.rs
+++ b/src-tauri/src/cli/tui/data.rs
@@ -251,6 +251,7 @@ impl ProxySnapshot {
             AppType::Gemini => Some(self.gemini_takeover),
             AppType::OpenCode => None,
             AppType::OpenClaw => None,
+            AppType::Hermes => None,
         }
     }
 
@@ -323,7 +324,7 @@ pub(crate) fn provider_display_name(app_type: &AppType, row: &ProviderRow) -> St
         return row.provider.name.clone();
     }
 
-    if matches!(app_type, AppType::OpenClaw) {
+    if matches!(app_type, AppType::OpenClaw | AppType::Hermes) {
         return row.id.clone();
     }
 
@@ -524,6 +525,9 @@ fn load_providers(state: &AppState, app_type: &AppType) -> Result<ProvidersSnaps
     if matches!(app_type, AppType::OpenClaw) {
         ProviderService::sync_openclaw_providers_from_live(state)?;
     }
+    if matches!(app_type, AppType::Hermes) {
+        ProviderService::sync_hermes_providers_from_live(state)?;
+    }
 
     let current_id = ProviderService::current(state, app_type.clone())?;
     let providers = ProviderService::list(state, app_type.clone())?;
@@ -541,6 +545,14 @@ fn load_providers(state: &AppState, app_type: &AppType) -> Result<ProvidersSnaps
     };
     let opencode_live_ids = if matches!(app_type, AppType::OpenCode) {
         crate::opencode_config::get_providers()?
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect::<HashSet<_>>()
+    } else {
+        HashSet::new()
+    };
+    let hermes_live_ids = if matches!(app_type, AppType::Hermes) {
+        crate::hermes_config::get_providers()?
             .into_iter()
             .map(|(id, _)| id)
             .collect::<HashSet<_>>()
@@ -573,6 +585,7 @@ fn load_providers(state: &AppState, app_type: &AppType) -> Result<ProvidersSnaps
                 is_in_config: match app_type {
                     AppType::OpenCode => opencode_live_ids.contains(&id),
                     AppType::OpenClaw => openclaw_live_ids.contains(&id),
+                    AppType::Hermes => hermes_live_ids.contains(&id),
                     _ => true,
                 },
                 is_saved: true,
@@ -659,6 +672,11 @@ fn extract_api_url(settings_config: &Value, app_type: &AppType) -> Option<String
             .or_else(|| settings_config.get("base_url"))?
             .as_str()
             .map(|s| s.to_string()),
+        AppType::Hermes => settings_config
+            .get("base_url")
+            .or_else(|| settings_config.get("baseUrl"))?
+            .as_str()
+            .map(|s| s.to_string()),
     }
 }
 
@@ -672,6 +690,13 @@ fn extract_primary_model_id(
             Some(live_provider) => openclaw_primary_model_id(live_provider),
             None => openclaw_primary_model_id(settings_config),
         },
+        AppType::Hermes => settings_config
+            .get("models")
+            .and_then(|value| value.as_array())
+            .and_then(|models| models.first())
+            .and_then(|model| model.get("id").and_then(Value::as_str))
+            .or_else(|| settings_config.get("model").and_then(Value::as_str))
+            .map(str::to_string),
         _ => None,
     }
 }

--- a/src-tauri/src/cli/tui/form/provider_json.rs
+++ b/src-tauri/src/cli/tui/form/provider_json.rs
@@ -399,6 +399,73 @@ impl ProviderAddFormState {
                     settings_obj.insert("models".to_string(), Value::Array(models));
                 }
             }
+            AppType::Hermes => {
+                settings_obj.remove("npm");
+                settings_obj.remove("options");
+                settings_obj.remove("apiKey");
+                settings_obj.remove("baseUrl");
+                settings_obj.remove("api");
+                settings_obj.remove("headers");
+
+                set_or_remove_trimmed(settings_obj, "api_key", &self.opencode_api_key.value);
+                set_or_remove_trimmed(settings_obj, "base_url", &self.opencode_base_url.value);
+
+                let mut models = match settings_obj.remove("models") {
+                    Some(Value::Array(items)) => items,
+                    _ => Vec::new(),
+                };
+
+                let model_id = self.opencode_primary_model_id();
+                match model_id {
+                    Some(model_id) => {
+                        let original_index = self
+                            .opencode_model_original_id
+                            .as_deref()
+                            .and_then(|original_id| openclaw_model_index(&models, original_id));
+                        let target_index =
+                            original_index.or_else(|| openclaw_model_index(&models, &model_id));
+
+                        let mut model_obj = target_index
+                            .and_then(|index| models.get(index).cloned())
+                            .and_then(|value| value.as_object().cloned())
+                            .unwrap_or_default();
+
+                        model_obj.insert("id".to_string(), json!(model_id.clone()));
+                        let model_name = self.opencode_model_name.value.trim();
+                        if model_name.is_empty() {
+                            model_obj.remove("name");
+                        } else {
+                            model_obj.insert("name".to_string(), json!(model_name));
+                        }
+                        let context_value = self.opencode_model_context_limit.value.trim();
+                        if context_value.is_empty() {
+                            model_obj.remove("context_length");
+                        } else if let Ok(context_length) = context_value.parse::<u64>() {
+                            model_obj.insert("context_length".to_string(), json!(context_length));
+                        }
+
+                        let updated_model = Value::Object(model_obj);
+                        if let Some(index) = target_index {
+                            models[index] = updated_model;
+                        } else {
+                            models.push(updated_model);
+                        }
+                    }
+                    None => {
+                        if let Some(original_id) = self.opencode_model_original_id.as_deref() {
+                            if let Some(index) = openclaw_model_index(&models, original_id) {
+                                models.remove(index);
+                            }
+                        }
+                    }
+                }
+
+                if models.is_empty() {
+                    settings_obj.remove("models");
+                } else {
+                    settings_obj.insert("models".to_string(), Value::Array(models));
+                }
+            }
         }
 
         Value::Object(provider_obj)
@@ -563,7 +630,7 @@ pub(crate) fn strip_common_config_from_settings(
             )
             .map_err(|e| e.to_string())?;
         }
-        AppType::OpenCode | AppType::OpenClaw => {}
+        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => {}
         AppType::Codex => {
             *settings_value = ProviderService::remove_common_config_from_settings_for_preview(
                 app_type,

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -155,7 +155,7 @@ impl ProviderAddFormState {
                 .ok()
                 .and_then(|value| value.as_object().cloned())
                 .is_some_and(|obj| !obj.is_empty()),
-            AppType::OpenCode | AppType::OpenClaw => false,
+            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => false,
         }
     }
 
@@ -210,7 +210,7 @@ impl ProviderAddFormState {
             ProviderAddField::Notes,
         ];
 
-        if matches!(self.app_type, AppType::OpenClaw) {
+        if matches!(self.app_type, AppType::OpenClaw | AppType::Hermes) {
             fields.insert(0, ProviderAddField::Id);
         }
 
@@ -254,6 +254,13 @@ impl ProviderAddFormState {
                 fields.push(ProviderAddField::OpenCodeBaseUrl);
                 fields.push(ProviderAddField::OpenClawUserAgent);
                 fields.push(ProviderAddField::OpenClawModels);
+            }
+            AppType::Hermes => {
+                fields.push(ProviderAddField::OpenCodeApiKey);
+                fields.push(ProviderAddField::OpenCodeBaseUrl);
+                fields.push(ProviderAddField::OpenCodeModelId);
+                fields.push(ProviderAddField::OpenCodeModelName);
+                fields.push(ProviderAddField::OpenCodeModelContextLimit);
             }
         }
 

--- a/src-tauri/src/cli/tui/form/provider_state_loading.rs
+++ b/src-tauri/src/cli/tui/form/provider_state_loading.rs
@@ -19,6 +19,7 @@ pub(super) fn populate_form_from_provider(
         AppType::Gemini => populate_gemini_form(form, provider),
         AppType::OpenCode => populate_opencode_form(form, provider),
         AppType::OpenClaw => populate_openclaw_form(form, provider),
+        AppType::Hermes => populate_hermes_form(form, provider),
     }
 }
 
@@ -249,6 +250,55 @@ fn populate_openclaw_form(form: &mut ProviderAddFormState, provider: &Provider) 
             form.opencode_model_context_limit
                 .set(context_window.to_string());
         }
+    }
+}
+
+fn populate_hermes_form(form: &mut ProviderAddFormState, provider: &Provider) {
+    if let Some(api_key) = provider
+        .settings_config
+        .get("api_key")
+        .or_else(|| provider.settings_config.get("apiKey"))
+        .and_then(|value| value.as_str())
+    {
+        form.opencode_api_key.set(api_key);
+    }
+    if let Some(base_url) = provider
+        .settings_config
+        .get("base_url")
+        .or_else(|| provider.settings_config.get("baseUrl"))
+        .and_then(|value| value.as_str())
+    {
+        form.opencode_base_url.set(base_url);
+    }
+    if let Some(models) = provider
+        .settings_config
+        .get("models")
+        .and_then(|value| value.as_array())
+    {
+        if let Some(model) = models.first() {
+            if let Some(id) = model.get("id").and_then(|value| value.as_str()) {
+                form.opencode_model_original_id = Some(id.to_string());
+                form.opencode_model_id.set(id);
+            }
+            if let Some(name) = model.get("name").and_then(|value| value.as_str()) {
+                form.opencode_model_name.set(name);
+            }
+            if let Some(context_length) = model
+                .get("context_length")
+                .or_else(|| model.get("contextWindow"))
+                .and_then(|value| value.as_u64())
+            {
+                form.opencode_model_context_limit
+                    .set(context_length.to_string());
+            }
+        }
+    } else if let Some(model) = provider
+        .settings_config
+        .get("model")
+        .and_then(|value| value.as_str())
+    {
+        form.opencode_model_original_id = Some(model.to_string());
+        form.opencode_model_id.set(model);
     }
 }
 

--- a/src-tauri/src/cli/tui/form/provider_templates.rs
+++ b/src-tauri/src/cli/tui/form/provider_templates.rs
@@ -119,6 +119,8 @@ static SPONSOR_PROVIDER_PRESETS_OPENCODE: [SponsorProviderPreset; 1] =
 static SPONSOR_PROVIDER_PRESETS_OPENCLAW: [SponsorProviderPreset; 1] =
     [SPONSOR_PROVIDER_PRESETS[1]];
 
+static SPONSOR_PROVIDER_PRESETS_HERMES: [SponsorProviderPreset; 1] = [SPONSOR_PROVIDER_PRESETS[1]];
+
 static PROVIDER_TEMPLATE_DEFS_CLAUDE: [ProviderTemplateDef; 2] = [
     ProviderTemplateDef {
         id: ProviderTemplateId::Custom,
@@ -162,6 +164,11 @@ static PROVIDER_TEMPLATE_DEFS_OPENCLAW: [ProviderTemplateDef; 1] = [ProviderTemp
     label: "Custom",
 }];
 
+static PROVIDER_TEMPLATE_DEFS_HERMES: [ProviderTemplateDef; 1] = [ProviderTemplateDef {
+    id: ProviderTemplateId::Custom,
+    label: "Custom",
+}];
+
 pub(super) fn provider_builtin_template_defs(app_type: &AppType) -> &'static [ProviderTemplateDef] {
     match app_type {
         AppType::Claude => &PROVIDER_TEMPLATE_DEFS_CLAUDE,
@@ -169,6 +176,7 @@ pub(super) fn provider_builtin_template_defs(app_type: &AppType) -> &'static [Pr
         AppType::Gemini => &PROVIDER_TEMPLATE_DEFS_GEMINI,
         AppType::OpenCode => &PROVIDER_TEMPLATE_DEFS_OPENCODE,
         AppType::OpenClaw => &PROVIDER_TEMPLATE_DEFS_OPENCLAW,
+        AppType::Hermes => &PROVIDER_TEMPLATE_DEFS_HERMES,
     }
 }
 
@@ -179,6 +187,7 @@ pub(super) fn provider_sponsor_presets(app_type: &AppType) -> &'static [SponsorP
         AppType::Gemini => &SPONSOR_PROVIDER_PRESETS_GEMINI,
         AppType::OpenCode => &SPONSOR_PROVIDER_PRESETS_OPENCODE,
         AppType::OpenClaw => &SPONSOR_PROVIDER_PRESETS_OPENCLAW,
+        AppType::Hermes => &SPONSOR_PROVIDER_PRESETS_HERMES,
     }
 }
 
@@ -410,6 +419,17 @@ impl ProviderAddFormState {
                     self.opencode_model_id.set("claude-opus-4-6");
                     self.opencode_model_name.set("Claude Opus 4.6");
                     self.opencode_model_context_limit.set("200000");
+                    self.opencode_model_original_id = Some("claude-opus-4-6".to_string());
+                }
+            }
+            AppType::Hermes => {
+                if preset.id == "aicodemirror" {
+                    self.opencode_api_key.set("");
+                    self.opencode_base_url.set(preset.claude_base_url);
+                    self.opencode_model_id.set("claude-opus-4-6");
+                    self.opencode_model_name.set("Claude Opus 4.6");
+                    self.opencode_model_context_limit.set("200000");
+                    self.opencode_model_output_limit.set("");
                     self.opencode_model_original_id = Some("claude-opus-4-6".to_string());
                 }
             }

--- a/src-tauri/src/cli/tui/runtime_actions/helpers.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/helpers.rs
@@ -43,6 +43,7 @@ pub(crate) fn import_mcp_for_current_app(app: &mut App, data: &mut UiData) -> Re
                 AppType::Gemini => McpService::import_from_gemini(&state),
                 AppType::OpenCode => McpService::import_from_opencode(&state),
                 AppType::OpenClaw => Ok(0),
+                AppType::Hermes => Ok(0),
             }
         },
         UiData::load,
@@ -69,6 +70,7 @@ pub(crate) fn app_display_name(app_type: &AppType) -> &'static str {
         AppType::Gemini => "Gemini",
         AppType::OpenCode => "OpenCode",
         AppType::OpenClaw => "OpenClaw",
+        AppType::Hermes => "Hermes",
     }
 }
 

--- a/src-tauri/src/cli/tui/runtime_actions/mod.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/mod.rs
@@ -572,6 +572,7 @@ mod tests {
             gemini: true,
             opencode: true,
             openclaw: true,
+            hermes: false,
         })
         .expect("save initial visible apps");
 
@@ -581,6 +582,7 @@ mod tests {
             gemini: false,
             opencode: false,
             openclaw: false,
+            hermes: false,
         };
         let mut app = App::new(Some(AppType::OpenClaw));
         app.route = Route::ConfigOpenClawTools;
@@ -640,6 +642,7 @@ mod tests {
             gemini: false,
             opencode: true,
             openclaw: true,
+            hermes: false,
         };
         crate::settings::set_visible_apps(initial_visible_apps.clone())
             .expect("save initial visible apps");
@@ -661,6 +664,7 @@ mod tests {
                     gemini: false,
                     opencode: false,
                     openclaw: false,
+                    hermes: false,
                 },
             },
         )
@@ -688,6 +692,7 @@ mod tests {
             gemini: false,
             opencode: true,
             openclaw: true,
+            hermes: false,
         })
         .expect("save initial visible apps");
         write_invalid_legacy_config(temp_home.path());
@@ -698,6 +703,7 @@ mod tests {
             gemini: false,
             opencode: true,
             openclaw: false,
+            hermes: false,
         };
         let mut app = App::new(Some(AppType::Claude));
         let mut data = UiData::default();
@@ -734,6 +740,7 @@ mod tests {
             gemini: false,
             opencode: true,
             openclaw: true,
+            hermes: false,
         };
         crate::settings::set_visible_apps(initial_visible_apps.clone())
             .expect("save initial visible apps");
@@ -752,6 +759,7 @@ mod tests {
                     gemini: false,
                     opencode: false,
                     openclaw: false,
+                    hermes: false,
                 },
             },
         )

--- a/src-tauri/src/cli/tui/runtime_actions/providers.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/providers.rs
@@ -77,6 +77,9 @@ pub(super) fn import_live_config(ctx: &mut RuntimeActionContext<'_>) -> Result<(
         crate::app_config::AppType::OpenClaw => {
             ProviderService::import_openclaw_providers_from_live(&state)? > 0
         }
+        crate::app_config::AppType::Hermes => {
+            ProviderService::import_hermes_providers_from_live(&state)? > 0
+        }
         _ => ProviderService::import_default_config(&state, ctx.app.app_type.clone())?,
     };
 
@@ -326,6 +329,16 @@ pub(super) fn remove_from_config(
             Ok(())
         }
         crate::app_config::AppType::OpenCode => {
+            let state = load_state()?;
+            ProviderService::remove_from_live_config(&state, ctx.app.app_type.clone(), &id)?;
+            ctx.app.push_toast(
+                texts::tui_toast_provider_removed_from_app_config(ctx.app.app_type.as_str()),
+                ToastKind::Success,
+            );
+            *ctx.data = UiData::load(&ctx.app.app_type)?;
+            Ok(())
+        }
+        crate::app_config::AppType::Hermes => {
             let state = load_state()?;
             ProviderService::remove_from_live_config(&state, ctx.app.app_type.clone(), &id)?;
             ctx.app.push_toast(

--- a/src-tauri/src/cli/tui/tests.rs
+++ b/src-tauri/src/cli/tui/tests.rs
@@ -644,6 +644,7 @@ fn startup_hidden_requested_app_bootstrap_uses_visible_app_normalization_before_
         gemini: false,
         opencode: true,
         openclaw: true,
+        hermes: false,
     })
     .expect("save visible apps");
 

--- a/src-tauri/src/cli/tui/theme.rs
+++ b/src-tauri/src/cli/tui/theme.rs
@@ -7,6 +7,7 @@ const COLOR_MODE_ENV: &str = "CC_SWITCH_COLOR_MODE";
 const DRACULA_GREEN: (u8, u8, u8) = (80, 250, 123);
 const DRACULA_CYAN: (u8, u8, u8) = (139, 233, 253);
 const DRACULA_PINK: (u8, u8, u8) = (255, 121, 198);
+const DRACULA_PURPLE: (u8, u8, u8) = (189, 147, 249);
 const DRACULA_ORANGE: (u8, u8, u8) = (255, 184, 108);
 const DRACULA_YELLOW: (u8, u8, u8) = (241, 250, 140);
 const DRACULA_RED: (u8, u8, u8) = (255, 85, 85);
@@ -184,6 +185,7 @@ fn accent_rgb(app: &AppType) -> (u8, u8, u8) {
         AppType::Gemini => DRACULA_PINK,
         AppType::OpenCode => DRACULA_ORANGE,
         AppType::OpenClaw => OPENCLAW_CORAL,
+        AppType::Hermes => DRACULA_PURPLE,
     }
 }
 

--- a/src-tauri/src/cli/tui/ui/forms/provider.rs
+++ b/src-tauri/src/cli/tui/ui/forms/provider.rs
@@ -10,7 +10,7 @@ fn should_redact_provider_field(
     provider: &super::form::ProviderAddFormState,
     field: ProviderAddField,
 ) -> bool {
-    matches!(provider.app_type, AppType::OpenClaw)
+    matches!(provider.app_type, AppType::OpenClaw | AppType::Hermes)
         && matches!(field, ProviderAddField::OpenCodeApiKey)
 }
 
@@ -24,7 +24,7 @@ fn common_json_preview_value(app_type: &AppType, common_snippet: &str) -> Option
         AppType::Gemini => serde_json::from_str::<Value>(common_snippet)
             .ok()
             .map(|env| json!({ "env": env })),
-        AppType::Codex | AppType::OpenCode | AppType::OpenClaw => None,
+        AppType::Codex | AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => None,
     }
     .filter(Value::is_object)
 }
@@ -405,7 +405,7 @@ pub(crate) fn render_provider_add_form(
             .get("settingsConfig")
             .cloned()
             .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
-        let json_value = if matches!(provider.app_type, AppType::OpenClaw) {
+        let json_value = if matches!(provider.app_type, AppType::OpenClaw | AppType::Hermes) {
             redact_sensitive_json(&json_value)
         } else {
             json_value

--- a/src-tauri/src/cli/tui/ui/header_tests.rs
+++ b/src-tauri/src/cli/tui/ui/header_tests.rs
@@ -195,6 +195,7 @@ fn header_openclaw_sacrifices_tabs_before_losing_the_only_status_badge() {
         gemini: true,
         opencode: true,
         openclaw: true,
+        hermes: false,
     });
     let _lang = use_test_language(Language::English);
     let _no_color = super::tests::EnvGuard::remove("NO_COLOR");
@@ -234,6 +235,7 @@ fn header_openclaw_truncates_long_default_model_without_fake_proxy_gap() {
         gemini: true,
         opencode: true,
         openclaw: true,
+        hermes: false,
     });
     let _lang = use_test_language(Language::English);
     let _no_color = super::tests::EnvGuard::remove("NO_COLOR");

--- a/src-tauri/src/cli/tui/ui/main_page.rs
+++ b/src-tauri/src/cli/tui/ui/main_page.rs
@@ -585,18 +585,28 @@ fn render_local_env_check_card(
 
     let cols0 = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .constraints([
+            Constraint::Percentage(34),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ])
         .split(rows[0]);
     let cols1 = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .constraints([
+            Constraint::Percentage(34),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ])
         .split(rows[1]);
 
     let cells = [
         (LocalTool::Claude, "Claude", cols0[0]),
         (LocalTool::Codex, "Codex", cols0[1]),
-        (LocalTool::Gemini, "Gemini", cols1[0]),
-        (LocalTool::OpenCode, "OpenCode", cols1[1]),
+        (LocalTool::Gemini, "Gemini", cols0[2]),
+        (LocalTool::OpenCode, "OpenCode", cols1[0]),
+        (LocalTool::OpenClaw, "OpenClaw", cols1[1]),
+        (LocalTool::Hermes, "Hermes", cols1[2]),
     ];
 
     for (tool, display_name, cell_area) in cells {

--- a/src-tauri/src/cli/tui/ui/overlay/pickers.rs
+++ b/src-tauri/src/cli/tui/ui/overlay/pickers.rs
@@ -783,6 +783,7 @@ pub(super) fn render_visible_apps_picker_overlay(
             crate::app_config::AppType::Gemini,
             crate::app_config::AppType::OpenCode,
             crate::app_config::AppType::OpenClaw,
+            crate::app_config::AppType::Hermes,
         ],
     );
 }
@@ -808,6 +809,7 @@ pub(super) fn render_skills_apps_picker_overlay(
             crate::app_config::AppType::Codex,
             crate::app_config::AppType::Gemini,
             crate::app_config::AppType::OpenCode,
+            crate::app_config::AppType::Hermes,
         ],
     );
 }

--- a/src-tauri/src/cli/tui/ui/tests.rs
+++ b/src-tauri/src/cli/tui/ui/tests.rs
@@ -575,6 +575,7 @@ fn installed_skill(directory: &str, name: &str) -> InstalledSkill {
             codex: false,
             gemini: false,
             opencode: false,
+            hermes: false,
         },
         installed_at: 1,
     }
@@ -799,6 +800,7 @@ fn header_only_renders_selected_visible_apps() {
         gemini: false,
         opencode: false,
         openclaw: true,
+        hermes: false,
     })
     .expect("save visible apps");
 
@@ -827,6 +829,7 @@ fn header_keeps_all_app_tabs_visible_with_proxy_chip() {
         gemini: true,
         opencode: true,
         openclaw: true,
+        hermes: false,
     })
     .expect("save visible apps");
 
@@ -855,6 +858,7 @@ fn settings_page_shows_visible_apps_row_value() {
         gemini: true,
         opencode: false,
         openclaw: true,
+        hermes: false,
     })
     .expect("save visible apps");
 
@@ -935,6 +939,7 @@ fn zero_selection_warning_toast_renders_after_picker_rejection() {
             gemini: false,
             opencode: false,
             openclaw: false,
+            hermes: false,
         },
     };
     app.push_toast(
@@ -971,6 +976,7 @@ fn visible_apps_picker_uses_space_toggle_key() {
             gemini: false,
             opencode: false,
             openclaw: false,
+            hermes: false,
         },
     };
 
@@ -1587,6 +1593,7 @@ fn home_connection_card_labels_mcp_and_skills_with_active_counts() {
                 codex: false,
                 gemini: false,
                 opencode: false,
+                hermes: false,
             },
             installed_at: 0,
         },
@@ -2397,6 +2404,7 @@ fn skills_page_shows_opencode_summary() {
         codex: false,
         gemini: false,
         opencode: true,
+        hermes: false,
     };
     data.skills.installed = vec![skill];
 
@@ -2424,6 +2432,7 @@ fn skill_detail_page_shows_opencode_enabled_state() {
         codex: false,
         gemini: false,
         opencode: true,
+        hermes: false,
     };
     data.skills.installed = vec![skill];
 

--- a/src-tauri/src/cli/ui/colors.rs
+++ b/src-tauri/src/cli/ui/colors.rs
@@ -35,6 +35,7 @@ fn inquire_color_for_app(app_type: &AppType) -> InquireColor {
         AppType::Gemini => InquireColor::LightMagenta,
         AppType::OpenCode => InquireColor::LightGreen,
         AppType::OpenClaw => InquireColor::LightRed,
+        AppType::Hermes => InquireColor::LightMagenta,
     }
 }
 
@@ -86,6 +87,7 @@ fn highlight_color_for_app(app_type: &AppType) -> Color {
         AppType::Gemini => Color::BrightMagenta,
         AppType::OpenCode => Color::BrightGreen,
         AppType::OpenClaw => Color::BrightRed,
+        AppType::Hermes => Color::BrightMagenta,
     }
 }
 

--- a/src-tauri/src/database/dao/skills.rs
+++ b/src-tauri/src/database/dao/skills.rs
@@ -22,7 +22,7 @@ impl Database {
         let mut stmt = conn
             .prepare(
                 "SELECT id, name, description, directory, repo_owner, repo_name, repo_branch,
-                        readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, installed_at
+                        readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes, installed_at
                  FROM skills ORDER BY name ASC",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -43,8 +43,9 @@ impl Database {
                         codex: row.get(9)?,
                         gemini: row.get(10)?,
                         opencode: row.get(11)?,
+                        hermes: row.get(12)?,
                     },
-                    installed_at: row.get(12)?,
+                    installed_at: row.get(13)?,
                 })
             })
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -63,7 +64,7 @@ impl Database {
         let mut stmt = conn
             .prepare(
                 "SELECT id, name, description, directory, repo_owner, repo_name, repo_branch,
-                        readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, installed_at
+                        readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes, installed_at
                  FROM skills WHERE id = ?1",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -83,8 +84,9 @@ impl Database {
                     codex: row.get(9)?,
                     gemini: row.get(10)?,
                     opencode: row.get(11)?,
+                    hermes: row.get(12)?,
                 },
-                installed_at: row.get(12)?,
+                installed_at: row.get(13)?,
             })
         });
 
@@ -101,8 +103,8 @@ impl Database {
         conn.execute(
             "INSERT OR REPLACE INTO skills
              (id, name, description, directory, repo_owner, repo_name, repo_branch,
-              readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, installed_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+              readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes, installed_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             params![
                 skill.id,
                 skill.name,
@@ -116,6 +118,7 @@ impl Database {
                 skill.apps.codex,
                 skill.apps.gemini,
                 skill.apps.opencode,
+                skill.apps.hermes,
                 skill.installed_at,
             ],
         )
@@ -145,8 +148,8 @@ impl Database {
         let conn = lock_conn!(self.conn);
         let affected = conn
             .execute(
-                "UPDATE skills SET enabled_claude = ?1, enabled_codex = ?2, enabled_gemini = ?3, enabled_opencode = ?4 WHERE id = ?5",
-                params![apps.claude, apps.codex, apps.gemini, apps.opencode, id],
+                "UPDATE skills SET enabled_claude = ?1, enabled_codex = ?2, enabled_gemini = ?3, enabled_opencode = ?4, enabled_hermes = ?5 WHERE id = ?6",
+                params![apps.claude, apps.codex, apps.gemini, apps.opencode, apps.hermes, id],
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
         Ok(affected > 0)

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -140,6 +140,7 @@ fn build_provider_from_request(
         AppType::Gemini => build_gemini_settings(request),
         AppType::OpenCode => build_opencode_settings(request),
         AppType::OpenClaw => build_openclaw_settings(request),
+        AppType::Hermes => build_hermes_settings(request),
     };
 
     let meta = build_provider_meta(request)?;
@@ -370,6 +371,30 @@ fn build_openclaw_settings(request: &DeepLinkImportRequest) -> serde_json::Value
     }
     settings.insert("api".to_string(), json!("openai-completions"));
 
+    if let Some(model) = request
+        .model
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        settings.insert(
+            "models".to_string(),
+            json!([{ "id": model, "name": model }]),
+        );
+    }
+
+    serde_json::Value::Object(settings)
+}
+
+fn build_hermes_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
+    let endpoint = get_primary_endpoint(request);
+    let mut settings = serde_json::Map::new();
+
+    if !endpoint.is_empty() {
+        settings.insert("base_url".to_string(), json!(endpoint));
+    }
+    if let Some(api_key) = &request.api_key {
+        settings.insert("api_key".to_string(), json!(api_key));
+    }
     if let Some(model) = request
         .model
         .as_deref()

--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -1,0 +1,1946 @@
+//! Hermes Agent 配置文件读写模块
+//!
+//! 处理 `~/.hermes/config.yaml` 配置文件的读写操作（YAML 格式）。
+//! Hermes 使用累加式供应商管理，所有供应商配置共存于同一配置文件中。
+//!
+//! ## 配置结构示例
+//!
+//! ```yaml
+//! model:
+//!   default: "anthropic/claude-opus-4-7"
+//!   provider: "openrouter"
+//!   base_url: "https://openrouter.ai/api/v1"
+//!
+//! agent:
+//!   max_turns: 50
+//!   reasoning_effort: "high"
+//!
+//! custom_providers:
+//!   - name: openrouter
+//!     base_url: https://openrouter.ai/api/v1
+//!     api_key: sk-or-...
+//!     model: anthropic/claude-opus-4-7
+//!     models:
+//!       anthropic/claude-opus-4-7:
+//!         context_length: 200000
+//!
+//! mcp_servers:
+//!   filesystem:
+//!     command: npx
+//!     args: ["-y", "@modelcontextprotocol/server-filesystem"]
+//! ```
+
+use crate::config::{atomic_write, get_app_config_dir};
+use crate::error::AppError;
+use crate::settings::{effective_backup_retain_count, get_hermes_override_dir};
+use chrono::Local;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+// ============================================================================
+// Path Functions
+// ============================================================================
+
+/// 获取 Hermes 配置目录
+///
+/// 默认路径: `~/.hermes/`
+/// 可通过 settings.hermes_config_dir 覆盖
+pub fn get_hermes_dir() -> PathBuf {
+    if let Some(override_dir) = get_hermes_override_dir() {
+        return override_dir;
+    }
+
+    crate::config::home_dir()
+        .expect("无法获取用户主目录")
+        .join(".hermes")
+}
+
+/// 获取 Hermes 配置文件路径
+///
+/// 返回 `~/.hermes/config.yaml`
+pub fn get_hermes_config_path() -> PathBuf {
+    get_hermes_dir().join("config.yaml")
+}
+
+fn hermes_write_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+/// Hermes 写入结果
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct HermesWriteOutcome {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backup_path: Option<String>,
+}
+
+/// Hermes model section config
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HermesModelConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_length: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u64>,
+    /// Preserve unknown fields for forward compatibility
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+// ============================================================================
+// Core YAML Read Functions
+// ============================================================================
+
+/// 读取 Hermes 配置文件为 serde_yaml::Value
+///
+/// 如果文件不存在，返回空 Mapping
+pub fn read_hermes_config() -> Result<serde_yaml::Value, AppError> {
+    let path = get_hermes_config_path();
+    if !path.exists() {
+        return Ok(serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    }
+
+    let content = fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))?;
+    if content.trim().is_empty() {
+        return Ok(serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    }
+
+    serde_yaml::from_str(&content)
+        .map_err(|e| AppError::Config(format!("Failed to parse Hermes config as YAML: {e}")))
+}
+
+// ============================================================================
+// YAML Section-Level Replacement
+// ============================================================================
+
+/// Check if a line is a YAML top-level key (mapping key at column 0).
+///
+/// A top-level key line must:
+/// - Start at column 0 (no leading whitespace)
+/// - Not be empty or whitespace-only
+/// - Not be a comment (starting with `#`)
+/// - Not be a sequence item (starting with `-`)
+/// - Contain `:` followed by space, tab, newline, or end-of-line
+fn is_top_level_key_line(line: &str) -> bool {
+    if line.is_empty() {
+        return false;
+    }
+    let first_char = line.as_bytes()[0];
+    if first_char == b' ' || first_char == b'\t' || first_char == b'#' || first_char == b'-' {
+        return false;
+    }
+    if let Some(colon_pos) = line.find(':') {
+        let after_colon = &line[colon_pos + 1..];
+        after_colon.is_empty() || after_colon.starts_with(' ') || after_colon.starts_with('\t')
+    } else {
+        false
+    }
+}
+
+/// Find the byte range of a top-level YAML section.
+///
+/// A YAML top-level key is a line that starts at column 0 (no leading
+/// whitespace), is not a comment, and contains `:` after the key name.
+///
+/// Returns `(start_byte_inclusive, end_byte_exclusive)` or `None` if not found.
+fn find_yaml_section_range(raw: &str, section_key: &str) -> Option<(usize, usize)> {
+    let target = format!("{}:", section_key);
+    let mut section_start = None;
+    let mut offset = 0;
+
+    for line in raw.split('\n') {
+        if section_start.is_none() && is_top_level_key_line(line) && line.starts_with(&target) {
+            // Verify exact match: after "key:" must be whitespace or EOL
+            let after_target = &line[target.len()..];
+            if after_target.is_empty()
+                || after_target.starts_with(' ')
+                || after_target.starts_with('\t')
+                || after_target.starts_with('\r')
+            {
+                section_start = Some(offset);
+            }
+        } else if section_start.is_some() && is_top_level_key_line(line) {
+            // Found the next top-level key — this is the end of our section
+            return Some((section_start.unwrap(), offset));
+        }
+        offset += line.len() + 1; // +1 for the \n
+    }
+
+    // Section extends to end of file
+    section_start.map(|start| (start, raw.len()))
+}
+
+/// Serialize a section key + value into a YAML fragment like:
+///
+/// ```yaml
+/// model:
+///   default: "anthropic/claude-opus-4-7"
+///   provider: "openrouter"
+/// ```
+fn serialize_yaml_section(key: &str, value: &serde_yaml::Value) -> Result<String, AppError> {
+    let mut section = serde_yaml::Mapping::new();
+    section.insert(serde_yaml::Value::String(key.to_string()), value.clone());
+    let yaml_str = serde_yaml::to_string(&serde_yaml::Value::Mapping(section))
+        .map_err(|e| AppError::Config(format!("Failed to serialize YAML section '{key}': {e}")))?;
+    Ok(yaml_str)
+}
+
+/// Replace a YAML section in raw text, or append it if not found.
+fn replace_yaml_section(
+    raw: &str,
+    section_key: &str,
+    value: &serde_yaml::Value,
+) -> Result<String, AppError> {
+    let serialized = serialize_yaml_section(section_key, value)?;
+
+    if let Some((start, end)) = find_yaml_section_range(raw, section_key) {
+        let mut result = String::with_capacity(raw.len());
+        result.push_str(&raw[..start]);
+        result.push_str(&serialized);
+        // Ensure proper separation between sections
+        let remainder = &raw[end..];
+        if !serialized.ends_with('\n') && !remainder.is_empty() && !remainder.starts_with('\n') {
+            result.push('\n');
+        }
+        result.push_str(remainder);
+        Ok(result)
+    } else {
+        // Section not found — append at end
+        let mut result = raw.to_string();
+        if !result.is_empty() && !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push_str(&serialized);
+        if !result.ends_with('\n') {
+            result.push('\n');
+        }
+        Ok(result)
+    }
+}
+
+// ============================================================================
+// Backup & Cleanup
+// ============================================================================
+
+fn create_hermes_backup(source: &str) -> Result<PathBuf, AppError> {
+    let backup_dir = get_app_config_dir().join("backups").join("hermes");
+    fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+
+    let base_id = format!("hermes_{}", Local::now().format("%Y%m%d_%H%M%S"));
+    let mut filename = format!("{base_id}.yaml");
+    let mut backup_path = backup_dir.join(&filename);
+    let mut counter = 1;
+
+    while backup_path.exists() {
+        filename = format!("{base_id}_{counter}.yaml");
+        backup_path = backup_dir.join(&filename);
+        counter += 1;
+    }
+
+    atomic_write(&backup_path, source.as_bytes())?;
+    cleanup_hermes_backups(&backup_dir)?;
+    Ok(backup_path)
+}
+
+fn cleanup_hermes_backups(dir: &Path) -> Result<(), AppError> {
+    let retain = effective_backup_retain_count();
+    let mut entries = fs::read_dir(dir)
+        .map_err(|e| AppError::io(dir, e))?
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            entry
+                .path()
+                .extension()
+                .map(|ext| ext == "yaml" || ext == "yml")
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+
+    if entries.len() <= retain {
+        return Ok(());
+    }
+
+    entries.sort_by_key(|entry| entry.metadata().and_then(|m| m.modified()).ok());
+    let remove_count = entries.len().saturating_sub(retain);
+    for entry in entries.into_iter().take(remove_count) {
+        if let Err(err) = fs::remove_file(entry.path()) {
+            log::warn!(
+                "Failed to remove old Hermes config backup {}: {err}",
+                entry.path().display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// High-level Write Helper
+// ============================================================================
+
+/// Write a single top-level YAML section to config.yaml using section-level replacement.
+///
+/// This preserves comments and unrelated sections while only modifying the
+/// target section.
+fn write_yaml_section_to_config(
+    section_key: &str,
+    value: &serde_yaml::Value,
+) -> Result<HermesWriteOutcome, AppError> {
+    let _guard = hermes_write_lock().lock()?;
+    write_yaml_section_to_config_locked(section_key, value)
+}
+
+/// Inner write helper — caller must already hold the write lock.
+fn write_yaml_section_to_config_locked(
+    section_key: &str,
+    value: &serde_yaml::Value,
+) -> Result<HermesWriteOutcome, AppError> {
+    let config_path = get_hermes_config_path();
+    let raw = if config_path.exists() {
+        fs::read_to_string(&config_path).map_err(|e| AppError::io(&config_path, e))?
+    } else {
+        String::new()
+    };
+
+    let new_raw = replace_yaml_section(&raw, section_key, value)?;
+
+    if new_raw == raw {
+        return Ok(HermesWriteOutcome::default());
+    }
+
+    let backup_path = if !raw.is_empty() {
+        Some(create_hermes_backup(&raw)?)
+    } else {
+        None
+    };
+
+    if let Some(parent) = config_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+
+    atomic_write(&config_path, new_raw.as_bytes())?;
+
+    log::debug!(
+        "Hermes config section '{}' written to {:?}",
+        section_key,
+        config_path
+    );
+    Ok(HermesWriteOutcome {
+        backup_path: backup_path.map(|p| p.display().to_string()),
+    })
+}
+
+// ============================================================================
+// Provider Functions
+// ============================================================================
+
+/// Convert a provider's `models` field from a UI-friendly array to the YAML
+/// dict shape that Hermes expects.
+///
+/// Input (from CC Switch UI / database):
+/// ```json
+/// "models": [{ "id": "foo", "context_length": 200000 }, { "id": "bar" }]
+/// ```
+///
+/// Output (what we write to YAML):
+/// ```json
+/// "models": { "foo": { "context_length": 200000 }, "bar": {} }
+/// ```
+///
+/// Entries with a missing or empty `id` are dropped. The top-level `id` key
+/// is stripped from each value since it now lives on the parent as the map
+/// key. Insertion order is preserved (serde_json uses IndexMap under the
+/// `preserve_order` feature).
+fn models_array_to_dict(array: Vec<serde_json::Value>) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for item in array {
+        let serde_json::Value::Object(mut obj) = item else {
+            continue;
+        };
+        let Some(id) = obj
+            .remove("id")
+            .and_then(|v| v.as_str().map(|s| s.trim().to_string()))
+            .filter(|s| !s.is_empty())
+        else {
+            continue;
+        };
+        map.insert(id, serde_json::Value::Object(obj));
+    }
+    serde_json::Value::Object(map)
+}
+
+/// Inverse of [`models_array_to_dict`]. Converts the YAML dict shape back to
+/// the UI-friendly ordered array, re-injecting `id` as an object field.
+fn models_dict_to_array(dict: serde_json::Map<String, serde_json::Value>) -> serde_json::Value {
+    let mut out = Vec::with_capacity(dict.len());
+    for (id, value) in dict {
+        let mut obj = match value {
+            serde_json::Value::Object(obj) => obj,
+            serde_json::Value::Null => serde_json::Map::new(),
+            other => {
+                log::warn!("Unexpected Hermes model entry for '{id}': {other:?}, skipping");
+                continue;
+            }
+        };
+        obj.insert("id".to_string(), serde_json::Value::String(id));
+        out.push(serde_json::Value::Object(obj));
+    }
+    serde_json::Value::Array(out)
+}
+
+/// Rewrite historical camelCase keys to Hermes' snake_case schema.
+///
+/// Older DeepLink import paths emitted `baseUrl` / `apiKey` / `apiMode` /
+/// `maxTokens` / `contextLength`, which do not belong to Hermes'
+/// `_VALID_CUSTOM_PROVIDER_FIELDS` set. Writing those raw to YAML silently
+/// poisons `custom_providers:` entries. This sanitiser runs defensively on
+/// every `set_provider` call so stored data heals on the next activation;
+/// unknown keys pass through untouched to keep forward-compat with new
+/// Hermes fields (e.g. `request_timeout_seconds`).
+fn sanitize_hermes_provider_keys(config: &mut serde_json::Value) {
+    const KEY_ALIASES: &[(&str, &str)] = &[
+        ("baseUrl", "base_url"),
+        ("apiKey", "api_key"),
+        ("apiMode", "api_mode"),
+        ("maxTokens", "max_tokens"),
+        ("contextLength", "context_length"),
+    ];
+    // Legacy DeepLink emitted `api: "openai-completions"` which is neither a
+    // Hermes field nor mappable to `api_mode`. `_cc_source` / `provider_key`
+    // are UI-only markers injected on read — they must never reach YAML.
+    const LEGACY_FIELDS_TO_DROP: &[&str] = &["api", PROVIDER_SOURCE_FIELD, "provider_key"];
+
+    let Some(obj) = config.as_object_mut() else {
+        return;
+    };
+
+    for (from, to) in KEY_ALIASES {
+        if let Some(val) = obj.remove(*from) {
+            // snake_case wins when both are present; stale camelCase is dropped.
+            obj.entry((*to).to_string()).or_insert(val);
+        }
+    }
+
+    for field in LEGACY_FIELDS_TO_DROP {
+        obj.remove(*field);
+    }
+}
+
+/// If `config.models` is a JSON array, convert it in-place to the dict shape.
+/// No-op when `models` is absent or already a dict.
+fn normalize_provider_models_for_write(config: &mut serde_json::Value) {
+    let Some(obj) = config.as_object_mut() else {
+        return;
+    };
+    let Some(models_val) = obj.get_mut("models") else {
+        return;
+    };
+    if models_val.is_array() {
+        let taken = std::mem::take(models_val);
+        if let serde_json::Value::Array(arr) = taken {
+            *models_val = models_array_to_dict(arr);
+        }
+    }
+}
+
+/// If `config.models` is a JSON dict, convert it in-place to the ordered array
+/// shape. No-op when `models` is absent or already an array.
+fn denormalize_provider_models_for_read(config: &mut serde_json::Value) {
+    let Some(obj) = config.as_object_mut() else {
+        return;
+    };
+    let Some(models_val) = obj.get_mut("models") else {
+        return;
+    };
+    if models_val.is_object() {
+        let taken = std::mem::take(models_val);
+        if let serde_json::Value::Object(map) = taken {
+            *models_val = models_dict_to_array(map);
+        }
+    }
+}
+
+/// Marker field injected on provider payloads sourced from Hermes v12+
+/// `providers:` dict. CC Switch treats those as read-only — writes have to
+/// go through Hermes' own Web UI to keep its overlay semantics intact.
+pub const PROVIDER_SOURCE_FIELD: &str = "_cc_source";
+pub const PROVIDER_SOURCE_CUSTOM_LIST: &str = "custom_providers";
+pub const PROVIDER_SOURCE_DICT: &str = "providers_dict";
+
+/// Normalize a single entry from the v12+ `providers:` dict into the same
+/// JSON shape that `custom_providers:` list entries take, mirroring upstream
+/// `_normalize_custom_provider_entry` (hermes_cli/config.py).
+///
+/// Returns `None` when the entry is not a mapping or lacks any usable name.
+fn normalize_providers_dict_entry(
+    key: &str,
+    entry: &serde_yaml::Value,
+) -> Result<Option<serde_json::Value>, AppError> {
+    if !entry.is_mapping() {
+        return Ok(None);
+    }
+    let mut json_val = yaml_to_json(entry)?;
+    let Some(obj) = json_val.as_object_mut() else {
+        return Ok(None);
+    };
+    // Upstream prefers an explicit `name` when present, falling back to the
+    // dict key. Always round-trip it to a trimmed non-empty string.
+    let resolved_name = obj
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| key.trim().to_string());
+    if resolved_name.is_empty() {
+        return Ok(None);
+    }
+    obj.insert("name".to_string(), serde_json::json!(resolved_name));
+    obj.insert("provider_key".to_string(), serde_json::json!(key));
+    obj.insert(
+        PROVIDER_SOURCE_FIELD.to_string(),
+        serde_json::json!(PROVIDER_SOURCE_DICT),
+    );
+    Ok(Some(json_val))
+}
+
+/// Collect provider entries living under the v12+ `providers:` dict.
+fn read_providers_dict_entries(config: &serde_yaml::Value) -> Vec<(String, serde_json::Value)> {
+    let Some(mapping) = config.get("providers").and_then(|v| v.as_mapping()) else {
+        return Vec::new();
+    };
+    let mut out = Vec::with_capacity(mapping.len());
+    for (k, v) in mapping {
+        let Some(key_str) = k.as_str().map(str::trim).filter(|s| !s.is_empty()) else {
+            continue;
+        };
+        match normalize_providers_dict_entry(key_str, v) {
+            Ok(Some(entry)) => {
+                let name = entry
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .unwrap_or(key_str)
+                    .to_string();
+                out.push((name, entry));
+            }
+            Ok(None) => {
+                log::debug!("Skipping Hermes providers['{key_str}']: not a mapping");
+            }
+            Err(e) => {
+                log::warn!("Failed to normalize Hermes providers['{key_str}']: {e}");
+            }
+        }
+    }
+    out
+}
+
+/// Get all providers as a JSON map keyed by provider name.
+///
+/// Unions two on-disk sources, matching upstream `get_compatible_custom_providers`:
+/// - `custom_providers:` list entries (writable by CC Switch)
+/// - `providers:` dict entries (v12+ schema, surfaced read-only with
+///   `_cc_source = "providers_dict"` so the UI can disable edit/delete)
+///
+/// When a name appears in both, the list entry wins (upstream dedup order),
+/// keeping CC Switch free to edit it. Models are denormalized from the YAML
+/// dict shape to the UI-friendly ordered array.
+pub fn get_providers() -> Result<serde_json::Map<String, serde_json::Value>, AppError> {
+    let config = read_hermes_config()?;
+    let mut map = serde_json::Map::new();
+
+    if let Some(seq) = config.get("custom_providers").and_then(|v| v.as_sequence()) {
+        for item in seq {
+            if let Some(name) = item.get("name").and_then(|n| n.as_str()) {
+                match yaml_to_json(item) {
+                    Ok(mut json_val) => {
+                        // Heal legacy camelCase records (from older DeepLink
+                        // imports) before the UI sees them, so editing doesn't
+                        // reveal stale `baseUrl` / `apiKey` fields.
+                        sanitize_hermes_provider_keys(&mut json_val);
+                        denormalize_provider_models_for_read(&mut json_val);
+                        if let Some(obj) = json_val.as_object_mut() {
+                            obj.insert(
+                                PROVIDER_SOURCE_FIELD.to_string(),
+                                serde_json::json!(PROVIDER_SOURCE_CUSTOM_LIST),
+                            );
+                        }
+                        map.insert(name.to_string(), json_val);
+                    }
+                    Err(e) => {
+                        log::warn!("Failed to convert Hermes provider '{name}' to JSON: {e}");
+                    }
+                }
+            }
+        }
+    }
+
+    for (name, mut entry) in read_providers_dict_entries(&config) {
+        if map.contains_key(&name) {
+            continue; // list wins over dict on duplicate names
+        }
+        denormalize_provider_models_for_read(&mut entry);
+        map.insert(name, entry);
+    }
+
+    Ok(map)
+}
+
+/// Reject writes that would target a dict-only overlay entry.
+///
+/// `verb` is inlined into the user-facing error so both "edit" and "remove"
+/// callers can share one implementation.
+fn ensure_provider_writable(
+    config: &serde_yaml::Value,
+    name: &str,
+    verb: &str,
+) -> Result<(), AppError> {
+    if is_dict_only_provider(config, name) {
+        return Err(AppError::Config(format!(
+            "Provider '{name}' is managed by Hermes' 'providers:' dict — {verb} via Hermes Web UI"
+        )));
+    }
+    Ok(())
+}
+
+/// True when `name` appears in `providers:` dict but not in `custom_providers:`
+/// list — i.e. it is a read-only overlay CC Switch must not touch.
+fn is_dict_only_provider(config: &serde_yaml::Value, name: &str) -> bool {
+    let list_has = config
+        .get("custom_providers")
+        .and_then(|v| v.as_sequence())
+        .map(|seq| {
+            seq.iter()
+                .any(|item| item.get("name").and_then(|n| n.as_str()) == Some(name))
+        })
+        .unwrap_or(false);
+    if list_has {
+        return false;
+    }
+    config
+        .get("providers")
+        .and_then(|v| v.as_mapping())
+        .map(|m| {
+            m.iter().any(|(k, v)| {
+                let key_matches = k.as_str() == Some(name);
+                let name_matches = v
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .map(|s| s == name)
+                    .unwrap_or(false);
+                (key_matches || name_matches) && v.is_mapping()
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// Get a single custom provider by name.
+pub fn get_provider(name: &str) -> Result<Option<serde_json::Value>, AppError> {
+    Ok(get_providers()?.get(name).cloned())
+}
+
+/// Set (upsert) a custom provider by name.
+///
+/// Upserts into the `custom_providers:` YAML sequence (matched by `name`).
+/// The entry includes:
+///   - `name:` field matching the provider id
+///   - singular `model:` field set to the first model id from the `models:`
+///     dict — the Hermes runtime and `/model` picker both read this field
+///     (runtime_provider.py reads it via `_normalize_custom_provider_entry`;
+///     main.py:1436/1450 uses it for picker hints)
+///   - plural `models:` dict carrying per-model `context_length` etc.
+///
+/// The entire read-modify-write is done under the write lock to prevent
+/// TOCTOU races.
+pub fn set_provider(
+    name: &str,
+    provider_config: serde_json::Value,
+) -> Result<HermesWriteOutcome, AppError> {
+    let _guard = hermes_write_lock().lock()?;
+
+    let config = read_hermes_config()?;
+    ensure_provider_writable(&config, name, "edit")?;
+    let mut providers: Vec<serde_yaml::Value> = config
+        .get("custom_providers")
+        .and_then(|v| v.as_sequence())
+        .cloned()
+        .unwrap_or_default();
+
+    // Rewrite any historical camelCase keys (e.g. from older DeepLink imports)
+    // before touching models / YAML — avoids writing non-Hermes fields back.
+    let mut normalized = provider_config;
+    sanitize_hermes_provider_keys(&mut normalized);
+
+    // Normalize `models` from UI array to Hermes YAML dict before serializing.
+    normalize_provider_models_for_write(&mut normalized);
+
+    // Extract the first model id (now a key in the normalized dict) so we can
+    // propagate it to the singular `model:` field Hermes reads.
+    let first_model_id = normalized
+        .get("models")
+        .and_then(|v| v.as_object())
+        .and_then(|obj| obj.keys().next())
+        .cloned();
+
+    let mut yaml_val: serde_yaml::Value = json_to_yaml(&normalized)?;
+    if let serde_yaml::Value::Mapping(ref mut m) = yaml_val {
+        m.insert(
+            serde_yaml::Value::String("name".to_string()),
+            serde_yaml::Value::String(name.to_string()),
+        );
+        if let Some(model_id) = first_model_id {
+            m.insert(
+                serde_yaml::Value::String("model".to_string()),
+                serde_yaml::Value::String(model_id),
+            );
+        } else {
+            m.remove(serde_yaml::Value::String("model".to_string()));
+        }
+    }
+
+    if let Some(existing) = providers
+        .iter_mut()
+        .find(|p| p.get("name").and_then(|n| n.as_str()) == Some(name))
+    {
+        // Forward-compat: carry over any on-disk fields the UI payload didn't
+        // include. Hermes keeps evolving (e.g. `request_timeout_seconds`,
+        // `key_env`), and users may set those via Hermes Web UI — without
+        // this merge, a CC Switch edit to an unrelated field would silently
+        // strip them on write-back.
+        if let (Some(existing_map), serde_yaml::Value::Mapping(new_map)) =
+            (existing.as_mapping(), &mut yaml_val)
+        {
+            for (k, v) in existing_map {
+                new_map.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+        }
+        *existing = yaml_val;
+    } else {
+        providers.push(yaml_val);
+    }
+
+    let providers_value = serde_yaml::Value::Sequence(providers);
+    write_yaml_section_to_config_locked("custom_providers", &providers_value)
+}
+
+/// Remove a custom provider by name.
+///
+/// Filters out the matching entry from the `custom_providers:` sequence.
+/// No-op if the section is missing or no entry matches. The entire
+/// read-modify-write is done under the write lock to prevent TOCTOU races.
+pub fn remove_provider(name: &str) -> Result<HermesWriteOutcome, AppError> {
+    let _guard = hermes_write_lock().lock()?;
+    let config = read_hermes_config()?;
+
+    ensure_provider_writable(&config, name, "remove")?;
+
+    let mut providers: Vec<serde_yaml::Value> = config
+        .get("custom_providers")
+        .and_then(|v| v.as_sequence())
+        .cloned()
+        .unwrap_or_default();
+
+    let original_len = providers.len();
+    providers.retain(|p| p.get("name").and_then(|n| n.as_str()) != Some(name));
+    if providers.len() == original_len {
+        return Ok(HermesWriteOutcome::default());
+    }
+
+    let providers_value = serde_yaml::Value::Sequence(providers);
+    write_yaml_section_to_config_locked("custom_providers", &providers_value)
+}
+
+// ============================================================================
+// Model Config Functions
+// ============================================================================
+
+/// Get the `model` section as a typed config.
+pub fn get_model_config() -> Result<Option<HermesModelConfig>, AppError> {
+    let config = read_hermes_config()?;
+    let Some(model_value) = config.get("model") else {
+        return Ok(None);
+    };
+    let json_val = yaml_to_json(model_value)?;
+    let model = serde_json::from_value(json_val)
+        .map_err(|e| AppError::Config(format!("Failed to parse Hermes model config: {e}")))?;
+    Ok(Some(model))
+}
+
+/// Set the `model` section.
+pub fn set_model_config(model: &HermesModelConfig) -> Result<HermesWriteOutcome, AppError> {
+    let json_val =
+        serde_json::to_value(model).map_err(|e| AppError::JsonSerialize { source: e })?;
+    let yaml_val = json_to_yaml(&json_val)?;
+    write_yaml_section_to_config("model", &yaml_val)
+}
+
+/// Apply the top-level `model:` defaults when switching to a Hermes provider.
+///
+/// `model.provider` is **always** updated to the new provider id — without
+/// this, switching to a provider whose settings lack a `models` list would
+/// leave the runtime routing requests to the previously active provider.
+///
+/// `model.default` is only overwritten when the new provider declares at
+/// least one model; otherwise the previous default is preserved so users
+/// still have a runnable configuration (Hermes will surface a clear error
+/// if the default no longer belongs to the active provider).
+///
+/// Existing fields in `model:` (`context_length` / `max_tokens` / `base_url`
+/// / `extra`) are preserved via struct-update.
+pub fn apply_switch_defaults(
+    provider_id: &str,
+    settings_config: &serde_json::Value,
+) -> Result<HermesWriteOutcome, AppError> {
+    let first_model_id = settings_config
+        .get("models")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|m| m.get("id"))
+        .and_then(|id| id.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    let current = get_model_config()?.unwrap_or_default();
+    let merged = HermesModelConfig {
+        default: first_model_id.or(current.default.clone()),
+        provider: Some(provider_id.to_string()),
+        ..current
+    };
+    set_model_config(&merged)
+}
+
+// ============================================================================
+// MCP Section Access (for mcp/hermes.rs to use in Phase 4)
+// ============================================================================
+
+/// Get the `mcp_servers` section as a YAML Mapping.
+pub fn get_mcp_servers_yaml() -> Result<serde_yaml::Mapping, AppError> {
+    let config = read_hermes_config()?;
+    Ok(config
+        .get("mcp_servers")
+        .and_then(|v| v.as_mapping())
+        .cloned()
+        .unwrap_or_default())
+}
+
+/// Atomically read-modify-write the `mcp_servers` section under the write lock.
+///
+/// Prevents TOCTOU races when multiple sync operations run concurrently.
+pub fn update_mcp_servers_yaml<F>(updater: F) -> Result<(), AppError>
+where
+    F: FnOnce(&mut serde_yaml::Mapping) -> Result<(), AppError>,
+{
+    let _guard = hermes_write_lock().lock()?;
+    let config = read_hermes_config()?;
+    let mut servers = config
+        .get("mcp_servers")
+        .and_then(|v| v.as_mapping())
+        .cloned()
+        .unwrap_or_default();
+    updater(&mut servers)?;
+    let value = serde_yaml::Value::Mapping(servers);
+    write_yaml_section_to_config_locked("mcp_servers", &value)?;
+    Ok(())
+}
+
+// ============================================================================
+// YAML ↔ JSON Conversion Helpers
+// ============================================================================
+
+/// Convert a `serde_yaml::Value` to a `serde_json::Value`.
+pub(crate) fn yaml_to_json(yaml: &serde_yaml::Value) -> Result<serde_json::Value, AppError> {
+    // Serialize YAML value to string, then parse as JSON value.
+    // This handles all type mappings correctly.
+    let yaml_str = serde_yaml::to_string(yaml)
+        .map_err(|e| AppError::Config(format!("Failed to serialize YAML value: {e}")))?;
+    serde_yaml::from_str::<serde_json::Value>(&yaml_str)
+        .map_err(|e| AppError::Config(format!("Failed to convert YAML to JSON: {e}")))
+}
+
+/// Convert a `serde_json::Value` to a `serde_yaml::Value`.
+pub(crate) fn json_to_yaml(json: &serde_json::Value) -> Result<serde_yaml::Value, AppError> {
+    let json_str = serde_json::to_string(json)
+        .map_err(|e| AppError::Config(format!("Failed to serialize JSON value: {e}")))?;
+    serde_yaml::from_str(&json_str)
+        .map_err(|e| AppError::Config(format!("Failed to convert JSON to YAML: {e}")))
+}
+
+// ============================================================================
+// Memory Files (~/.hermes/memories/{MEMORY,USER}.md)
+// ============================================================================
+//
+// Hermes Agent persists two memory blobs on disk:
+//   - `MEMORY.md` — agent's personal notes, snapshotted into the system prompt
+//   - `USER.md`   — user profile, same treatment
+// Entries are separated by a `§` on its own line. Hermes' own Web UI only
+// exposes on/off toggles and character budgets — it has no content editor.
+// CC Switch fills that gap by reading/writing the whole file as a markdown
+// blob. Character budgets (`memory_char_limit`, `user_char_limit`) and enable
+// flags (`memory_enabled`, `user_profile_enabled`) live at the top level of
+// `config.yaml`; Hermes truncates over-budget content at load time.
+
+/// Which of Hermes' two memory files to operate on. Tauri deserializes this
+/// directly from the `"memory"` / `"user"` strings the frontend sends, so an
+/// unknown value is rejected at the IPC boundary instead of deep in the stack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MemoryKind {
+    Memory,
+    User,
+}
+
+impl MemoryKind {
+    fn filename(self) -> &'static str {
+        match self {
+            Self::Memory => "MEMORY.md",
+            Self::User => "USER.md",
+        }
+    }
+}
+
+fn memories_dir() -> PathBuf {
+    get_hermes_dir().join("memories")
+}
+
+/// Read a Hermes memory file as a markdown blob. Returns an empty string
+/// when the file doesn't exist yet (first-run case).
+pub fn read_memory(kind: MemoryKind) -> Result<String, AppError> {
+    let path = memories_dir().join(kind.filename());
+    match fs::read_to_string(&path) {
+        Ok(content) => Ok(content),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(e) => Err(AppError::io(&path, e)),
+    }
+}
+
+/// Atomically replace a Hermes memory file. `atomic_write` creates parent
+/// directories as needed, so `~/.hermes/memories/` is materialized on first
+/// write without a separate `create_dir_all` call.
+pub fn write_memory(kind: MemoryKind, content: &str) -> Result<(), AppError> {
+    let path = memories_dir().join(kind.filename());
+    atomic_write(&path, content.as_bytes())
+}
+
+/// Character budget + enable flags for the two memory blobs, as configured
+/// in Hermes' `config.yaml`. Defaults mirror `~/.hermes`'s own defaults so
+/// callers get a usable budget bar even before the user edits config.yaml.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HermesMemoryLimits {
+    pub memory: usize,
+    pub user: usize,
+    pub memory_enabled: bool,
+    pub user_enabled: bool,
+}
+
+impl Default for HermesMemoryLimits {
+    fn default() -> Self {
+        Self {
+            memory: 2200,
+            user: 1375,
+            memory_enabled: true,
+            user_enabled: true,
+        }
+    }
+}
+
+/// Toggle the on/off flag for one of Hermes' two memory blobs, preserving all
+/// other fields in the `memory:` section (character budgets, external provider
+/// settings, etc.). Hermes stores the user-profile toggle under
+/// `user_profile_enabled` (not `user_enabled`), so the mapping to on-disk keys
+/// lives here rather than leaking to callers.
+pub fn set_memory_enabled(kind: MemoryKind, enabled: bool) -> Result<HermesWriteOutcome, AppError> {
+    let _guard = hermes_write_lock().lock()?;
+    let config = read_hermes_config()?;
+
+    let mut memory = match config.get("memory") {
+        Some(serde_yaml::Value::Mapping(m)) => m.clone(),
+        _ => serde_yaml::Mapping::new(),
+    };
+
+    let key = match kind {
+        MemoryKind::Memory => "memory_enabled",
+        MemoryKind::User => "user_profile_enabled",
+    };
+    memory.insert(
+        serde_yaml::Value::String(key.to_string()),
+        serde_yaml::Value::Bool(enabled),
+    );
+
+    write_yaml_section_to_config_locked("memory", &serde_yaml::Value::Mapping(memory))
+}
+
+/// Read memory budgets + toggles from `config.yaml`. Missing/unparsable
+/// fields fall back to `HermesMemoryLimits::default()` rather than erroring,
+/// so an empty or partially-populated config still yields a usable UI.
+pub fn read_memory_limits() -> Result<HermesMemoryLimits, AppError> {
+    let mut out = HermesMemoryLimits::default();
+    let config = read_hermes_config()?;
+    let Some(memory) = config.get("memory") else {
+        return Ok(out);
+    };
+
+    if let Some(v) = memory.get("memory_char_limit").and_then(|v| v.as_u64()) {
+        out.memory = v as usize;
+    }
+    if let Some(v) = memory.get("user_char_limit").and_then(|v| v.as_u64()) {
+        out.user = v as usize;
+    }
+    if let Some(v) = memory.get("memory_enabled").and_then(|v| v.as_bool()) {
+        out.memory_enabled = v;
+    }
+    if let Some(v) = memory.get("user_profile_enabled").and_then(|v| v.as_bool()) {
+        out.user_enabled = v;
+    }
+
+    Ok(out)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::sync::{Mutex, OnceLock};
+
+    fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+    }
+
+    /// Run a test with an isolated temp home directory.
+    ///
+    fn with_test_home<T>(test_fn: impl FnOnce() -> T) -> T {
+        let _guard = test_guard();
+        let _settings_guard = crate::test_support::lock_test_home_and_settings();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::test_support::set_test_home_override(Some(tmp.path()));
+        crate::settings::reload_test_settings();
+        let result = test_fn();
+        crate::test_support::set_test_home_override(None);
+        crate::settings::reload_test_settings();
+        result
+    }
+
+    // ---- sanitize_hermes_provider_keys tests ----
+
+    #[test]
+    fn sanitize_rewrites_camel_case_aliases() {
+        let mut v = serde_json::json!({
+            "name": "test",
+            "baseUrl": "https://api.example.com",
+            "apiKey": "sk-123",
+            "apiMode": "chat_completions",
+            "maxTokens": 8192,
+            "contextLength": 200000,
+        });
+        sanitize_hermes_provider_keys(&mut v);
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.get("base_url").unwrap(), "https://api.example.com");
+        assert_eq!(obj.get("api_key").unwrap(), "sk-123");
+        assert_eq!(obj.get("api_mode").unwrap(), "chat_completions");
+        assert_eq!(obj.get("max_tokens").unwrap(), 8192);
+        assert_eq!(obj.get("context_length").unwrap(), 200000);
+        assert!(obj.get("baseUrl").is_none());
+        assert!(obj.get("apiKey").is_none());
+    }
+
+    #[test]
+    fn sanitize_drops_stale_duplicate_when_snake_case_exists() {
+        let mut v = serde_json::json!({
+            "baseUrl": "https://old.example.com",
+            "base_url": "https://new.example.com",
+        });
+        sanitize_hermes_provider_keys(&mut v);
+        let obj = v.as_object().unwrap();
+        // snake_case wins; stale camelCase is dropped
+        assert_eq!(obj.get("base_url").unwrap(), "https://new.example.com");
+        assert!(obj.get("baseUrl").is_none());
+    }
+
+    #[test]
+    fn sanitize_drops_legacy_api_field() {
+        let mut v = serde_json::json!({
+            "base_url": "https://api.example.com",
+            "api": "openai-completions",
+        });
+        sanitize_hermes_provider_keys(&mut v);
+        let obj = v.as_object().unwrap();
+        assert!(obj.get("api").is_none(), "legacy 'api' key must be removed");
+        assert!(obj.get("base_url").is_some());
+    }
+
+    #[test]
+    fn sanitize_preserves_unknown_fields() {
+        let mut v = serde_json::json!({
+            "base_url": "https://api.example.com",
+            "request_timeout_seconds": 300,
+            "rate_limit_delay": 1.5,
+        });
+        sanitize_hermes_provider_keys(&mut v);
+        let obj = v.as_object().unwrap();
+        // Forward-compat: Hermes' own new fields pass through untouched
+        assert_eq!(obj.get("request_timeout_seconds").unwrap(), 300);
+        assert_eq!(obj.get("rate_limit_delay").unwrap(), 1.5);
+    }
+
+    #[test]
+    fn sanitize_noop_on_non_object() {
+        let mut v = serde_json::json!(["not", "an", "object"]);
+        sanitize_hermes_provider_keys(&mut v);
+        assert!(v.is_array());
+    }
+
+    // ---- find_yaml_section_range tests ----
+
+    #[test]
+    fn find_section_in_multi_section_yaml() {
+        let yaml = "\
+model:
+  default: gpt-4
+  provider: openai
+agent:
+  max_turns: 10
+custom_providers:
+  - name: foo
+";
+        let (start, end) = find_yaml_section_range(yaml, "agent").unwrap();
+        let section = &yaml[start..end];
+        assert!(section.starts_with("agent:"));
+        assert!(section.contains("max_turns"));
+        assert!(!section.contains("custom_providers"));
+    }
+
+    #[test]
+    fn find_section_at_end_of_file() {
+        let yaml = "\
+model:
+  default: gpt-4
+agent:
+  max_turns: 10
+";
+        let (start, end) = find_yaml_section_range(yaml, "agent").unwrap();
+        let section = &yaml[start..end];
+        assert!(section.starts_with("agent:"));
+        assert!(section.contains("max_turns"));
+        assert_eq!(end, yaml.len());
+    }
+
+    #[test]
+    fn find_section_not_found() {
+        let yaml = "\
+model:
+  default: gpt-4
+";
+        assert!(find_yaml_section_range(yaml, "agent").is_none());
+    }
+
+    #[test]
+    fn find_section_with_comments_between() {
+        let yaml = "\
+model:
+  default: gpt-4
+
+# This is a comment
+  # indented comment
+
+agent:
+  max_turns: 10
+";
+        // model section should span from start to "agent:"
+        let (start, end) = find_yaml_section_range(yaml, "model").unwrap();
+        let section = &yaml[start..end];
+        assert!(section.starts_with("model:"));
+        // Comments and blank lines between sections are included in the prior section
+        assert!(section.contains("# This is a comment"));
+    }
+
+    #[test]
+    fn find_section_with_empty_lines() {
+        let yaml = "\
+model:
+  default: gpt-4
+
+agent:
+  max_turns: 10
+";
+        let (start, end) = find_yaml_section_range(yaml, "model").unwrap();
+        let section = &yaml[start..end];
+        assert!(section.starts_with("model:"));
+        // Empty lines don't terminate a section
+        assert!(section.contains('\n'));
+    }
+
+    #[test]
+    fn find_section_does_not_match_substring_key() {
+        let yaml = "\
+model_extra:
+  foo: bar
+model:
+  default: gpt-4
+";
+        let (start, _end) = find_yaml_section_range(yaml, "model").unwrap();
+        let section = &yaml[start..];
+        // Should match "model:", not "model_extra:"
+        assert!(section.starts_with("model:"));
+        assert!(!section.starts_with("model_extra:"));
+    }
+
+    // ---- replace_yaml_section tests ----
+
+    #[test]
+    fn replace_existing_section() {
+        let yaml = "\
+model:
+  default: gpt-4
+  provider: openai
+agent:
+  max_turns: 10
+";
+        let new_model = serde_yaml::Value::Mapping({
+            let mut m = serde_yaml::Mapping::new();
+            m.insert(
+                serde_yaml::Value::String("default".to_string()),
+                serde_yaml::Value::String("claude-opus-4-7".to_string()),
+            );
+            m.insert(
+                serde_yaml::Value::String("provider".to_string()),
+                serde_yaml::Value::String("anthropic".to_string()),
+            );
+            m
+        });
+
+        let result = replace_yaml_section(yaml, "model", &new_model).unwrap();
+        // The result should still contain the agent section
+        assert!(result.contains("agent:"));
+        assert!(result.contains("max_turns"));
+        // And the model section should be updated
+        assert!(result.contains("claude-opus-4-7"));
+        assert!(result.contains("anthropic"));
+        assert!(!result.contains("gpt-4"));
+        assert!(!result.contains("openai"));
+    }
+
+    #[test]
+    fn append_new_section() {
+        let yaml = "\
+model:
+  default: gpt-4
+";
+        let new_agent = serde_yaml::Value::Mapping({
+            let mut m = serde_yaml::Mapping::new();
+            m.insert(
+                serde_yaml::Value::String("max_turns".to_string()),
+                serde_yaml::Value::Number(serde_yaml::Number::from(50)),
+            );
+            m
+        });
+
+        let result = replace_yaml_section(yaml, "agent", &new_agent).unwrap();
+        assert!(result.contains("model:"));
+        assert!(result.contains("gpt-4"));
+        assert!(result.contains("agent:"));
+        assert!(result.contains("max_turns: 50"));
+    }
+
+    #[test]
+    fn replace_section_in_empty_file() {
+        let yaml = "";
+        let new_model = serde_yaml::Value::Mapping({
+            let mut m = serde_yaml::Mapping::new();
+            m.insert(
+                serde_yaml::Value::String("default".to_string()),
+                serde_yaml::Value::String("gpt-4".to_string()),
+            );
+            m
+        });
+
+        let result = replace_yaml_section(yaml, "model", &new_model).unwrap();
+        assert!(result.contains("model:"));
+        assert!(result.contains("gpt-4"));
+        assert!(result.ends_with('\n'));
+    }
+
+    // ---- Provider CRUD via mock config ----
+
+    #[test]
+    #[serial]
+    fn provider_crud_roundtrip() {
+        with_test_home(|| {
+            // Initially no providers
+            let providers = get_providers().unwrap();
+            assert!(providers.is_empty());
+
+            // Add a provider
+            let config = serde_json::json!({
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "sk-or-test"
+            });
+            set_provider("openrouter", config).unwrap();
+
+            let providers = get_providers().unwrap();
+            assert_eq!(providers.len(), 1);
+            assert!(providers.contains_key("openrouter"));
+
+            let provider = get_provider("openrouter").unwrap().unwrap();
+            assert_eq!(provider["base_url"], "https://openrouter.ai/api/v1");
+            assert_eq!(provider["name"], "openrouter");
+
+            // Update the provider
+            let config2 = serde_json::json!({
+                "base_url": "https://openrouter.ai/api/v2",
+                "api_key": "sk-or-updated"
+            });
+            set_provider("openrouter", config2).unwrap();
+
+            let provider = get_provider("openrouter").unwrap().unwrap();
+            assert_eq!(provider["base_url"], "https://openrouter.ai/api/v2");
+
+            // Remove the provider
+            remove_provider("openrouter").unwrap();
+            let providers = get_providers().unwrap();
+            assert!(providers.is_empty());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn set_provider_preserves_unknown_fields_on_update() {
+        // Hermes keeps adding provider-level fields (e.g.
+        // `request_timeout_seconds`, `key_env`). Users may set those via
+        // Hermes Web UI; a later CC Switch edit must not strip them — set_provider
+        // carries over any existing on-disk fields that the UI payload didn't
+        // submit.
+        with_test_home(|| {
+            let yaml = "\
+custom_providers:
+  - name: acme
+    base_url: https://old.example.com
+    api_key: sk-old
+    request_timeout_seconds: 300
+    key_env: ACME_API_KEY
+";
+            let config_path = get_hermes_config_path();
+            fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+            fs::write(&config_path, yaml).unwrap();
+
+            let update = serde_json::json!({
+                "base_url": "https://new.example.com",
+                "api_key": "sk-new"
+            });
+            set_provider("acme", update).unwrap();
+
+            let provider = get_provider("acme").unwrap().unwrap();
+            assert_eq!(provider["base_url"], "https://new.example.com");
+            assert_eq!(provider["api_key"], "sk-new");
+            assert_eq!(provider["request_timeout_seconds"], 300);
+            assert_eq!(provider["key_env"], "ACME_API_KEY");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn get_providers_surfaces_providers_dict_as_read_only() {
+        with_test_home(|| {
+            let yaml = "\
+_config_version: 19
+custom_providers:
+  - name: mine
+    base_url: https://mine.example.com
+    api_key: sk-mine
+providers:
+  anthropic:
+    base_url: https://api.anthropic.com
+    api_key: sk-ant
+    model: claude-opus-4.6
+  ollama-local:
+    base_url: http://localhost:11434/v1
+    request_timeout_seconds: 300
+";
+            let config_path = get_hermes_config_path();
+            fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+            fs::write(&config_path, yaml).unwrap();
+
+            let providers = get_providers().unwrap();
+            assert_eq!(providers.len(), 3);
+
+            let mine = providers.get("mine").unwrap();
+            assert_eq!(mine[PROVIDER_SOURCE_FIELD], PROVIDER_SOURCE_CUSTOM_LIST);
+
+            let anthropic = providers.get("anthropic").unwrap();
+            assert_eq!(anthropic[PROVIDER_SOURCE_FIELD], PROVIDER_SOURCE_DICT);
+            assert_eq!(anthropic["provider_key"], "anthropic");
+            assert_eq!(anthropic["base_url"], "https://api.anthropic.com");
+
+            let ollama = providers.get("ollama-local").unwrap();
+            assert_eq!(ollama[PROVIDER_SOURCE_FIELD], PROVIDER_SOURCE_DICT);
+            // Forward-compat fields from the dict pass through untouched
+            assert_eq!(ollama["request_timeout_seconds"], 300);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn get_providers_list_wins_on_name_collision() {
+        with_test_home(|| {
+            let yaml = "\
+_config_version: 19
+custom_providers:
+  - name: shared
+    base_url: https://writable.example.com
+providers:
+  shared:
+    base_url: https://overlay.example.com
+";
+            let config_path = get_hermes_config_path();
+            fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+            fs::write(&config_path, yaml).unwrap();
+
+            let providers = get_providers().unwrap();
+            assert_eq!(providers.len(), 1);
+            let shared = providers.get("shared").unwrap();
+            assert_eq!(shared["base_url"], "https://writable.example.com");
+            assert_eq!(shared[PROVIDER_SOURCE_FIELD], PROVIDER_SOURCE_CUSTOM_LIST);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn set_provider_rejects_dict_only_entries() {
+        with_test_home(|| {
+            let yaml = "\
+_config_version: 19
+providers:
+  anthropic:
+    base_url: https://api.anthropic.com
+    model: claude-opus-4.6
+";
+            let config_path = get_hermes_config_path();
+            fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+            fs::write(&config_path, yaml).unwrap();
+
+            let update = serde_json::json!({ "base_url": "https://hacked.example.com" });
+            let err = set_provider("anthropic", update).unwrap_err();
+            assert!(
+                format!("{err}").contains("providers:"),
+                "error message should point user at providers dict: {err}"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn remove_provider_rejects_dict_only_entries() {
+        with_test_home(|| {
+            let yaml = "\
+_config_version: 19
+providers:
+  anthropic:
+    base_url: https://api.anthropic.com
+";
+            let config_path = get_hermes_config_path();
+            fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+            fs::write(&config_path, yaml).unwrap();
+
+            assert!(remove_provider("anthropic").is_err());
+        });
+    }
+
+    #[test]
+    fn sanitize_strips_ui_only_markers() {
+        let mut v = serde_json::json!({
+            "base_url": "https://api.example.com",
+            "_cc_source": "providers_dict",
+            "provider_key": "anthropic",
+        });
+        sanitize_hermes_provider_keys(&mut v);
+        let obj = v.as_object().unwrap();
+        assert!(obj.get("_cc_source").is_none());
+        assert!(obj.get("provider_key").is_none());
+        assert!(obj.get("base_url").is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn get_providers_heals_legacy_camel_case_on_read() {
+        // A DB may still hold records from older DeepLink imports that wrote
+        // camelCase fields into `settings_config`. The read path must surface
+        // them in Hermes' native snake_case so UI editors aren't lying to users.
+        with_test_home(|| {
+            let yaml = "\
+custom_providers:
+  - name: legacy
+    baseUrl: https://legacy.example.com
+    apiKey: sk-legacy
+    apiMode: chat_completions
+    api: openai-completions
+";
+            let config_path = get_hermes_config_path();
+            fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+            fs::write(&config_path, yaml).unwrap();
+
+            let provider = get_provider("legacy").unwrap().unwrap();
+            assert_eq!(provider["base_url"], "https://legacy.example.com");
+            assert_eq!(provider["api_key"], "sk-legacy");
+            assert_eq!(provider["api_mode"], "chat_completions");
+            assert!(provider.get("baseUrl").is_none());
+            assert!(provider.get("apiKey").is_none());
+            assert!(provider.get("api").is_none());
+        });
+    }
+
+    // ---- Model config tests ----
+
+    #[test]
+    #[serial]
+    fn model_config_roundtrip() {
+        with_test_home(|| {
+            // Initially none
+            assert!(get_model_config().unwrap().is_none());
+
+            let model = HermesModelConfig {
+                default: Some("anthropic/claude-opus-4-7".to_string()),
+                provider: Some("openrouter".to_string()),
+                base_url: Some("https://openrouter.ai/api/v1".to_string()),
+                context_length: Some(200000),
+                max_tokens: None,
+                extra: HashMap::new(),
+            };
+            set_model_config(&model).unwrap();
+
+            let read_model = get_model_config().unwrap().unwrap();
+            assert_eq!(
+                read_model.default.as_deref(),
+                Some("anthropic/claude-opus-4-7")
+            );
+            assert_eq!(read_model.provider.as_deref(), Some("openrouter"));
+            assert_eq!(read_model.context_length, Some(200000));
+        });
+    }
+
+    // ---- yaml_to_json / json_to_yaml ----
+
+    #[test]
+    fn yaml_json_conversion_roundtrip() {
+        let json = serde_json::json!({
+            "name": "test",
+            "count": 42,
+            "nested": {
+                "flag": true
+            }
+        });
+        let yaml = json_to_yaml(&json).unwrap();
+        let back = yaml_to_json(&yaml).unwrap();
+        assert_eq!(json, back);
+    }
+
+    // ---- models array ↔ dict transforms ----
+
+    #[test]
+    fn models_array_to_dict_strips_id_and_preserves_order() {
+        let arr = vec![
+            serde_json::json!({ "id": "foo", "context_length": 100 }),
+            serde_json::json!({ "id": "bar", "max_tokens": 2000 }),
+            serde_json::json!({ "id": "baz" }),
+        ];
+        let dict = models_array_to_dict(arr);
+        let obj = dict.as_object().unwrap();
+        let keys: Vec<&String> = obj.keys().collect();
+        assert_eq!(keys, vec!["foo", "bar", "baz"]);
+        assert_eq!(obj["foo"]["context_length"], 100);
+        assert_eq!(obj["bar"]["max_tokens"], 2000);
+        assert!(obj["baz"].as_object().unwrap().is_empty());
+        // id must not leak into values
+        assert!(obj["foo"].get("id").is_none());
+    }
+
+    #[test]
+    fn models_array_to_dict_drops_empty_and_missing_ids() {
+        let arr = vec![
+            serde_json::json!({ "id": "", "context_length": 1 }),
+            serde_json::json!({ "id": "   ", "context_length": 2 }),
+            serde_json::json!({ "context_length": 3 }),
+            serde_json::json!({ "id": "kept" }),
+        ];
+        let dict = models_array_to_dict(arr);
+        let obj = dict.as_object().unwrap();
+        assert_eq!(obj.len(), 1);
+        assert!(obj.contains_key("kept"));
+    }
+
+    #[test]
+    fn models_dict_to_array_reinjects_id_and_preserves_order() {
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "alpha".to_string(),
+            serde_json::json!({ "context_length": 10 }),
+        );
+        map.insert("beta".to_string(), serde_json::json!({ "max_tokens": 20 }));
+        map.insert("gamma".to_string(), serde_json::Value::Null);
+        let arr = models_dict_to_array(map);
+        let list = arr.as_array().unwrap();
+        assert_eq!(list.len(), 3);
+        assert_eq!(list[0]["id"], "alpha");
+        assert_eq!(list[0]["context_length"], 10);
+        assert_eq!(list[1]["id"], "beta");
+        assert_eq!(list[2]["id"], "gamma");
+    }
+
+    #[test]
+    #[serial]
+    fn provider_with_models_array_writes_dict_to_yaml() {
+        with_test_home(|| {
+            let config = serde_json::json!({
+                "base_url": "https://api.example.com/v1",
+                "api_key": "sk-test",
+                "api_mode": "chat_completions",
+                "models": [
+                    { "id": "model-a", "context_length": 200000, "max_tokens": 32000 },
+                    { "id": "model-b", "context_length": 100000 },
+                ]
+            });
+            set_provider("demo", config).unwrap();
+
+            // Read raw YAML to verify the on-disk shape is a sequence under `custom_providers:`.
+            let raw = fs::read_to_string(get_hermes_config_path()).unwrap();
+            let yaml: serde_yaml::Value = serde_yaml::from_str(&raw).unwrap();
+            let providers = yaml
+                .get("custom_providers")
+                .and_then(|v| v.as_sequence())
+                .unwrap();
+            let provider = &providers[0];
+            assert_eq!(
+                provider.get("name").and_then(|v| v.as_str()),
+                Some("demo"),
+                "entry should carry a name field"
+            );
+            assert_eq!(
+                provider.get("model").and_then(|v| v.as_str()),
+                Some("model-a"),
+                "entry should carry a singular `model:` field set to the first model id \
+                 so Hermes runtime/picker reads it"
+            );
+            let models = provider.get("models").and_then(|v| v.as_mapping()).unwrap();
+            assert_eq!(models.len(), 2);
+            assert!(models.contains_key(serde_yaml::Value::String("model-a".into())));
+            assert!(models.contains_key(serde_yaml::Value::String("model-b".into())));
+            let model_a = models
+                .get(serde_yaml::Value::String("model-a".into()))
+                .unwrap();
+            assert_eq!(
+                model_a
+                    .get("context_length")
+                    .and_then(|v| v.as_u64())
+                    .unwrap(),
+                200000
+            );
+            // id should not leak into each model value
+            assert!(model_a.get("id").is_none());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn provider_models_roundtrip_array_dict_array_preserves_order() {
+        with_test_home(|| {
+            let input = serde_json::json!({
+                "base_url": "https://api.example.com/v1",
+                "api_key": "sk-test",
+                "models": [
+                    { "id": "first", "context_length": 1 },
+                    { "id": "second", "context_length": 2 },
+                    { "id": "third", "context_length": 3 },
+                ]
+            });
+            set_provider("order", input).unwrap();
+
+            let providers = get_providers().unwrap();
+            let provider = providers.get("order").unwrap();
+            let models = provider.get("models").and_then(|v| v.as_array()).unwrap();
+            let ids: Vec<&str> = models
+                .iter()
+                .map(|m| m.get("id").and_then(|v| v.as_str()).unwrap())
+                .collect();
+            assert_eq!(ids, vec!["first", "second", "third"]);
+            assert_eq!(models[0].get("context_length").unwrap(), 1);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn provider_without_models_is_unaffected() {
+        with_test_home(|| {
+            let input = serde_json::json!({
+                "base_url": "https://api.example.com/v1",
+                "api_key": "sk-test"
+            });
+            set_provider("simple", input).unwrap();
+            let providers = get_providers().unwrap();
+            let provider = providers.get("simple").unwrap();
+            assert!(provider.get("models").is_none());
+            assert!(
+                provider.get("model").is_none(),
+                "singular `model:` should not appear when no models are declared"
+            );
+        });
+    }
+
+    // ---- apply_switch_defaults ----
+
+    #[test]
+    #[serial]
+    fn apply_switch_defaults_sets_default_and_provider() {
+        with_test_home(|| {
+            let settings = serde_json::json!({
+                "base_url": "https://api.example.com/v1",
+                "models": [
+                    { "id": "primary-model", "context_length": 200000 },
+                    { "id": "fallback", "context_length": 100000 },
+                ]
+            });
+            apply_switch_defaults("demo", &settings).unwrap();
+
+            let model = get_model_config().unwrap().unwrap();
+            assert_eq!(model.default.as_deref(), Some("primary-model"));
+            assert_eq!(model.provider.as_deref(), Some("demo"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn apply_switch_defaults_preserves_user_context_length() {
+        with_test_home(|| {
+            // User previously set a custom context_length via the Model panel.
+            let initial = HermesModelConfig {
+                default: Some("old-model".to_string()),
+                provider: Some("old-provider".to_string()),
+                base_url: Some("https://user-override.example.com".to_string()),
+                context_length: Some(131072),
+                max_tokens: Some(16384),
+                extra: HashMap::new(),
+            };
+            set_model_config(&initial).unwrap();
+
+            let settings = serde_json::json!({
+                "models": [{ "id": "new-model" }]
+            });
+            apply_switch_defaults("new-provider", &settings).unwrap();
+
+            let model = get_model_config().unwrap().unwrap();
+            assert_eq!(model.default.as_deref(), Some("new-model"));
+            assert_eq!(model.provider.as_deref(), Some("new-provider"));
+            // User-customized fields must survive the switch.
+            assert_eq!(
+                model.base_url.as_deref(),
+                Some("https://user-override.example.com")
+            );
+            assert_eq!(model.context_length, Some(131072));
+            assert_eq!(model.max_tokens, Some(16384));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn apply_switch_defaults_updates_provider_even_without_models() {
+        with_test_home(|| {
+            // Seed an existing `model:` section — the user was already running
+            // some provider before this switch.
+            let initial = HermesModelConfig {
+                default: Some("legacy-default".to_string()),
+                provider: Some("legacy-provider".to_string()),
+                ..Default::default()
+            };
+            set_model_config(&initial).unwrap();
+
+            // New provider has no `models` list — previously this would no-op
+            // and leave `model.provider` pointing at the legacy provider,
+            // causing "switch succeeds but has no effect" bug.
+            let settings = serde_json::json!({
+                "base_url": "https://api.example.com/v1"
+            });
+            apply_switch_defaults("bare", &settings).unwrap();
+
+            let model = get_model_config().unwrap().unwrap();
+            assert_eq!(model.provider.as_deref(), Some("bare"));
+            assert_eq!(model.default.as_deref(), Some("legacy-default"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn apply_switch_defaults_keeps_old_default_when_first_model_id_is_blank() {
+        with_test_home(|| {
+            let initial = HermesModelConfig {
+                default: Some("prev-default".to_string()),
+                provider: Some("prev-provider".to_string()),
+                ..Default::default()
+            };
+            set_model_config(&initial).unwrap();
+
+            let settings = serde_json::json!({
+                "models": [{ "id": "   " }, { "id": "real" }]
+            });
+            apply_switch_defaults("edge", &settings).unwrap();
+
+            let model = get_model_config().unwrap().unwrap();
+            // Provider always updates.
+            assert_eq!(model.provider.as_deref(), Some("edge"));
+            // First entry's id is whitespace-only → blank → fall back to old default
+            // (we intentionally don't scan past the first entry for a default).
+            assert_eq!(model.default.as_deref(), Some("prev-default"));
+        });
+    }
+
+    // ---- memory file tests ----
+
+    #[test]
+    #[serial]
+    fn read_memory_returns_empty_when_file_missing() {
+        with_test_home(|| {
+            let memory = read_memory(MemoryKind::Memory).unwrap();
+            let user = read_memory(MemoryKind::User).unwrap();
+            assert!(memory.is_empty());
+            assert!(user.is_empty());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn write_then_read_memory_round_trip() {
+        with_test_home(|| {
+            let blob = "> note\n§\nfirst entry\n§\nsecond entry\n";
+            write_memory(MemoryKind::Memory, blob).unwrap();
+            assert_eq!(read_memory(MemoryKind::Memory).unwrap(), blob);
+
+            // Writing USER.md doesn't clobber MEMORY.md.
+            write_memory(MemoryKind::User, "user profile").unwrap();
+            assert_eq!(read_memory(MemoryKind::Memory).unwrap(), blob);
+            assert_eq!(read_memory(MemoryKind::User).unwrap(), "user profile");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn memory_limits_fall_back_to_defaults_when_config_missing() {
+        with_test_home(|| {
+            let limits = read_memory_limits().unwrap();
+            let defaults = HermesMemoryLimits::default();
+            assert_eq!(limits.memory, defaults.memory);
+            assert_eq!(limits.user, defaults.user);
+            assert_eq!(limits.memory_enabled, defaults.memory_enabled);
+            assert_eq!(limits.user_enabled, defaults.user_enabled);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn set_memory_enabled_preserves_other_fields() {
+        // Flipping one toggle must preserve character budgets and external
+        // provider settings the user configured via Hermes Web UI — otherwise
+        // a CC Switch toggle would silently wipe those fields.
+        with_test_home(|| {
+            let yaml = "\
+memory:
+  memory_char_limit: 4096
+  user_char_limit: 2048
+  memory_enabled: true
+  user_profile_enabled: true
+  provider: mem0
+";
+            let config_path = get_hermes_config_path();
+            fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+            fs::write(&config_path, yaml).unwrap();
+
+            set_memory_enabled(MemoryKind::Memory, false).unwrap();
+
+            let limits = read_memory_limits().unwrap();
+            assert!(!limits.memory_enabled, "toggle applied");
+            assert!(limits.user_enabled, "unrelated toggle untouched");
+            assert_eq!(limits.memory, 4096, "budgets preserved");
+            assert_eq!(limits.user, 2048);
+
+            // Verify the external provider field survived the section replacement.
+            let config = read_hermes_config().unwrap();
+            let provider = config
+                .get("memory")
+                .and_then(|v| v.get("provider"))
+                .and_then(|v| v.as_str());
+            assert_eq!(provider, Some("mem0"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn memory_limits_read_from_config_yaml() {
+        with_test_home(|| {
+            let yaml = "\
+memory:
+  memory_char_limit: 4096
+  user_char_limit: 2048
+  memory_enabled: false
+  user_profile_enabled: true
+";
+            let config_path = get_hermes_config_path();
+            fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+            fs::write(&config_path, yaml).unwrap();
+
+            let limits = read_memory_limits().unwrap();
+            assert_eq!(limits.memory, 4096);
+            assert_eq!(limits.user, 2048);
+            assert!(!limits.memory_enabled);
+            assert!(limits.user_enabled);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn memory_limits_ignore_top_level_keys() {
+        // Regression guard: Hermes nests memory settings under `memory:`, so
+        // identically-named keys at the top level must be ignored rather than
+        // silently consumed.
+        with_test_home(|| {
+            let yaml = "\
+memory_char_limit: 9999
+user_char_limit: 9999
+memory_enabled: false
+user_profile_enabled: false
+";
+            let config_path = get_hermes_config_path();
+            fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+            fs::write(&config_path, yaml).unwrap();
+
+            let limits = read_memory_limits().unwrap();
+            let defaults = HermesMemoryLimits::default();
+            assert_eq!(limits.memory, defaults.memory);
+            assert_eq!(limits.user, defaults.user);
+            assert_eq!(limits.memory_enabled, defaults.memory_enabled);
+            assert_eq!(limits.user_enabled, defaults.user_enabled);
+        });
+    }
+
+    #[test]
+    fn memory_kind_deserializes_from_lowercase_strings() {
+        let memory: MemoryKind = serde_json::from_str("\"memory\"").unwrap();
+        let user: MemoryKind = serde_json::from_str("\"user\"").unwrap();
+        assert_eq!(memory, MemoryKind::Memory);
+        assert_eq!(user, MemoryKind::User);
+        assert!(serde_json::from_str::<MemoryKind>("\"bogus\"").is_err());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod deeplink;
 mod error;
 mod gemini_config;
 mod gemini_mcp;
+mod hermes_config;
 mod import_export;
 mod init_status;
 mod mcp;

--- a/src-tauri/src/prompt_files.rs
+++ b/src-tauri/src/prompt_files.rs
@@ -6,7 +6,7 @@ use crate::config::get_claude_settings_path;
 use crate::error::AppError;
 use crate::gemini_config::get_gemini_dir;
 use crate::opencode_config::get_opencode_dir;
-use crate::settings::get_openclaw_override_dir;
+use crate::settings::{get_hermes_override_dir, get_openclaw_override_dir};
 
 /// 返回指定应用所使用的提示词文件路径。
 pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
@@ -16,6 +16,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::Gemini => get_gemini_dir(),
         AppType::OpenCode => get_opencode_dir(),
         AppType::OpenClaw => get_openclaw_override_dir().unwrap_or_else(default_openclaw_dir),
+        AppType::Hermes => get_hermes_override_dir().unwrap_or_else(default_hermes_dir),
     };
 
     let filename = match app {
@@ -24,6 +25,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::Gemini => "GEMINI.md",
         AppType::OpenCode => "AGENTS.md",
         AppType::OpenClaw => "AGENTS.md",
+        AppType::Hermes => "AGENTS.md",
     };
 
     Ok(base_dir.join(filename))
@@ -33,6 +35,12 @@ fn default_openclaw_dir() -> PathBuf {
     dirs::home_dir()
         .map(|home| home.join(".openclaw"))
         .unwrap_or_else(|| PathBuf::from(".openclaw"))
+}
+
+fn default_hermes_dir() -> PathBuf {
+    dirs::home_dir()
+        .map(|home| home.join(".hermes"))
+        .unwrap_or_else(|| PathBuf::from(".hermes"))
 }
 
 fn get_base_dir_with_fallback(

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -114,7 +114,7 @@ impl ProviderType {
                 }
                 ProviderType::Gemini
             }
-            AppType::OpenCode | AppType::OpenClaw => ProviderType::Codex,
+            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => ProviderType::Codex,
         }
     }
 
@@ -165,6 +165,7 @@ pub fn get_adapter(app_type: &AppType) -> Box<dyn ProviderAdapter> {
         AppType::Gemini => Box::new(GeminiAdapter::new()),
         AppType::OpenCode => Box::new(CodexAdapter::new()),
         AppType::OpenClaw => Box::new(CodexAdapter::new()),
+        AppType::Hermes => Box::new(CodexAdapter::new()),
     }
 }
 

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -253,6 +253,7 @@ impl ConfigService {
         Self::sync_current_provider_for_app(config, &AppType::Gemini)?;
         Self::sync_current_provider_for_app(config, &AppType::OpenCode)?;
         Self::sync_current_provider_for_app(config, &AppType::OpenClaw)?;
+        Self::sync_current_provider_for_app(config, &AppType::Hermes)?;
         Ok(())
     }
 
@@ -289,6 +290,7 @@ impl ConfigService {
             AppType::Gemini => Self::sync_gemini_live(config, &current_id, &provider)?,
             AppType::OpenCode => {}
             AppType::OpenClaw => {}
+            AppType::Hermes => {}
         }
 
         Ok(())

--- a/src-tauri/src/services/local_env_check.rs
+++ b/src-tauri/src/services/local_env_check.rs
@@ -8,6 +8,8 @@ pub enum LocalTool {
     Codex,
     Gemini,
     OpenCode,
+    OpenClaw,
+    Hermes,
 }
 
 #[derive(Debug, Clone)]
@@ -24,25 +26,37 @@ pub struct ToolCheckResult {
     pub status: ToolCheckStatus,
 }
 
-pub fn check_local_environment() -> Vec<ToolCheckResult> {
-    const SPECS: &[(LocalTool, &str, &str, &[&str])] = &[
-        (
-            LocalTool::Claude,
-            "claude",
-            "Claude",
-            &["--version", "version"],
-        ),
-        (LocalTool::Codex, "codex", "Codex", &["--version"]),
-        (LocalTool::Gemini, "gemini", "Gemini", &["--version", "-v"]),
-        (
-            LocalTool::OpenCode,
-            "opencode",
-            "OpenCode",
-            &["--version", "version"],
-        ),
-    ];
+const TOOL_SPECS: &[(LocalTool, &str, &str, &[&str])] = &[
+    (
+        LocalTool::Claude,
+        "claude",
+        "Claude",
+        &["--version", "version"],
+    ),
+    (LocalTool::Codex, "codex", "Codex", &["--version"]),
+    (LocalTool::Gemini, "gemini", "Gemini", &["--version", "-v"]),
+    (
+        LocalTool::OpenCode,
+        "opencode",
+        "OpenCode",
+        &["--version", "version"],
+    ),
+    (
+        LocalTool::OpenClaw,
+        "openclaw",
+        "OpenClaw",
+        &["--version", "version"],
+    ),
+    (
+        LocalTool::Hermes,
+        "hermes",
+        "Hermes",
+        &["--version", "version"],
+    ),
+];
 
-    SPECS
+pub fn check_local_environment() -> Vec<ToolCheckResult> {
+    TOOL_SPECS
         .iter()
         .map(|(tool, bin, display_name, args)| ToolCheckResult {
             tool: *tool,
@@ -140,7 +154,7 @@ pub(crate) fn parse_version(output: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_version;
+    use super::{parse_version, LocalTool, TOOL_SPECS};
 
     #[test]
     fn parse_version_extracts_semver() {
@@ -159,5 +173,16 @@ mod tests {
     #[test]
     fn parse_version_returns_none_for_garbage() {
         assert_eq!(parse_version("nonsense").as_deref(), None);
+    }
+
+    #[test]
+    fn tool_specs_include_openclaw_and_hermes() {
+        let tools = TOOL_SPECS
+            .iter()
+            .map(|(tool, _, _, _)| *tool)
+            .collect::<Vec<_>>();
+
+        assert!(tools.contains(&LocalTool::OpenClaw));
+        assert!(tools.contains(&LocalTool::Hermes));
     }
 }

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -164,6 +164,7 @@ impl McpService {
                 mcp::sync_single_server_to_opencode(cfg, &server.id, &server.server)?;
             }
             AppType::OpenClaw => {}
+            AppType::Hermes => {}
         }
         Ok(())
     }
@@ -188,6 +189,7 @@ impl McpService {
             AppType::Gemini => mcp::remove_server_from_gemini(id)?,
             AppType::OpenCode => mcp::remove_server_from_opencode(id)?,
             AppType::OpenClaw => {}
+            AppType::Hermes => {}
         }
         Ok(())
     }
@@ -197,7 +199,7 @@ impl McpService {
         let servers = Self::get_all_servers(state)?;
 
         for app in AppType::all() {
-            if matches!(app, AppType::OpenClaw) {
+            if matches!(app, AppType::OpenClaw | AppType::Hermes) {
                 continue;
             }
 

--- a/src-tauri/src/services/provider/common_config.rs
+++ b/src-tauri/src/services/provider/common_config.rs
@@ -284,7 +284,7 @@ fn parse_json_object_snippet(
             format!("Gemini 通用配置片段不是有效的 JSON：{e}"),
             format!("Gemini common config snippet is not valid JSON: {e}"),
         ),
-        AppType::OpenCode | AppType::OpenClaw => AppError::localized(
+        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => AppError::localized(
             "common_config.opencode.invalid_json",
             format!("OpenCode 通用配置片段不是有效的 JSON：{e}"),
             format!("OpenCode common config snippet is not valid JSON: {e}"),
@@ -304,7 +304,7 @@ fn parse_json_object_snippet(
                 "Gemini 通用配置片段必须是 JSON 对象",
                 "Gemini common config snippet must be a JSON object",
             ),
-            AppType::OpenCode | AppType::OpenClaw => AppError::localized(
+            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => AppError::localized(
                 "common_config.opencode.not_object",
                 "OpenCode 通用配置片段必须是 JSON 对象",
                 "OpenCode common config snippet must be a JSON object",
@@ -339,7 +339,11 @@ pub(super) fn validate_common_config_snippet(
     }
 
     match app_type {
-        AppType::Claude | AppType::Gemini | AppType::OpenCode | AppType::OpenClaw => {
+        AppType::Claude
+        | AppType::Gemini
+        | AppType::OpenCode
+        | AppType::OpenClaw
+        | AppType::Hermes => {
             parse_json_object_snippet(app_type, snippet, false)?;
         }
         AppType::Codex => {
@@ -395,7 +399,7 @@ pub(super) fn settings_contain_common_config(
             }
             _ => false,
         },
-        AppType::OpenCode | AppType::OpenClaw => false,
+        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => false,
     }
 }
 
@@ -460,7 +464,7 @@ pub(super) fn apply_common_config_to_settings(
             }
             Ok(result)
         }
-        AppType::OpenCode | AppType::OpenClaw => Ok(settings.clone()),
+        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => Ok(settings.clone()),
     }
 }
 
@@ -509,7 +513,7 @@ pub(super) fn remove_common_config_from_settings(
             }
             Ok(result)
         }
-        AppType::OpenCode | AppType::OpenClaw => Ok(settings.clone()),
+        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => Ok(settings.clone()),
     }
 }
 

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -29,6 +29,9 @@ pub(super) enum LiveSnapshot {
     OpenClaw {
         config_source: Option<String>,
     },
+    Hermes {
+        config_source: Option<String>,
+    },
 }
 
 impl LiveSnapshot {
@@ -96,6 +99,14 @@ impl LiveSnapshot {
                     delete_file(&path)?;
                 }
             }
+            LiveSnapshot::Hermes { config_source } => {
+                let path = crate::hermes_config::get_hermes_config_path();
+                if let Some(source) = config_source {
+                    crate::config::write_text_file(&path, source)?;
+                } else if path.exists() {
+                    delete_file(&path)?;
+                }
+            }
         }
         Ok(())
     }
@@ -159,7 +170,116 @@ pub(super) fn capture_live_snapshot(app_type: &AppType) -> Result<LiveSnapshot, 
             let config_source = crate::openclaw_config::read_openclaw_config_source()?;
             Ok(LiveSnapshot::OpenClaw { config_source })
         }
+        AppType::Hermes => {
+            let path = crate::hermes_config::get_hermes_config_path();
+            let config_source = if path.exists() {
+                Some(std::fs::read_to_string(&path).map_err(|err| AppError::io(&path, err))?)
+            } else {
+                None
+            };
+            Ok(LiveSnapshot::Hermes { config_source })
+        }
     }
+}
+
+pub fn sync_hermes_providers_from_live(state: &AppState) -> Result<usize, AppError> {
+    if !crate::hermes_config::get_hermes_config_path().exists() {
+        return Ok(0);
+    }
+
+    let providers = crate::hermes_config::get_providers()?;
+    let mut live_providers = IndexMap::new();
+    for (id, live_provider) in providers {
+        if id.trim().is_empty() {
+            log::warn!("Skipping Hermes live provider with blank id during local mirror");
+            continue;
+        }
+
+        if let Err(err) = super::ProviderService::validate_hermes_provider_settings(&live_provider)
+        {
+            log::warn!("Skipping malformed Hermes live provider '{id}' during local mirror: {err}");
+            continue;
+        }
+
+        live_providers.insert(id, live_provider);
+    }
+
+    let mut changed = 0;
+    {
+        let mut config = state.config.write().map_err(AppError::from)?;
+        config.ensure_app(&AppType::Hermes);
+        let manager = config
+            .get_manager_mut(&AppType::Hermes)
+            .ok_or_else(|| AppError::Config("Hermes manager missing".to_string()))?;
+
+        for (id, live_provider) in live_providers {
+            if let Some(existing) = manager.providers.get_mut(&id) {
+                let mut provider_changed = false;
+                if existing.id != id {
+                    existing.id = id.clone();
+                    provider_changed = true;
+                }
+                if is_auto_mirrored_hermes_snapshot(existing) && existing.name != id {
+                    existing.name = id.clone();
+                    provider_changed = true;
+                }
+                if existing.settings_config != live_provider {
+                    existing.settings_config = live_provider;
+                    provider_changed = true;
+                }
+                if provider_changed {
+                    changed += 1;
+                }
+                continue;
+            }
+
+            manager.providers.insert(
+                id.clone(),
+                Provider::with_id(id.clone(), id.clone(), live_provider, None),
+            );
+            changed += 1;
+        }
+    }
+
+    if changed > 0 {
+        state.save()?;
+    }
+
+    Ok(changed)
+}
+
+pub(super) fn is_auto_mirrored_hermes_snapshot(provider: &Provider) -> bool {
+    provider.website_url.is_none()
+        && provider.category.is_none()
+        && provider.created_at.is_none()
+        && provider.sort_index.is_none()
+        && provider.notes.is_none()
+        && provider
+            .meta
+            .as_ref()
+            .map_or(true, is_default_hermes_common_config_marker)
+        && provider.icon.is_none()
+        && provider.icon_color.is_none()
+        && !provider.in_failover_queue
+}
+
+fn is_default_hermes_common_config_marker(meta: &ProviderMeta) -> bool {
+    meta.apply_common_config == Some(false)
+        && meta.codex_official.is_none()
+        && meta.custom_endpoints.is_empty()
+        && meta.usage_script.is_none()
+        && meta.endpoint_auto_select.is_none()
+        && meta.is_partner.is_none()
+        && meta.partner_promotion_key.is_none()
+        && meta.cost_multiplier.is_none()
+        && meta.pricing_model_source.is_none()
+        && meta.limit_daily_usd.is_none()
+        && meta.limit_monthly_usd.is_none()
+        && meta.test_config.is_none()
+        && meta.proxy_config.is_none()
+        && meta.api_format.is_none()
+        && meta.prompt_cache_key.is_none()
+        && meta.live_config_managed.is_none()
 }
 
 pub fn sync_openclaw_providers_from_live(state: &AppState) -> Result<usize, AppError> {
@@ -341,6 +461,57 @@ pub fn import_openclaw_providers_from_live(state: &AppState) -> Result<usize, Ap
 
         imported += 1;
         log::info!("Imported OpenClaw provider '{id}' from live config");
+    }
+
+    Ok(imported)
+}
+
+pub fn import_hermes_providers_from_live(state: &AppState) -> Result<usize, AppError> {
+    let providers = crate::hermes_config::get_providers()?;
+    if providers.is_empty() {
+        return Ok(0);
+    }
+
+    let mut imported = 0usize;
+    let existing_ids = state.db.get_provider_ids("hermes")?;
+
+    for (id, settings_config) in providers {
+        if id.trim().is_empty() {
+            log::warn!("Skipping Hermes provider with empty id");
+            continue;
+        }
+        if existing_ids.contains(&id) {
+            log::debug!("Hermes provider '{id}' already exists in database, skipping");
+            continue;
+        }
+        if let Err(err) =
+            super::ProviderService::validate_hermes_provider_settings(&settings_config)
+        {
+            log::warn!("Skipping malformed Hermes provider '{id}': {err}");
+            continue;
+        }
+
+        let mut provider = Provider::with_id(id.clone(), id.clone(), settings_config.clone(), None);
+        provider.meta = Some(ProviderMeta {
+            live_config_managed: Some(true),
+            ..Default::default()
+        });
+
+        if let Err(err) = state.db.save_provider("hermes", &provider) {
+            log::warn!("Failed to import Hermes provider '{id}': {err}");
+            continue;
+        }
+
+        {
+            let mut config = state.config.write().map_err(AppError::from)?;
+            config.ensure_app(&AppType::Hermes);
+            if let Some(manager) = config.get_manager_mut(&AppType::Hermes) {
+                manager.providers.insert(id.clone(), provider);
+            }
+        }
+
+        imported += 1;
+        log::info!("Imported Hermes provider '{id}' from live config");
     }
 
     Ok(imported)

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -149,6 +149,28 @@ impl ProviderService {
         Ok(())
     }
 
+    pub fn sync_hermes_to_live(state: &AppState) -> Result<(), AppError> {
+        let providers = {
+            let guard = state.config.read().map_err(AppError::from)?;
+            let Some(manager) = guard.get_manager(&AppType::Hermes) else {
+                return Ok(());
+            };
+
+            manager
+                .providers
+                .values()
+                .filter(|provider| Self::provider_live_config_managed(provider) != Some(false))
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+
+        for provider in &providers {
+            Self::write_live_snapshot(&AppType::Hermes, provider, None, true)?;
+        }
+
+        Ok(())
+    }
+
     pub(crate) fn valid_openclaw_live_provider_ids() -> Result<Option<HashSet<String>>, AppError> {
         if !crate::openclaw_config::get_openclaw_config_path().exists() {
             return Ok(None);
@@ -202,6 +224,8 @@ impl ProviderService {
                 .map(|providers| providers.contains_key(provider_id)),
             AppType::OpenClaw => Self::valid_openclaw_live_provider_ids()
                 .map(|ids| ids.is_some_and(|ids| ids.contains(provider_id))),
+            AppType::Hermes => crate::hermes_config::get_providers()
+                .map(|providers| providers.contains_key(provider_id)),
             _ => Ok(false),
         };
 
@@ -393,6 +417,12 @@ impl ProviderService {
                 action.common_config_snippet.as_deref(),
                 apply_common_config,
             )?;
+            if matches!(action.app_type, AppType::Hermes) {
+                crate::hermes_config::apply_switch_defaults(
+                    &action.provider.id,
+                    &action.provider.settings_config,
+                )?;
+            }
         }
         if action.sync_mcp {
             // 使用 v3.7.0 统一的 MCP 同步机制，支持所有应用
@@ -664,6 +694,26 @@ impl ProviderService {
                 }
                 state.save()?;
             }
+            AppType::Hermes => {
+                let providers = crate::hermes_config::get_providers()?;
+                let live_after = providers.get(provider_id).cloned().ok_or_else(|| {
+                    AppError::localized(
+                        "hermes.live.missing_provider",
+                        format!("Hermes live 配置中缺少供应商: {provider_id}"),
+                        format!("Hermes live config missing provider: {provider_id}"),
+                    )
+                })?;
+
+                {
+                    let mut guard = state.config.write().map_err(AppError::from)?;
+                    if let Some(manager) = guard.get_manager_mut(app_type) {
+                        if let Some(target) = manager.providers.get_mut(provider_id) {
+                            target.settings_config = live_after;
+                        }
+                    }
+                }
+                state.save()?;
+            }
         }
         Ok(())
     }
@@ -719,7 +769,7 @@ impl ProviderService {
                 strict_current_provider_id,
                 old_snippet,
             ),
-            AppType::OpenCode | AppType::OpenClaw => Ok(()),
+            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => Ok(()),
         };
 
         match result {
@@ -834,7 +884,7 @@ impl ProviderService {
             }
             AppType::Gemini => live_settings.get("env") != provider_settings.get("env"),
             AppType::Claude => live_settings != provider_settings,
-            AppType::OpenCode | AppType::OpenClaw => false,
+            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => false,
         }
     }
 
@@ -985,6 +1035,7 @@ impl ProviderService {
             AppType::Gemini => Self::extract_gemini_common_config(settings_config),
             AppType::OpenCode => Self::extract_opencode_common_config(settings_config),
             AppType::OpenClaw => Self::extract_openclaw_common_config(settings_config),
+            AppType::Hermes => Self::extract_openclaw_common_config(settings_config),
         }
     }
 
@@ -1346,8 +1397,17 @@ impl ProviderService {
         Ok(())
     }
 
+    pub(crate) fn sync_hermes_providers_from_live(state: &AppState) -> Result<(), AppError> {
+        live::sync_hermes_providers_from_live(state)?;
+        Ok(())
+    }
+
     /// 获取当前供应商 ID
     pub fn current(state: &AppState, app_type: AppType) -> Result<String, AppError> {
+        if matches!(app_type, AppType::Hermes) {
+            return crate::hermes_config::get_model_config()
+                .map(|model| model.and_then(|cfg| cfg.provider).unwrap_or_default());
+        }
         if app_type.is_additive_mode() {
             return Ok(String::new());
         }
@@ -1379,10 +1439,12 @@ impl ProviderService {
                 common_config_snippet.as_deref(),
             )?;
 
-            if matches!(app_type_clone, AppType::OpenClaw)
-                && provider_to_store.created_at.is_none()
-                && live::is_auto_mirrored_openclaw_snapshot(&provider_to_store)
-            {
+            let is_auto_mirrored_additive = match &app_type_clone {
+                AppType::OpenClaw => live::is_auto_mirrored_openclaw_snapshot(&provider_to_store),
+                AppType::Hermes => live::is_auto_mirrored_hermes_snapshot(&provider_to_store),
+                _ => false,
+            };
+            if provider_to_store.created_at.is_none() && is_auto_mirrored_additive {
                 provider_to_store.created_at = Some(current_timestamp());
             }
             if app_type_clone.is_additive_mode() {
@@ -1510,10 +1572,12 @@ impl ProviderService {
                         updated.meta = Some(new_meta);
                     }
                 }
-                if matches!(app_type_clone, AppType::OpenClaw)
-                    && updated.created_at.is_none()
-                    && live::is_auto_mirrored_openclaw_snapshot(&updated)
-                {
+                let is_auto_mirrored_additive = match &app_type_clone {
+                    AppType::OpenClaw => live::is_auto_mirrored_openclaw_snapshot(&updated),
+                    AppType::Hermes => live::is_auto_mirrored_hermes_snapshot(&updated),
+                    _ => false,
+                };
+                if updated.created_at.is_none() && is_auto_mirrored_additive {
                     updated.created_at = Some(current_timestamp());
                 }
                 updated
@@ -1651,6 +1715,7 @@ impl ProviderService {
             }
             AppType::OpenCode => unreachable!("additive mode apps are handled earlier"),
             AppType::OpenClaw => unreachable!("additive mode apps are handled earlier"),
+            AppType::Hermes => unreachable!("additive mode apps are handled earlier"),
         };
 
         let mut provider = Provider::with_id(
@@ -1770,6 +1835,17 @@ impl ProviderService {
                 }
                 crate::openclaw_config::read_openclaw_config()
             }
+            AppType::Hermes => {
+                let config_path = crate::hermes_config::get_hermes_config_path();
+                if !config_path.exists() {
+                    return Err(AppError::localized(
+                        "hermes.config.missing",
+                        "Hermes 配置文件不存在",
+                        "Hermes configuration file not found",
+                    ));
+                }
+                crate::hermes_config::get_providers().map(Value::Object)
+            }
         }
     }
 
@@ -1834,6 +1910,11 @@ impl ProviderService {
             AppType::OpenClaw => {
                 if crate::openclaw_config::get_openclaw_dir().exists() {
                     crate::openclaw_config::remove_provider(provider_id)?;
+                }
+            }
+            AppType::Hermes => {
+                if crate::hermes_config::get_hermes_dir().exists() {
+                    crate::hermes_config::remove_provider(provider_id)?;
                 }
             }
             _ => unreachable!("non-additive apps should not enter remove-from-live branch"),
@@ -2073,6 +2154,7 @@ impl ProviderService {
                 )?,
                 AppType::OpenCode => unreachable!("additive mode handled above"),
                 AppType::OpenClaw => unreachable!("additive mode handled above"),
+                AppType::Hermes => unreachable!("additive mode handled above"),
             };
 
             let action = PostCommitAction {
@@ -2160,7 +2242,25 @@ impl ProviderService {
 
                 write_result.map_err(Self::normalize_openclaw_live_write_error)
             }
+            AppType::Hermes => {
+                Self::validate_hermes_provider_settings(&provider.settings_config)?;
+                crate::hermes_config::set_provider(&provider.id, provider.settings_config.clone())
+                    .map(|_| ())
+            }
         }
+    }
+
+    pub(crate) fn validate_hermes_provider_settings(
+        settings_config: &Value,
+    ) -> Result<(), AppError> {
+        if !settings_config.is_object() {
+            return Err(AppError::localized(
+                "provider.hermes.settings.not_object",
+                "Hermes 配置必须是 JSON 对象",
+                "Hermes configuration must be a JSON object",
+            ));
+        }
+        Ok(())
     }
 
     fn parse_openclaw_provider_settings(
@@ -2373,6 +2473,9 @@ impl ProviderService {
             AppType::OpenClaw => Err(AppError::Config(
                 "OpenClaw does not support proxy takeover backups".into(),
             )),
+            AppType::Hermes => Err(AppError::Config(
+                "Hermes does not support proxy takeover backups".into(),
+            )),
         }
     }
 
@@ -2457,6 +2560,9 @@ impl ProviderService {
             AppType::OpenClaw => {
                 let config = Self::parse_openclaw_provider_settings(&provider.settings_config)?;
                 Self::validate_openclaw_provider_models(&provider.id, &config)?;
+            }
+            AppType::Hermes => {
+                Self::validate_hermes_provider_settings(&provider.settings_config)?;
             }
         }
 
@@ -2597,6 +2703,11 @@ impl ProviderService {
                         crate::openclaw_config::remove_provider(provider_id)?;
                     }
                 }
+                AppType::Hermes => {
+                    if crate::hermes_config::get_hermes_dir().exists() {
+                        crate::hermes_config::remove_provider(provider_id)?;
+                    }
+                }
                 _ => unreachable!("non-additive apps should not enter additive delete branch"),
             }
 
@@ -2635,6 +2746,9 @@ impl ProviderService {
             AppType::OpenClaw => {
                 let _ = provider_snapshot;
             }
+            AppType::Hermes => {
+                let _ = provider_snapshot;
+            }
         }
 
         {
@@ -2666,6 +2780,10 @@ impl ProviderService {
 
     pub fn import_openclaw_providers_from_live(state: &AppState) -> Result<usize, AppError> {
         live::import_openclaw_providers_from_live(state)
+    }
+
+    pub fn import_hermes_providers_from_live(state: &AppState) -> Result<usize, AppError> {
+        live::import_hermes_providers_from_live(state)
     }
 
     pub fn import_opencode_providers_from_live(state: &AppState) -> Result<usize, AppError> {

--- a/src-tauri/src/services/provider/usage.rs
+++ b/src-tauri/src/services/provider/usage.rs
@@ -279,6 +279,19 @@ impl ProviderService {
                     )
                 })
                 .map(|s| s.to_string()),
+            AppType::Hermes => provider
+                .settings_config
+                .get("api_key")
+                .or_else(|| provider.settings_config.get("apiKey"))
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    AppError::localized(
+                        "provider.hermes.api_key.missing",
+                        "缺少 API Key",
+                        "API key is missing",
+                    )
+                })
+                .map(|s| s.to_string()),
         }
     }
 
@@ -359,6 +372,13 @@ impl ProviderService {
             AppType::OpenClaw => Ok(provider
                 .settings_config
                 .get("baseUrl")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string()),
+            AppType::Hermes => Ok(provider
+                .settings_config
+                .get("base_url")
+                .or_else(|| provider.settings_config.get("baseUrl"))
                 .and_then(|v| v.as_str())
                 .unwrap_or_default()
                 .to_string()),

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -391,6 +391,7 @@ impl SkillService {
             AppType::Codex,
             AppType::Gemini,
             AppType::OpenCode,
+            AppType::Hermes,
         ]
         .into_iter()
     }
@@ -449,6 +450,11 @@ impl SkillService {
                     return Ok(custom.join("skills"));
                 }
             }
+            AppType::Hermes => {
+                if let Some(custom) = crate::settings::get_hermes_override_dir() {
+                    return Ok(custom.join("skills"));
+                }
+            }
         }
 
         let home = dirs::home_dir().ok_or_else(|| {
@@ -465,6 +471,7 @@ impl SkillService {
             AppType::Gemini => home.join(".gemini").join("skills"),
             AppType::OpenCode => home.join(".config").join("opencode").join("skills"),
             AppType::OpenClaw => home.join(".openclaw").join("skills"),
+            AppType::Hermes => home.join(".hermes").join("skills"),
         })
     }
 
@@ -946,6 +953,7 @@ impl SkillService {
             AppType::Codex,
             AppType::Gemini,
             AppType::OpenCode,
+            AppType::Hermes,
         ] {
             if let Err(e) = Self::remove_from_app(&dir, &app) {
                 log::warn!("从 {app:?} 删除 Skill {dir} 失败: {e}");

--- a/src-tauri/src/services/stream_check/provider_extract.rs
+++ b/src-tauri/src/services/stream_check/provider_extract.rs
@@ -38,6 +38,20 @@ impl StreamCheckService {
                 .and_then(|model| model.get("id").and_then(|value| value.as_str()))
                 .map(str::to_string)
                 .unwrap_or_else(|| config.codex_model.clone()),
+            AppType::Hermes => provider
+                .settings_config
+                .get("models")
+                .and_then(|value| value.as_array())
+                .and_then(|models| models.first())
+                .and_then(|model| model.get("id").and_then(|value| value.as_str()))
+                .or_else(|| {
+                    provider
+                        .settings_config
+                        .get("model")
+                        .and_then(|value| value.as_str())
+                })
+                .map(str::to_string)
+                .unwrap_or_else(|| config.codex_model.clone()),
         }
     }
 
@@ -175,6 +189,14 @@ impl StreamCheckService {
                 .unwrap_or_default()
                 .trim_end_matches('/')
                 .to_string()),
+            AppType::Hermes => Ok(provider
+                .settings_config
+                .get("base_url")
+                .or_else(|| provider.settings_config.get("baseUrl"))
+                .and_then(|value| value.as_str())
+                .unwrap_or_default()
+                .trim_end_matches('/')
+                .to_string()),
         }
     }
 
@@ -226,6 +248,19 @@ impl StreamCheckService {
                 .ok_or_else(|| {
                     AppError::localized(
                         "provider.openclaw.api_key.missing",
+                        "缺少 API Key",
+                        "API key is missing",
+                    )
+                }),
+            AppType::Hermes => provider
+                .settings_config
+                .get("api_key")
+                .or_else(|| provider.settings_config.get("apiKey"))
+                .and_then(|value| value.as_str())
+                .map(|key| AuthInfo::new(key.to_string(), AuthStrategy::Bearer))
+                .ok_or_else(|| {
+                    AppError::localized(
+                        "provider.hermes.api_key.missing",
                         "缺少 API Key",
                         "API key is missing",
                     )

--- a/src-tauri/src/services/stream_check/service.rs
+++ b/src-tauri/src/services/stream_check/service.rs
@@ -162,6 +162,17 @@ impl StreamCheckService {
                 .await
             }
             AppType::OpenClaw => unreachable!("OpenClaw should return unsupported earlier"),
+            AppType::Hermes => {
+                Self::check_codex_stream(
+                    &client,
+                    &base_url,
+                    &auth,
+                    &model_to_test,
+                    test_prompt,
+                    request_timeout,
+                )
+                .await
+            }
         };
 
         let response_time = start.elapsed().as_millis() as u64;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -20,6 +20,8 @@ pub struct VisibleApps {
     pub opencode: bool,
     #[serde(default = "default_visible_app_openclaw")]
     pub openclaw: bool,
+    #[serde(default = "default_visible_app_hermes")]
+    pub hermes: bool,
 }
 
 fn default_visible_app_claude() -> bool {
@@ -42,6 +44,10 @@ fn default_visible_app_openclaw() -> bool {
     true
 }
 
+fn default_visible_app_hermes() -> bool {
+    true
+}
+
 pub fn default_visible_apps() -> VisibleApps {
     VisibleApps {
         claude: true,
@@ -49,6 +55,7 @@ pub fn default_visible_apps() -> VisibleApps {
         gemini: false,
         opencode: true,
         openclaw: true,
+        hermes: true,
     }
 }
 
@@ -73,6 +80,7 @@ impl VisibleApps {
             AppType::Gemini => self.gemini,
             AppType::OpenCode => self.opencode,
             AppType::OpenClaw => self.openclaw,
+            AppType::Hermes => self.hermes,
         }
     }
 
@@ -83,6 +91,7 @@ impl VisibleApps {
             AppType::Gemini => self.gemini = enabled,
             AppType::OpenCode => self.opencode = enabled,
             AppType::OpenClaw => self.openclaw = enabled,
+            AppType::Hermes => self.hermes = enabled,
         }
     }
 
@@ -103,13 +112,14 @@ impl VisibleApps {
     }
 }
 
-fn app_order() -> [AppType; 5] {
+fn app_order() -> [AppType; 6] {
     [
         AppType::Claude,
         AppType::Codex,
         AppType::Gemini,
         AppType::OpenCode,
         AppType::OpenClaw,
+        AppType::Hermes,
     ]
 }
 
@@ -312,6 +322,8 @@ pub struct AppSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub openclaw_config_dir: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hermes_config_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_provider_claude: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_provider_codex: Option<String>,
@@ -321,6 +333,8 @@ pub struct AppSettings {
     pub current_provider_opencode: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_provider_openclaw: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_provider_hermes: Option<String>,
     #[serde(default = "default_visible_apps")]
     pub visible_apps: VisibleApps,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -366,11 +380,13 @@ impl Default for AppSettings {
             gemini_config_dir: None,
             opencode_config_dir: None,
             openclaw_config_dir: None,
+            hermes_config_dir: None,
             current_provider_claude: None,
             current_provider_codex: None,
             current_provider_gemini: None,
             current_provider_opencode: None,
             current_provider_openclaw: None,
+            current_provider_hermes: None,
             visible_apps: default_visible_apps(),
             language: None,
             launch_on_startup: false,
@@ -422,6 +438,13 @@ impl AppSettings {
 
         self.openclaw_config_dir = self
             .openclaw_config_dir
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        self.hermes_config_dir = self
+            .hermes_config_dir
             .as_ref()
             .map(|s| s.trim())
             .filter(|s| !s.is_empty())
@@ -598,6 +621,14 @@ pub fn get_openclaw_override_dir() -> Option<PathBuf> {
         .map(|p| resolve_override_path(p))
 }
 
+pub fn get_hermes_override_dir() -> Option<PathBuf> {
+    let settings = settings_store().read().ok()?;
+    settings
+        .hermes_config_dir
+        .as_ref()
+        .map(|p| resolve_override_path(p))
+}
+
 pub fn get_current_provider(app_type: &AppType) -> Option<String> {
     let settings = settings_store().read().ok()?;
     match app_type {
@@ -606,6 +637,7 @@ pub fn get_current_provider(app_type: &AppType) -> Option<String> {
         AppType::Gemini => settings.current_provider_gemini.clone(),
         AppType::OpenCode => settings.current_provider_opencode.clone(),
         AppType::OpenClaw => settings.current_provider_openclaw.clone(),
+        AppType::Hermes => settings.current_provider_hermes.clone(),
     }
 }
 
@@ -618,6 +650,7 @@ pub fn set_current_provider(app_type: &AppType, id: Option<&str>) -> Result<(), 
         AppType::Gemini => settings.current_provider_gemini = id.map(|value| value.to_string()),
         AppType::OpenCode => settings.current_provider_opencode = id.map(|value| value.to_string()),
         AppType::OpenClaw => settings.current_provider_openclaw = id.map(|value| value.to_string()),
+        AppType::Hermes => settings.current_provider_hermes = id.map(|value| value.to_string()),
     }
 
     update_settings(settings)

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -226,6 +226,7 @@ fn export_db_to_multi_app_config(db: &Database) -> Result<MultiAppConfig, AppErr
         AppType::Gemini,
         AppType::OpenCode,
         AppType::OpenClaw,
+        AppType::Hermes,
     ] {
         let app_key = app.as_str();
         let providers = db.get_all_providers(app_key)?;
@@ -241,6 +242,7 @@ fn export_db_to_multi_app_config(db: &Database) -> Result<MultiAppConfig, AppErr
             AppType::Gemini => config.prompts.gemini.prompts = prompts.into_iter().collect(),
             AppType::OpenCode => config.prompts.opencode.prompts = prompts.into_iter().collect(),
             AppType::OpenClaw => config.prompts.openclaw.prompts = prompts.into_iter().collect(),
+            AppType::Hermes => config.prompts.hermes.prompts = prompts.into_iter().collect(),
         }
 
         // common snippet
@@ -277,6 +279,7 @@ fn persist_multi_app_config_to_db_preserving_current_providers(
         AppType::Gemini,
         AppType::OpenCode,
         AppType::OpenClaw,
+        AppType::Hermes,
     ] {
         let app_key = app.as_str();
         let manager = config.get_manager(&app);

--- a/src-tauri/src/sync_policy.rs
+++ b/src-tauri/src/sync_policy.rs
@@ -22,6 +22,8 @@ pub(crate) fn should_sync_live(app_type: &AppType) -> bool {
         AppType::OpenCode => crate::opencode_config::get_opencode_dir().exists(),
         // OpenClaw is considered initialized if ~/.openclaw (or override dir) exists.
         AppType::OpenClaw => get_openclaw_dir().exists(),
+        // Hermes is considered initialized if ~/.hermes (or override dir) exists.
+        AppType::Hermes => crate::hermes_config::get_hermes_dir().exists(),
     }
 }
 

--- a/src-tauri/tests/settings_visible_apps.rs
+++ b/src-tauri/tests/settings_visible_apps.rs
@@ -13,6 +13,7 @@ mod app_config {
         Gemini,
         OpenCode,
         OpenClaw,
+        Hermes,
     }
 
     impl AppType {
@@ -23,6 +24,7 @@ mod app_config {
                 AppType::Gemini => "gemini",
                 AppType::OpenCode => "opencode",
                 AppType::OpenClaw => "openclaw",
+                AppType::Hermes => "hermes",
             }
         }
     }
@@ -292,6 +294,7 @@ fn default_visible_apps_hide_gemini() {
             AppType::Codex,
             AppType::OpenCode,
             AppType::OpenClaw,
+            AppType::Hermes,
         ]
     );
     assert!(!visible.is_enabled_for(&AppType::Gemini));
@@ -308,6 +311,7 @@ fn set_visible_apps_persists_visible_apps_as_camel_case_json() {
         gemini: true,
         opencode: false,
         openclaw: true,
+        hermes: false,
     })
     .expect("persist visible apps");
 
@@ -324,6 +328,7 @@ fn set_visible_apps_persists_visible_apps_as_camel_case_json() {
             "gemini": true,
             "opencode": false,
             "openclaw": true,
+            "hermes": false,
         })
     );
 }
@@ -341,6 +346,7 @@ fn load_reads_valid_non_default_visible_apps_from_settings_json() {
                 "gemini": true,
                 "opencode": true,
                 "openclaw": false,
+                "hermes": false,
             }
         }),
     );
@@ -356,6 +362,7 @@ fn load_reads_valid_non_default_visible_apps_from_settings_json() {
             gemini: true,
             opencode: true,
             openclaw: false,
+            hermes: false,
         }
     );
     assert_eq!(
@@ -387,6 +394,7 @@ fn load_partial_visible_apps_object_uses_defaults_for_missing_keys() {
             gemini: false,
             opencode: true,
             openclaw: true,
+            hermes: true,
         }
     );
 }
@@ -423,6 +431,7 @@ fn set_visible_apps_rejects_zero_selection() {
         gemini: false,
         opencode: false,
         openclaw: false,
+        hermes: false,
     })
     .expect_err("zero visible apps should be rejected");
 
@@ -444,6 +453,7 @@ fn update_settings_rejects_all_false_visible_apps() {
         gemini: false,
         opencode: false,
         openclaw: false,
+        hermes: false,
     };
 
     let err =
@@ -491,7 +501,8 @@ fn load_normalizes_all_false_visible_apps_to_defaults() {
                 "codex": false,
                 "gemini": false,
                 "opencode": false,
-                "openclaw": false
+                "openclaw": false,
+                "hermes": false
             }
         }),
     );
@@ -535,6 +546,7 @@ fn next_visible_app_wraps_and_skips_hidden_entries() {
         gemini: false,
         opencode: true,
         openclaw: true,
+        hermes: false,
     };
 
     assert_eq!(


### PR DESCRIPTION
## Summary

Adds Hermes as a first-class app target in `cc-switch-cli`, including provider management, live `~/.hermes/config.yaml` sync, TUI provider forms, skills/prompts integration, stream checks, and local environment version checks.

This PR also extends the home screen local environment card to show OpenClaw and Hermes CLI versions.

## Context / Source Notes

- Hermes config handling is adapted from the existing desktop `farion1231/cc-switch` behavior and the Hermes YAML schema used by `~/.hermes/config.yaml`.
- Provider/list/switch/add/update/remove behavior follows the existing `cc-switch-cli` OpenCode/OpenClaw service patterns so Hermes fits the current CLI architecture instead of adding a separate API surface.
- TUI form behavior follows the existing provider form state/template/json conversion patterns already used for OpenCode/OpenClaw.
- Local environment version detection extends the existing `services/local_env_check.rs` implementation that previously handled Claude, Codex, Gemini, and OpenCode.
- MCP support for Hermes is intentionally represented in shared app flags, but live MCP sync remains a no-op where the surrounding service already treats unsupported app-specific MCP writes conservatively.

## Detailed Review Map

### App model and settings

- `src-tauri/src/app_config.rs`
  - Adds `AppType::Hermes`.
  - Includes Hermes in app parsing, ordering, per-app provider managers, and app-specific roots for MCP/skills/prompts.
  - Extends shared app enablement structures with `hermes` where persisted state needs to round-trip.

- `src-tauri/src/settings.rs`
  - Adds `visible_apps.hermes`, `current_provider_hermes`, and `hermes_config_dir`.
  - Adds `get_hermes_override_dir()` so tests and users can point Hermes at a non-default config directory.

- `src-tauri/src/store.rs`, `src-tauri/src/sync_policy.rs`, `flake.nix`
  - Wires Hermes into app config persistence/sync and updates package description text.

### Hermes config adapter

- `src-tauri/src/hermes_config.rs`
  - New adapter for reading/writing `~/.hermes/config.yaml`.
  - Preserves existing YAML structure where possible and updates only managed provider/model fields.
  - Supports provider extraction, provider upsert/remove, default model updates, and future-facing memory/MCP helpers.
  - The live config shape follows Hermes YAML conventions rather than the JSON/TOML config shapes used by other apps.

### Provider service and live sync

- `src-tauri/src/services/provider/live.rs`
  - Adds live Hermes provider import/sync from `~/.hermes/config.yaml`.
  - Mirrors the existing OpenClaw live-provider sync approach while using Hermes YAML accessors.

- `src-tauri/src/services/provider/mod.rs`
  - Adds Hermes cases for provider add/update/delete/switch/remove-from-live.
  - Applies switch defaults by updating Hermes `model.provider` and default model fields.

- `src-tauri/src/services/provider/common_config.rs`
  - Keeps common config handling scoped to supported apps and avoids applying unsupported snippet logic to Hermes.

- `src-tauri/src/services/provider/usage.rs`
  - Adds Hermes credential extraction for API key/base URL/model discovery.

### CLI and TUI provider UX

- `src-tauri/src/cli/commands/provider_input.rs`
  - Adds interactive Hermes provider prompts.
  - Collects fields needed for Hermes-compatible provider entries.

- `src-tauri/src/cli/commands/provider_inspect.rs`
  - Adds Hermes as a target for model inspection/fetching.

- `src-tauri/src/cli/tui/form/provider_state.rs`
- `src-tauri/src/cli/tui/form/provider_state_loading.rs`
- `src-tauri/src/cli/tui/form/provider_json.rs`
- `src-tauri/src/cli/tui/form/provider_templates.rs`
- `src-tauri/src/cli/tui/ui/forms/provider.rs`
- `src-tauri/src/cli/tui/runtime_actions/providers.rs`
  - Adds Hermes-specific form loading, template defaults, JSON conversion, validation, and runtime save paths.
  - Reuses existing provider form abstractions to keep Hermes behavior consistent with other apps.

- `src-tauri/src/cli/tui/data.rs`
  - Syncs Hermes live providers before loading provider rows.
  - Marks whether Hermes providers exist in live config.

- `src-tauri/src/cli/tui/theme.rs`, `src-tauri/src/cli/ui/colors.rs`, `src-tauri/src/cli/tui/ui/overlay/pickers.rs`, `src-tauri/src/cli/tui/app/helpers.rs`
  - Adds Hermes display metadata, color, and app picker support.

### Environment check

- `src-tauri/src/services/local_env_check.rs`
  - Adds `OpenClaw` and `Hermes` tool specs.
  - Detects versions through `openclaw --version` / fallback `openclaw version` and `hermes --version` / fallback `hermes version`.

- `src-tauri/src/cli/tui/ui/main_page.rs`
  - Changes the home local environment card from 2x2 to 2x3.
  - Shows Claude, Codex, Gemini, OpenCode, OpenClaw, and Hermes without increasing card height.

- `src-tauri/src/cli/commands/env.rs`
  - Updates CLI help text from a fixed four-tool list to “supported app CLIs”.

### Skills, prompts, MCP, stream checks

- `src-tauri/src/services/skill.rs`
- `src-tauri/src/database/dao/skills.rs`
  - Adds Hermes enablement persistence for skills.
  - Uses `~/.hermes/skills` as the Hermes skills root.

- `src-tauri/src/prompt_files.rs`
  - Uses `~/.hermes/AGENTS.md` as the Hermes prompt file.

- `src-tauri/src/services/mcp.rs`
- `src-tauri/src/cli/commands/mcp.rs`
  - Adds Hermes app flags so shared MCP metadata round-trips correctly.
  - Keeps unsupported Hermes live MCP operations conservative.

- `src-tauri/src/services/stream_check/provider_extract.rs`
- `src-tauri/src/services/stream_check/service.rs`
  - Adds Hermes provider credential extraction and routes stream checks through the OpenAI-compatible path.

### Tests

- `src-tauri/src/services/local_env_check.rs`
  - Adds a unit test asserting OpenClaw and Hermes are included in local environment specs.

- `src-tauri/src/cli/tui/ui/tests.rs`
  - Updates TUI skill test fixtures for the new `SkillApps.hermes` field.

- `src-tauri/tests/settings_visible_apps.rs`
  - Updates isolated settings test stubs and expectations for the new Hermes app entry.

## Verification

Ran locally on macOS:

```bash
cargo fmt
cargo check --locked
cargo test --lib local_env_check
cargo test --test settings_visible_apps
cargo install --path . --locked --force
cc-switch env tools
```

Observed `cc-switch env tools` output includes:

```text
Claude   ok (2.1.143)
Codex    ok (0.130.0)
Gemini   ok (0.30.0)
OpenCode ok (1.2.15)
OpenClaw ok (2026.4.5)
Hermes   ok (0.13.0)
```

## Reviewer Notes

- The largest new surface is `hermes_config.rs`; it is intentionally isolated so reviewers can inspect YAML read/write behavior separately from CLI/TUI wiring.
- Provider switching writes to the real Hermes config file and follows existing backup/sync behavior used by the provider service.
- Existing local OpenCode warnings about providers missing `npm` were observed during smoke tests and appear unrelated to this change.
