### PR TITLE
Fix Claude model fetch picker returning to model picker

### DIFF
--- a/src-tauri/src/cli/tui/app/overlay_handlers/pickers.rs
+++ b/src-tauri/src/cli/tui/app/overlay_handlers/pickers.rs
@@ -351,6 +351,7 @@ impl App {
         let Overlay::ModelFetchPicker {
             field,
             claude_idx,
+            model_picker_selected_row,
             input,
             query,
             models,
@@ -373,7 +374,14 @@ impl App {
 
         Some(match key.code {
             KeyCode::Esc => {
-                self.overlay = Overlay::None;
+                if let Some(selected) = model_picker_selected_row {
+                    self.overlay = Overlay::ClaudeModelPicker {
+                        selected: *selected,
+                        editing: false,
+                    };
+                } else {
+                    self.overlay = Overlay::None;
+                }
                 Action::None
             }
             KeyCode::Up => {
@@ -403,13 +411,28 @@ impl App {
             KeyCode::Enter => {
                 let selected_model = input.value.trim().to_string();
                 if selected_model.is_empty() {
-                    self.overlay = Overlay::None;
+                    if let Some(selected) = model_picker_selected_row {
+                        self.overlay = Overlay::ClaudeModelPicker {
+                            selected: *selected,
+                            editing: false,
+                        };
+                    } else {
+                        self.overlay = Overlay::None;
+                    }
                     return Some(Action::None);
                 }
 
                 let field = *field;
                 let claude_idx = *claude_idx;
-                self.overlay = Overlay::None;
+                let return_to_picker = *model_picker_selected_row;
+                if let Some(selected) = return_to_picker {
+                    self.overlay = Overlay::ClaudeModelPicker {
+                        selected,
+                        editing: false,
+                    };
+                } else {
+                    self.overlay = Overlay::None;
+                }
 
                 if let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() {
                     if field == ProviderAddField::ClaudeModelConfig {

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -151,6 +151,7 @@ mod tests {
             request_id: 1,
             field: ProviderAddField::Name,
             claude_idx: None,
+            model_picker_selected_row: None,
             input: TextInput::new(""),
             query: String::new(),
             fetching: false,
@@ -1249,6 +1250,7 @@ mod tests {
             request_id: 1,
             field: ProviderAddField::Name,
             claude_idx: None,
+            model_picker_selected_row: None,
             input: TextInput::new("alpha beta"),
             query: "alpha beta".to_string(),
             fetching: false,
@@ -1269,6 +1271,152 @@ mod tests {
                     && input.cursor == ">alpha ".chars().count()
                     && query == ">alpha "
         ));
+    }
+
+    #[test]
+    fn model_fetch_picker_enter_with_picker_row_returns_to_claude_model_picker() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.form = Some(FormState::ProviderAdd(
+            ProviderAddFormState::new(AppType::Claude),
+        ));
+        app.overlay = Overlay::ModelFetchPicker {
+            request_id: 1,
+            field: ProviderAddField::ClaudeModelConfig,
+            claude_idx: Some(0),
+            model_picker_selected_row: Some(2),
+            input: TextInput::new("claude-sonnet-4-20250514"),
+            query: String::new(),
+            fetching: false,
+            models: vec!["claude-sonnet-4-20250514".to_string()],
+            error: None,
+            selected_idx: 0,
+        };
+
+        app.on_key(key(KeyCode::Enter), &data());
+
+        assert!(matches!(
+            app.overlay,
+            Overlay::ClaudeModelPicker {
+                selected: 2,
+                editing: false,
+            }
+        ));
+        let provider = match app.form.as_ref().unwrap() {
+            FormState::ProviderAdd(p) => p,
+            _ => panic!("expected ProviderAdd form"),
+        };
+        assert_eq!(
+            provider.claude_model_input(0).unwrap().value,
+            "claude-sonnet-4-20250514"
+        );
+    }
+
+    #[test]
+    fn model_fetch_picker_enter_without_picker_row_sets_overlay_none() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.form = Some(FormState::ProviderAdd(
+            ProviderAddFormState::new(AppType::Claude),
+        ));
+        app.overlay = Overlay::ModelFetchPicker {
+            request_id: 1,
+            field: ProviderAddField::ClaudeModelConfig,
+            claude_idx: Some(0),
+            model_picker_selected_row: None,
+            input: TextInput::new("claude-sonnet-4-20250514"),
+            query: String::new(),
+            fetching: false,
+            models: vec!["claude-sonnet-4-20250514".to_string()],
+            error: None,
+            selected_idx: 0,
+        };
+
+        app.on_key(key(KeyCode::Enter), &data());
+
+        assert!(matches!(app.overlay, Overlay::None));
+        let provider = match app.form.as_ref().unwrap() {
+            FormState::ProviderAdd(p) => p,
+            _ => panic!("expected ProviderAdd form"),
+        };
+        assert_eq!(
+            provider.claude_model_input(0).unwrap().value,
+            "claude-sonnet-4-20250514"
+        );
+    }
+
+    #[test]
+    fn model_fetch_picker_enter_empty_model_with_picker_row_returns_to_claude_model_picker() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.form = Some(FormState::ProviderAdd(
+            ProviderAddFormState::new(AppType::Claude),
+        ));
+        app.overlay = Overlay::ModelFetchPicker {
+            request_id: 1,
+            field: ProviderAddField::ClaudeModelConfig,
+            claude_idx: Some(0),
+            model_picker_selected_row: Some(3),
+            input: TextInput::new(""),
+            query: String::new(),
+            fetching: false,
+            models: Vec::new(),
+            error: None,
+            selected_idx: 0,
+        };
+
+        app.on_key(key(KeyCode::Enter), &data());
+
+        assert!(matches!(
+            app.overlay,
+            Overlay::ClaudeModelPicker {
+                selected: 3,
+                editing: false,
+            }
+        ));
+        let provider = match app.form.as_ref().unwrap() {
+            FormState::ProviderAdd(p) => p,
+            _ => panic!("expected ProviderAdd form"),
+        };
+        assert_eq!(provider.claude_model_input(0).unwrap().value, "");
+    }
+
+    #[test]
+    fn model_fetch_picker_enter_updates_correct_claude_idx_slot() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.form = Some(FormState::ProviderAdd(
+            ProviderAddFormState::new(AppType::Claude),
+        ));
+        app.overlay = Overlay::ModelFetchPicker {
+            request_id: 1,
+            field: ProviderAddField::ClaudeModelConfig,
+            claude_idx: Some(2),
+            model_picker_selected_row: Some(2),
+            input: TextInput::new("claude-haiku-4-20250514"),
+            query: String::new(),
+            fetching: false,
+            models: vec!["claude-haiku-4-20250514".to_string()],
+            error: None,
+            selected_idx: 0,
+        };
+
+        app.on_key(key(KeyCode::Enter), &data());
+
+        assert!(matches!(
+            app.overlay,
+            Overlay::ClaudeModelPicker { selected: 2, .. }
+        ));
+        let provider = match app.form.as_ref().unwrap() {
+            FormState::ProviderAdd(p) => p,
+            _ => panic!("expected ProviderAdd form"),
+        };
+        assert_eq!(
+            provider.claude_model_input(0).unwrap().value,
+            "",
+            "slot 0 should remain empty"
+        );
+        assert_eq!(
+            provider.claude_model_input(2).unwrap().value,
+            "claude-haiku-4-20250514",
+            "slot 2 should be updated"
+        );
     }
 
     #[test]

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -1276,9 +1276,9 @@ mod tests {
     #[test]
     fn model_fetch_picker_enter_with_picker_row_returns_to_claude_model_picker() {
         let mut app = App::new(Some(AppType::Claude));
-        app.form = Some(FormState::ProviderAdd(
-            ProviderAddFormState::new(AppType::Claude),
-        ));
+        app.form = Some(FormState::ProviderAdd(ProviderAddFormState::new(
+            AppType::Claude,
+        )));
         app.overlay = Overlay::ModelFetchPicker {
             request_id: 1,
             field: ProviderAddField::ClaudeModelConfig,
@@ -1314,9 +1314,9 @@ mod tests {
     #[test]
     fn model_fetch_picker_enter_without_picker_row_sets_overlay_none() {
         let mut app = App::new(Some(AppType::Claude));
-        app.form = Some(FormState::ProviderAdd(
-            ProviderAddFormState::new(AppType::Claude),
-        ));
+        app.form = Some(FormState::ProviderAdd(ProviderAddFormState::new(
+            AppType::Claude,
+        )));
         app.overlay = Overlay::ModelFetchPicker {
             request_id: 1,
             field: ProviderAddField::ClaudeModelConfig,
@@ -1346,9 +1346,9 @@ mod tests {
     #[test]
     fn model_fetch_picker_esc_with_picker_row_returns_to_claude_model_picker() {
         let mut app = App::new(Some(AppType::Claude));
-        app.form = Some(FormState::ProviderAdd(
-            ProviderAddFormState::new(AppType::Claude),
-        ));
+        app.form = Some(FormState::ProviderAdd(ProviderAddFormState::new(
+            AppType::Claude,
+        )));
         app.overlay = Overlay::ModelFetchPicker {
             request_id: 1,
             field: ProviderAddField::ClaudeModelConfig,
@@ -1381,9 +1381,9 @@ mod tests {
     #[test]
     fn model_fetch_picker_enter_empty_model_with_picker_row_returns_to_claude_model_picker() {
         let mut app = App::new(Some(AppType::Claude));
-        app.form = Some(FormState::ProviderAdd(
-            ProviderAddFormState::new(AppType::Claude),
-        ));
+        app.form = Some(FormState::ProviderAdd(ProviderAddFormState::new(
+            AppType::Claude,
+        )));
         app.overlay = Overlay::ModelFetchPicker {
             request_id: 1,
             field: ProviderAddField::ClaudeModelConfig,
@@ -1416,9 +1416,9 @@ mod tests {
     #[test]
     fn model_fetch_picker_enter_updates_correct_claude_idx_slot() {
         let mut app = App::new(Some(AppType::Claude));
-        app.form = Some(FormState::ProviderAdd(
-            ProviderAddFormState::new(AppType::Claude),
-        ));
+        app.form = Some(FormState::ProviderAdd(ProviderAddFormState::new(
+            AppType::Claude,
+        )));
         app.overlay = Overlay::ModelFetchPicker {
             request_id: 1,
             field: ProviderAddField::ClaudeModelConfig,

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -1344,6 +1344,41 @@ mod tests {
     }
 
     #[test]
+    fn model_fetch_picker_esc_with_picker_row_returns_to_claude_model_picker() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.form = Some(FormState::ProviderAdd(
+            ProviderAddFormState::new(AppType::Claude),
+        ));
+        app.overlay = Overlay::ModelFetchPicker {
+            request_id: 1,
+            field: ProviderAddField::ClaudeModelConfig,
+            claude_idx: Some(1),
+            model_picker_selected_row: Some(1),
+            input: TextInput::new("claude-sonnet-4-20250514"),
+            query: String::new(),
+            fetching: false,
+            models: vec!["claude-sonnet-4-20250514".to_string()],
+            error: None,
+            selected_idx: 0,
+        };
+
+        app.on_key(key(KeyCode::Esc), &data());
+
+        assert!(matches!(
+            app.overlay,
+            Overlay::ClaudeModelPicker {
+                selected: 1,
+                editing: false,
+            }
+        ));
+        let provider = match app.form.as_ref().unwrap() {
+            FormState::ProviderAdd(p) => p,
+            _ => panic!("expected ProviderAdd form"),
+        };
+        assert_eq!(provider.claude_model_input(1).unwrap().value, "");
+    }
+
+    #[test]
     fn model_fetch_picker_enter_empty_model_with_picker_row_returns_to_claude_model_picker() {
         let mut app = App::new(Some(AppType::Claude));
         app.form = Some(FormState::ProviderAdd(

--- a/src-tauri/src/cli/tui/app/types.rs
+++ b/src-tauri/src/cli/tui/app/types.rs
@@ -223,6 +223,7 @@ pub enum Overlay {
         request_id: u64,
         field: ProviderAddField,
         claude_idx: Option<usize>,
+        model_picker_selected_row: Option<usize>,
         input: TextInput,
         query: String,
         fetching: bool,

--- a/src-tauri/src/cli/tui/runtime_actions/providers.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/providers.rs
@@ -492,10 +492,16 @@ pub(super) fn model_fetch(
     };
     let request_id = next_model_fetch_request_id();
 
+    let model_picker_selected_row = match &ctx.app.overlay {
+        Overlay::ClaudeModelPicker { selected, .. } => Some(*selected),
+        _ => None,
+    };
+
     ctx.app.overlay = Overlay::ModelFetchPicker {
         request_id,
         field: field.clone(),
         claude_idx,
+        model_picker_selected_row,
         input: TextInput::new(""),
         query: String::new(),
         fetching: true,


### PR DESCRIPTION
**Description**

This PR fixes the Claude provider model selection flow so that returning from the model fetch picker preserves the Claude model picker context.

Previously, opening model fetch from the Claude model picker and then confirming or cancelling would close the overlay entirely. Now the fetch picker remembers the originating Claude model picker row and returns to `ClaudeModelPicker` when appropriate.

**Changes**

- Added `model_picker_selected_row` to `Overlay::ModelFetchPicker` to restore previous ClaudeModelPicker.
- Captured the selected Claude model row when launching model fetch from `ClaudeModelPicker`.
- Restored `ClaudeModelPicker` on `Esc`, empty `Enter`, and successful `Enter` when the fetch picker originated there.
- Kept non-Claude/direct model fetch behavior unchanged.
- Added regression tests for Enter, Esc, empty input, and correct Claude model slot updates.

**Testing**

```bash
cargo test model_fetch_picker --manifest-path src-tauri/Cargo.toml
```

