### PR TITLE
feat: duplicate provider configuration

### DIFF
--- a/src-tauri/src/cli/commands/provider.rs
+++ b/src-tauri/src/cli/commands/provider.rs
@@ -448,39 +448,13 @@ fn edit_provider(app_type: AppType, id: &str) -> Result<(), AppError> {
 
 fn duplicate_provider(app_type: AppType, id: &str) -> Result<(), AppError> {
     let state = AppState::try_new()?;
-    let (original, existing_ids) = {
-        let config = state.config.read().map_err(AppError::from)?;
-        let manager = config
-            .get_manager(&app_type)
-            .ok_or_else(|| AppError::Message(texts::app_config_not_found(app_type.as_str())))?;
-        let original = manager
-            .providers
-            .get(id)
-            .ok_or_else(|| {
-                let msg = texts::entity_not_found(texts::entity_provider(), id);
-                AppError::localized("provider.not_found", msg.clone(), msg)
-            })?
-            .clone();
-        let existing_ids = manager.providers.keys().cloned().collect::<Vec<_>>();
-        (original, existing_ids)
-    };
-
-    let duplicate_name = format!("{} copy", original.name.trim());
-    let duplicate_id = generate_provider_id(&duplicate_name, &existing_ids);
-    let mut duplicate = original;
-    duplicate.id = duplicate_id.clone();
-    duplicate.name = duplicate_name;
-    duplicate.created_at = None;
-    duplicate.sort_index = None;
-    duplicate.in_failover_queue = false;
-
-    ProviderService::add(&state, app_type, duplicate)?;
+    let duplicate = ProviderService::duplicate(&state, app_type, id, None)?;
 
     println!(
         "{}",
         success(&format!(
             "✓ Duplicated provider '{}' as '{}'",
-            id, duplicate_id
+            id, duplicate.id
         ))
     );
     Ok(())

--- a/src-tauri/src/cli/commands/provider.rs
+++ b/src-tauri/src/cli/commands/provider.rs
@@ -446,9 +446,43 @@ fn edit_provider(app_type: AppType, id: &str) -> Result<(), AppError> {
     Ok(())
 }
 
-fn duplicate_provider(_app_type: AppType, id: &str) -> Result<(), AppError> {
-    println!("{}", info(&format!("Duplicating provider '{}'...", id)));
-    println!("{}", error("Provider duplication is not yet implemented."));
+fn duplicate_provider(app_type: AppType, id: &str) -> Result<(), AppError> {
+    let state = AppState::try_new()?;
+    let (original, existing_ids) = {
+        let config = state.config.read().map_err(AppError::from)?;
+        let manager = config
+            .get_manager(&app_type)
+            .ok_or_else(|| AppError::Message(texts::app_config_not_found(app_type.as_str())))?;
+        let original = manager
+            .providers
+            .get(id)
+            .ok_or_else(|| {
+                let msg = texts::entity_not_found(texts::entity_provider(), id);
+                AppError::localized("provider.not_found", msg.clone(), msg)
+            })?
+            .clone();
+        let existing_ids = manager.providers.keys().cloned().collect::<Vec<_>>();
+        (original, existing_ids)
+    };
+
+    let duplicate_name = format!("{} copy", original.name.trim());
+    let duplicate_id = generate_provider_id(&duplicate_name, &existing_ids);
+    let mut duplicate = original;
+    duplicate.id = duplicate_id.clone();
+    duplicate.name = duplicate_name;
+    duplicate.created_at = None;
+    duplicate.sort_index = None;
+    duplicate.in_failover_queue = false;
+
+    ProviderService::add(&state, app_type, duplicate)?;
+
+    println!(
+        "{}",
+        success(&format!(
+            "✓ Duplicated provider '{}' as '{}'",
+            id, duplicate_id
+        ))
+    );
     Ok(())
 }
 

--- a/src-tauri/src/cli/commands/provider.rs
+++ b/src-tauri/src/cli/commands/provider.rs
@@ -452,10 +452,7 @@ fn duplicate_provider(app_type: AppType, id: &str) -> Result<(), AppError> {
 
     println!(
         "{}",
-        success(&format!(
-            "✓ Duplicated provider '{}' as '{}'",
-            id, duplicate.id
-        ))
+        success(&texts::provider_duplicated_success(id, &duplicate.id))
     );
     Ok(())
 }

--- a/src-tauri/src/cli/commands/provider.rs
+++ b/src-tauri/src/cli/commands/provider.rs
@@ -10,7 +10,7 @@ use crate::cli::commands::provider_input::{
     supports_common_config, OptionalFields, ProviderAddMode,
 };
 use crate::cli::i18n::texts;
-use crate::cli::ui::{error, highlight, info, success, warning};
+use crate::cli::ui::{highlight, info, success, warning};
 use crate::error::AppError;
 use crate::provider::{Provider, ProviderMeta};
 use crate::services::ProviderService;

--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -194,6 +194,17 @@ pub mod texts {
         }
     }
 
+    pub fn provider_duplicated_success(source_id: &str, duplicate_id: &str) -> String {
+        if is_chinese() {
+            format!("✓ 已复制供应商 '{}' 为 '{}'", source_id, duplicate_id)
+        } else {
+            format!(
+                "✓ Duplicated provider '{}' as '{}'",
+                source_id, duplicate_id
+            )
+        }
+    }
+
     pub fn entity_not_found(entity_type: &str, id: &str) -> String {
         if is_chinese() {
             format!("{}不存在: {}", entity_type, id)
@@ -9987,6 +9998,10 @@ mod tests {
     fn chinese_tui_copy_avoids_key_mixed_english_labels() {
         let _lang = use_test_language(Language::Chinese);
 
+        assert_eq!(
+            texts::provider_duplicated_success("source", "source-copy"),
+            "✓ 已复制供应商 'source' 为 'source-copy'"
+        );
         assert_eq!(texts::tui_home_section_connection(), "连接信息");
         assert_eq!(texts::tui_home_status_online(), "在线");
         assert_eq!(texts::tui_home_status_offline(), "离线");

--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -3070,6 +3070,14 @@ pub mod texts {
         }
     }
 
+    pub fn tui_key_copy() -> &'static str {
+        if is_chinese() {
+            "复制"
+        } else {
+            "copy"
+        }
+    }
+
     pub fn tui_key_delete() -> &'static str {
         if is_chinese() {
             "删除"

--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -5385,6 +5385,23 @@ pub mod texts {
         }
     }
 
+    pub fn tui_confirm_copy_provider_title() -> &'static str {
+        if is_chinese() {
+            "复制供应商"
+        } else {
+            // On the provider form we use "copy", however we use "duplicate" here to make it more clear.
+            "Duplicate(copy) Provider"
+        }
+    }
+
+    pub fn tui_confirm_copy_provider_message(name: &str, id: &str) -> String {
+        if is_chinese() {
+            format!("确定复制供应商 '{}' ({})？", name, id)
+        } else {
+            format!("Duplicate(copy) provider '{}' ({})?", name, id)
+        }
+    }
+
     pub fn tui_confirm_remove_provider_title() -> &'static str {
         if is_chinese() {
             "移除供应商"

--- a/src-tauri/src/cli/i18n/texts/core.rs
+++ b/src-tauri/src/cli/i18n/texts/core.rs
@@ -56,6 +56,17 @@ pub fn entity_deleted_success(entity_type: &str, name: &str) -> String {
     }
 }
 
+pub fn provider_duplicated_success(source_id: &str, duplicate_id: &str) -> String {
+    if is_chinese() {
+        format!("✓ 已复制供应商 '{}' 为 '{}'", source_id, duplicate_id)
+    } else {
+        format!(
+            "✓ Duplicated provider '{}' as '{}'",
+            source_id, duplicate_id
+        )
+    }
+}
+
 pub fn entity_not_found(entity_type: &str, id: &str) -> String {
     if is_chinese() {
         format!("{}不存在: {}", entity_type, id)

--- a/src-tauri/src/cli/tui/app/content_config.rs
+++ b/src-tauri/src/cli/tui/app/content_config.rs
@@ -1160,6 +1160,26 @@ impl App {
         self.maybe_show_common_config_notice();
     }
 
+    pub(crate) fn open_provider_copy_form(
+        &mut self,
+        row: &super::data::ProviderRow,
+        data: &UiData,
+    ) {
+        self.filter.active = false;
+        self.overlay = Overlay::None;
+        self.focus = Focus::Content;
+        self.editor = None;
+        self.form = Some(FormState::ProviderAdd(
+            ProviderAddFormState::copy_from_provider_with_common_snippet(
+                self.app_type.clone(),
+                &row.provider,
+                &data.config.common_snippet,
+                &data.existing_provider_ids(),
+            ),
+        ));
+        self.maybe_show_common_config_notice();
+    }
+
     pub(crate) fn open_mcp_add_form(&mut self) {
         self.filter.active = false;
         self.overlay = Overlay::None;

--- a/src-tauri/src/cli/tui/app/content_entities.rs
+++ b/src-tauri/src/cli/tui/app/content_entities.rs
@@ -143,6 +143,13 @@ impl App {
                 self.open_provider_add_form(data);
                 Action::None
             }
+            KeyCode::Char('c') => {
+                let Some(row) = visible.get(self.provider_idx) else {
+                    return Action::None;
+                };
+                self.open_provider_copy_form(row, data);
+                Action::None
+            }
             KeyCode::Char('e') => {
                 let Some(row) = visible.get(self.provider_idx) else {
                     return Action::None;

--- a/src-tauri/src/cli/tui/app/content_entities.rs
+++ b/src-tauri/src/cli/tui/app/content_entities.rs
@@ -37,6 +37,17 @@ impl App {
         });
     }
 
+    fn open_provider_copy_confirm(&mut self, row: &super::data::ProviderRow) {
+        self.overlay = Overlay::Confirm(ConfirmOverlay {
+            title: texts::tui_confirm_copy_provider_title().to_string(),
+            message: texts::tui_confirm_copy_provider_message(
+                &super::data::provider_display_name(&self.app_type, row),
+                &row.id,
+            ),
+            action: ConfirmAction::ProviderCopy { id: row.id.clone() },
+        });
+    }
+
     fn provider_switch_action(&mut self, row: &super::data::ProviderRow) -> Action {
         if self.app_type.is_additive_mode() {
             if row.is_in_config {
@@ -147,7 +158,7 @@ impl App {
                 let Some(row) = visible.get(self.provider_idx) else {
                     return Action::None;
                 };
-                self.open_provider_copy_form(row, data);
+                self.open_provider_copy_confirm(row);
                 Action::None
             }
             KeyCode::Char('e') => {

--- a/src-tauri/src/cli/tui/app/form_handlers/provider.rs
+++ b/src-tauri/src/cli/tui/app/form_handlers/provider.rs
@@ -30,7 +30,7 @@ impl App {
                 Some(Action::None)
             }
             KeyCode::Enter => {
-                let existing_ids = collect_existing_provider_ids(data);
+                let existing_ids = data.existing_provider_ids();
                 provider.apply_template(provider.template_idx, &existing_ids);
                 provider.focus = FormFocus::Fields;
                 Some(Action::None)
@@ -92,7 +92,7 @@ impl App {
                 Some(texts::base_url_empty_error())
             } else if let Some(message) = validate_usage_query_form(provider) {
                 Some(message)
-            } else if !provider.ensure_generated_id(&collect_existing_provider_ids(data)) {
+            } else if !provider.ensure_generated_id(&data.existing_provider_ids()) {
                 Some(if provider.mode.is_edit() {
                     texts::tui_toast_provider_missing_name()
                 } else {
@@ -869,7 +869,7 @@ impl App {
             provider.id_is_manual = true;
         }
         if changed && selected == ProviderAddField::Name && !provider.id_is_manual {
-            let existing_ids = collect_existing_provider_ids(data);
+            let existing_ids = data.existing_provider_ids();
             provider
                 .id
                 .set(crate::cli::commands::provider_input::generate_provider_id(
@@ -996,14 +996,6 @@ fn is_provider_divider_field(field: Option<&ProviderAddField>) -> bool {
                 | ProviderAddField::UsageQueryDivider
         )
     )
-}
-
-fn collect_existing_provider_ids(data: &UiData) -> Vec<String> {
-    data.providers
-        .rows
-        .iter()
-        .map(|row| row.id.clone())
-        .collect()
 }
 
 fn next_openclaw_api_protocol(current: &str) -> &'static str {

--- a/src-tauri/src/cli/tui/app/overlay_handlers/dialogs.rs
+++ b/src-tauri/src/cli/tui/app/overlay_handlers/dialogs.rs
@@ -30,6 +30,13 @@ impl App {
                     ConfirmAction::ProviderDelete { id } => {
                         Action::ProviderDelete { id: id.clone() }
                     }
+                    ConfirmAction::ProviderCopy { id } => {
+                        if let Some(row) = data.providers.rows.iter().find(|r| &r.id == id) {
+                            self.open_provider_copy_form(row, data);
+                        }
+                        // No action as we open a new form immediately
+                        return Some(Action::None);
+                    }
                     ConfirmAction::ProviderRemoveFromConfig { id } => {
                         Action::ProviderRemoveFromConfig { id: id.clone() }
                     }

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -214,6 +214,19 @@ mod tests {
         ));
     }
 
+    fn assert_provider_copy_confirm(app: &App, expected_id: &str, expected_name: &str) {
+        assert!(matches!(
+            &app.overlay,
+            Overlay::Confirm(ConfirmOverlay {
+                title,
+                message,
+                action: ConfirmAction::ProviderCopy { id },
+            }) if id == expected_id
+                && title == texts::tui_confirm_copy_provider_title()
+                && message == &texts::tui_confirm_copy_provider_message(expected_name, expected_id)
+        ));
+    }
+
     fn open_prompt_fields_form() -> App {
         let mut app = App::new(Some(AppType::Claude));
         app.route = Route::Prompts;
@@ -1921,7 +1934,7 @@ mod tests {
     }
 
     #[test]
-    fn providers_c_key_is_noop() {
+    fn providers_c_key_opens_copy_confirm() {
         let mut app = App::new(Some(AppType::Claude));
         app.route = Route::Providers;
         app.focus = Focus::Content;
@@ -1931,11 +1944,11 @@ mod tests {
 
         let action = app.on_key(key(KeyCode::Char('c')), &data);
         assert!(matches!(action, Action::None));
-        assert!(matches!(app.overlay, Overlay::None));
+        assert_provider_copy_confirm(&app, "p1", "Provider One");
     }
 
     #[test]
-    fn providers_c_key_is_noop_for_openclaw() {
+    fn providers_c_key_opens_copy_confirm_for_openclaw() {
         let mut app = App::new(Some(AppType::OpenClaw));
         app.route = Route::Providers;
         app.focus = Focus::Content;
@@ -1960,7 +1973,7 @@ mod tests {
 
         let action = app.on_key(key(KeyCode::Char('c')), &data);
         assert!(matches!(action, Action::None));
-        assert!(matches!(app.overlay, Overlay::None));
+        assert_provider_copy_confirm(&app, "p1", "Provider One");
     }
 
     #[test]
@@ -4323,6 +4336,47 @@ mod tests {
         assert!(matches!(action, Action::None));
         assert!(matches!(app.form, Some(FormState::ProviderAdd(_))));
         assert!(matches!(app.overlay, Overlay::None));
+    }
+
+    #[test]
+    fn provider_copy_confirm_opens_form_without_notice_after_common_config_confirmed() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+
+        let mut data = UiData::default();
+        data.providers.rows.push(claude_provider_row("p1"));
+
+        app.on_key(key(KeyCode::Char('c')), &data);
+        let action = app.on_key(key(KeyCode::Enter), &data);
+
+        assert!(matches!(action, Action::None));
+        assert!(matches!(app.form, Some(FormState::ProviderAdd(_))));
+        assert!(matches!(app.overlay, Overlay::None));
+    }
+
+    #[test]
+    fn provider_copy_confirm_preserves_first_common_config_notice() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+        app.common_config_notice_confirmed = false;
+
+        let mut data = UiData::default();
+        data.providers.rows.push(claude_provider_row("p1"));
+
+        app.on_key(key(KeyCode::Char('c')), &data);
+        let action = app.on_key(key(KeyCode::Enter), &data);
+
+        assert!(matches!(action, Action::None));
+        assert!(matches!(app.form, Some(FormState::ProviderAdd(_))));
+        assert!(matches!(
+            app.overlay,
+            Overlay::Confirm(ConfirmOverlay {
+                action: ConfirmAction::CommonConfigNotice,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -4388,6 +4388,82 @@ mod tests {
     }
 
     #[test]
+    #[serial]
+    fn provider_copy_confirm_save_persists_with_source_id_copy_semantics() {
+        let temp_home = TempDir::new().expect("create temp home");
+        let _home = EnvGuard::set_home(temp_home.path());
+
+        let state = crate::cli::tui::data::load_state().expect("load state");
+        {
+            let mut config = state.config.write().expect("lock config");
+            let manager = config
+                .get_manager_mut(&AppType::Claude)
+                .expect("claude manager");
+
+            let mut original = Provider::with_id(
+                "p1".to_string(),
+                "Provider One".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_BASE_URL": "https://example.com",
+                        "ANTHROPIC_AUTH_TOKEN": "sk-demo"
+                    }
+                }),
+                None,
+            );
+            original.sort_index = Some(4);
+            manager.providers.insert(original.id.clone(), original);
+
+            let mut existing_copy = Provider::with_id(
+                "p1-copy".to_string(),
+                "Existing Copy".to_string(),
+                json!({"env": {"ANTHROPIC_BASE_URL": "https://copy.example"}}),
+                None,
+            );
+            existing_copy.sort_index = Some(5);
+            manager
+                .providers
+                .insert(existing_copy.id.clone(), existing_copy);
+        }
+        state.save().expect("persist providers");
+
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+        app.common_config_notice_confirmed = true;
+        let mut data = UiData::load(&AppType::Claude).expect("load data");
+
+        app.on_key(key(KeyCode::Char('c')), &data);
+        app.on_key(key(KeyCode::Enter), &data);
+        let action = app.on_key(ctrl(KeyCode::Char('s')), &data);
+
+        run_runtime_action(&mut app, &mut data, action).expect("save copied provider");
+
+        let refreshed = UiData::load(&AppType::Claude).expect("reload data");
+        let copied = refreshed
+            .providers
+            .rows
+            .iter()
+            .find(|row| row.id == "p1-copy-2")
+            .expect("copy should use source id copy suffix");
+        assert_eq!(copied.provider.name, "Provider One copy");
+        assert_eq!(copied.provider.sort_index, Some(5));
+        assert!(copied.provider.created_at.is_some());
+        assert_eq!(
+            copied.provider.settings_config["env"]["ANTHROPIC_AUTH_TOKEN"],
+            "sk-demo"
+        );
+
+        let shifted = refreshed
+            .providers
+            .rows
+            .iter()
+            .find(|row| row.id == "p1-copy")
+            .expect("existing copy remains");
+        assert_eq!(shifted.provider.sort_index, Some(6));
+    }
+
+    #[test]
     fn provider_copy_confirm_preserves_first_common_config_notice() {
         let mut app = App::new(Some(AppType::Claude));
         app.route = Route::Providers;

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -4356,6 +4356,38 @@ mod tests {
     }
 
     #[test]
+    fn provider_copy_confirm_save_submits_new_copy_with_collision_free_id() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+        app.common_config_notice_confirmed = true;
+
+        let mut data = UiData::default();
+        data.providers.rows.push(claude_provider_row("p1"));
+        data.providers
+            .rows
+            .push(claude_provider_row("provider-one-copy"));
+
+        app.on_key(key(KeyCode::Char('c')), &data);
+        app.on_key(key(KeyCode::Enter), &data);
+        let action = app.on_key(ctrl(KeyCode::Char('s')), &data);
+
+        let Action::EditorSubmit { submit, content } = action else {
+            panic!("saving a copied provider should submit new provider content");
+        };
+        assert!(matches!(submit, EditorSubmit::ProviderAdd));
+
+        let copied: serde_json::Value =
+            serde_json::from_str(&content).expect("copy payload should be valid JSON");
+        assert_eq!(copied["id"], "provider-one-copy-1");
+        assert_eq!(copied["name"], "Provider One copy");
+        assert_eq!(
+            copied["settingsConfig"]["env"]["ANTHROPIC_AUTH_TOKEN"],
+            "sk-demo"
+        );
+    }
+
+    #[test]
     fn provider_copy_confirm_preserves_first_common_config_notice() {
         let mut app = App::new(Some(AppType::Claude));
         app.route = Route::Providers;

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -4379,7 +4379,7 @@ mod tests {
 
         let copied: serde_json::Value =
             serde_json::from_str(&content).expect("copy payload should be valid JSON");
-        assert_eq!(copied["id"], "provider-one-copy-1");
+        assert_eq!(copied["id"], "p1-copy");
         assert_eq!(copied["name"], "Provider One copy");
         assert_eq!(
             copied["settingsConfig"]["env"]["ANTHROPIC_AUTH_TOKEN"],

--- a/src-tauri/src/cli/tui/app/types.rs
+++ b/src-tauri/src/cli/tui/app/types.rs
@@ -60,6 +60,9 @@ pub enum ConfirmAction {
     ProviderDelete {
         id: String,
     },
+    ProviderCopy {
+        id: String,
+    },
     ProviderRemoveFromConfig {
         id: String,
     },

--- a/src-tauri/src/cli/tui/data.rs
+++ b/src-tauri/src/cli/tui/data.rs
@@ -369,7 +369,7 @@ impl UiData {
     // This method is called repeatedly during editing.
     // The ProvidersSnapshot in UiData never change, so it is safe to cache the existing_provider_ids.
     // However, the tests relied on a mutable and ProvidersSnapshot in UiData,
-    // so keep it re-computed every time for simplicity. 
+    // so keep it re-computed every time for simplicity.
     // If performance becomes an issue, we can refactor the tests to allow caching the existing_provider_ids.
     pub(crate) fn existing_provider_ids(&self) -> Vec<String> {
         self.providers

--- a/src-tauri/src/cli/tui/data.rs
+++ b/src-tauri/src/cli/tui/data.rs
@@ -365,6 +365,14 @@ impl UiData {
         self.proxy = load_proxy_snapshot(app_type)?;
         Ok(())
     }
+
+    pub(crate) fn existing_provider_ids(&self) -> Vec<String> {
+        self.providers
+            .rows
+            .iter()
+            .map(|row| row.id.clone())
+            .collect()
+    }
 }
 
 pub(crate) fn provider_display_name(app_type: &AppType, row: &ProviderRow) -> String {

--- a/src-tauri/src/cli/tui/data.rs
+++ b/src-tauri/src/cli/tui/data.rs
@@ -366,6 +366,11 @@ impl UiData {
         Ok(())
     }
 
+    // This method is called repeatedly during editing.
+    // The ProvidersSnapshot in UiData never change, so it is safe to cache the existing_provider_ids.
+    // However, the tests relied on a mutable and ProvidersSnapshot in UiData,
+    // so keep it re-computed every time for simplicity. 
+    // If performance becomes an issue, we can refactor the tests to allow caching the existing_provider_ids.
     pub(crate) fn existing_provider_ids(&self) -> Vec<String> {
         self.providers
             .rows

--- a/src-tauri/src/cli/tui/data.rs
+++ b/src-tauri/src/cli/tui/data.rs
@@ -169,6 +169,7 @@ impl QuotaSnapshot {
 pub struct ProvidersSnapshot {
     pub current_id: String,
     pub rows: Vec<ProviderRow>,
+    pub live_ids: HashSet<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -372,11 +373,14 @@ impl UiData {
     // so keep it re-computed every time for simplicity.
     // If performance becomes an issue, we can refactor the tests to allow caching the existing_provider_ids.
     pub(crate) fn existing_provider_ids(&self) -> Vec<String> {
-        self.providers
+        let mut ids = self
+            .providers
             .rows
             .iter()
             .map(|row| row.id.clone())
-            .collect()
+            .collect::<HashSet<_>>();
+        ids.extend(self.providers.live_ids.iter().cloned());
+        ids.into_iter().collect()
     }
 }
 
@@ -705,7 +709,18 @@ fn load_providers(state: &AppState, app_type: &AppType) -> Result<ProvidersSnaps
         rows
     };
 
-    Ok(ProvidersSnapshot { current_id, rows })
+    let live_ids = match app_type {
+        AppType::OpenCode => opencode_live_ids,
+        AppType::Hermes => hermes_live_ids,
+        AppType::OpenClaw => openclaw_live_providers.keys().cloned().collect(),
+        _ => HashSet::new(),
+    };
+
+    Ok(ProvidersSnapshot {
+        current_id,
+        rows,
+        live_ids,
+    })
 }
 
 fn sort_providers(providers: &IndexMap<String, Provider>) -> Vec<(String, Provider)> {
@@ -1644,6 +1659,59 @@ mod tests {
             saved_only.api_url.as_deref(),
             Some("https://saved.example.com/v1")
         );
+        assert!(snapshot.live_ids.contains("in-config"));
+    }
+
+    #[test]
+    #[serial]
+    fn existing_provider_ids_includes_opencode_live_only_ids() {
+        let _guard = lock_test_home_and_settings();
+        let temp = tempdir().expect("create tempdir");
+        let opencode_dir = temp.path().join("opencode");
+        std::fs::create_dir_all(&opencode_dir).expect("create opencode dir");
+        let _home = HomeGuard::set(temp.path());
+        let _settings = SettingsGuard::with_opencode_dir(&opencode_dir);
+
+        crate::opencode_config::set_provider(
+            "live-only",
+            json!({
+                "npm": "@ai-sdk/openai-compatible",
+                "options": {
+                    "baseURL": "https://live.example.com/v1"
+                },
+                "models": {
+                    "main": {"name": "Main"}
+                }
+            }),
+        )
+        .expect("seed live opencode provider");
+
+        let state = load_state().expect("load state");
+        {
+            let mut config = state.config.write().expect("lock config");
+            let manager = config
+                .get_manager_mut(&AppType::OpenCode)
+                .expect("opencode manager");
+            manager.providers.insert(
+                "saved-only".to_string(),
+                Provider::with_id(
+                    "saved-only".to_string(),
+                    "Saved Only".to_string(),
+                    json!({
+                        "options": {
+                            "baseURL": "https://saved.example.com/v1"
+                        }
+                    }),
+                    None,
+                ),
+            );
+        }
+        state.save().expect("persist opencode providers");
+
+        let data = UiData::load(&AppType::OpenCode).expect("load opencode data");
+        let ids = data.existing_provider_ids();
+        assert!(ids.iter().any(|id| id == "saved-only"));
+        assert!(ids.iter().any(|id| id == "live-only"));
     }
 
     #[test]

--- a/src-tauri/src/cli/tui/form.rs
+++ b/src-tauri/src/cli/tui/form.rs
@@ -281,6 +281,7 @@ pub struct McpEnvVarRow {
 pub struct ProviderAddFormState {
     pub app_type: AppType,
     pub mode: FormMode,
+    pub copy_source_id: Option<String>,
     pub focus: FormFocus,
     pub page: ProviderFormPage,
     pub template_idx: usize,

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -96,6 +96,7 @@ impl ProviderAddFormState {
         let mut form = Self {
             app_type,
             mode: FormMode::Add,
+            copy_source_id: None,
             focus: FormFocus::Templates,
             page: ProviderFormPage::Main,
             template_idx: 0,
@@ -224,11 +225,12 @@ impl ProviderAddFormState {
     ) -> Self {
         let mut form = Self::from_provider_with_common_snippet(app_type, provider, common_snippet);
         form.mode = FormMode::Add;
+        form.copy_source_id = Some(provider.id.clone());
         form.id_is_manual = false;
         form.name.set(format!("{} copy", provider.name.trim()));
         // Remove fields that should be unique or not copied over
         if let Some(extra) = form.extra.as_object_mut() {
-            for key in ["id", "createdAt", "sortIndex", "inFailoverQueue"] {
+            for key in ["id", "createdAt", "inFailoverQueue"] {
                 extra.remove(key);
             }
         }

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -216,6 +216,29 @@ impl ProviderAddFormState {
         form
     }
 
+    pub fn copy_from_provider_with_common_snippet(
+        app_type: AppType,
+        provider: &Provider,
+        common_snippet: &str,
+        existing_ids: &[String],
+    ) -> Self {
+        let mut form = Self::from_provider_with_common_snippet(app_type, provider, common_snippet);
+        form.mode = FormMode::Add;
+        form.id_is_manual = false;
+        form.name.set(format!("{} copy", provider.name.trim()));
+        if let Some(extra) = form.extra.as_object_mut() {
+            for key in ["id", "createdAt", "sortIndex", "inFailoverQueue"] {
+                extra.remove(key);
+            }
+        }
+        form.id
+            .set(crate::cli::commands::provider_input::generate_provider_id(
+                form.name.value.trim(),
+                existing_ids,
+            ));
+        form
+    }
+
     pub fn supports_common_config(app_type: &AppType) -> bool {
         matches!(app_type, AppType::Claude | AppType::Codex | AppType::Gemini)
     }

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -15,6 +15,22 @@ use super::{
     OPENCLAW_DEFAULT_API_PROTOCOL,
 };
 
+fn provider_copy_id(original_id: &str, existing_ids: &[String]) -> String {
+    let base_id = format!("{}-copy", original_id.trim());
+    if !existing_ids.iter().any(|id| id == &base_id) {
+        return base_id;
+    }
+
+    let mut counter = 2;
+    loop {
+        let candidate = format!("{base_id}-{counter}");
+        if !existing_ids.iter().any(|id| id == &candidate) {
+            return candidate;
+        }
+        counter += 1;
+    }
+}
+
 impl ProviderAddFormState {
     pub const USAGE_QUERY_GENERAL_PRESET: &'static str = r#"({
   request: {
@@ -234,11 +250,7 @@ impl ProviderAddFormState {
                 extra.remove(key);
             }
         }
-        form.id
-            .set(crate::cli::commands::provider_input::generate_provider_id(
-                form.name.value.trim(),
-                existing_ids,
-            ));
+        form.id.set(provider_copy_id(&provider.id, existing_ids));
         form
     }
 
@@ -294,7 +306,7 @@ impl ProviderAddFormState {
     }
 
     pub fn is_id_editable(&self) -> bool {
-        !self.mode.is_edit()
+        !self.mode.is_edit() && self.copy_source_id.is_none()
     }
 
     pub fn ensure_generated_id(&mut self, existing_ids: &[String]) -> bool {
@@ -320,7 +332,9 @@ impl ProviderAddFormState {
             ProviderAddField::Notes,
         ];
 
-        if matches!(self.app_type, AppType::Hermes | AppType::OpenClaw) {
+        if matches!(self.app_type, AppType::Hermes | AppType::OpenClaw)
+            && self.copy_source_id.is_none()
+        {
             fields.insert(0, ProviderAddField::Id);
         }
 

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -1105,6 +1105,7 @@ impl ProviderAddFormState {
         let previous_mode = self.mode.clone();
         let previous_focus = self.focus;
         let previous_page = self.page;
+        let previous_copy_source_id = self.copy_source_id.clone();
         let previous_template_idx = self.template_idx;
         let previous_field_idx = self.field_idx;
         let previous_usage_query_field_idx = self.usage_query_field_idx;
@@ -1137,6 +1138,7 @@ impl ProviderAddFormState {
         }
 
         next.mode = previous_mode.clone();
+        next.copy_source_id = previous_copy_source_id;
         next.focus = previous_focus;
         next.page = previous_page;
         next.template_idx = previous_template_idx;
@@ -1183,6 +1185,7 @@ impl ProviderAddFormState {
         let previous_mode = self.mode.clone();
         let previous_focus = self.focus;
         let previous_page = self.page;
+        let previous_copy_source_id = self.copy_source_id.clone();
         let previous_template_idx = self.template_idx;
         let previous_field_idx = self.field_idx;
         let previous_usage_query_field_idx = self.usage_query_field_idx;
@@ -1225,6 +1228,7 @@ impl ProviderAddFormState {
         }
 
         next.mode = previous_mode.clone();
+        next.copy_source_id = previous_copy_source_id;
         next.focus = previous_focus;
         next.page = previous_page;
         next.template_idx = previous_template_idx;

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -226,6 +226,7 @@ impl ProviderAddFormState {
         form.mode = FormMode::Add;
         form.id_is_manual = false;
         form.name.set(format!("{} copy", provider.name.trim()));
+        // Remove fields that should be unique or not copied over
         if let Some(extra) = form.extra.as_object_mut() {
             for key in ["id", "createdAt", "sortIndex", "inFailoverQueue"] {
                 extra.remove(key);

--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -2980,10 +2980,11 @@ fn provider_copy_form_uses_new_record_identity_without_queue_state() {
     let copied = form.to_provider_json_value();
 
     assert!(matches!(form.mode, FormMode::Add));
+    assert_eq!(form.copy_source_id.as_deref(), Some("test-provider"));
     assert_eq!(copied["id"], "test-provider-copy-1");
     assert_eq!(copied["name"], "Test Provider copy");
     assert!(copied.get("createdAt").is_none());
-    assert!(copied.get("sortIndex").is_none());
+    assert_eq!(copied["sortIndex"], 7);
     assert!(copied.get("inFailoverQueue").is_none());
     assert_eq!(
         copied["settingsConfig"]["env"]["ANTHROPIC_AUTH_TOKEN"],

--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -2347,6 +2347,39 @@ fn provider_edit_form_openclaw_keeps_provider_key_visible_but_locked() {
 }
 
 #[test]
+fn provider_copy_form_additive_apps_hide_provider_key() {
+    for app_type in [AppType::OpenClaw, AppType::Hermes] {
+        let provider = Provider::with_id(
+            "source-provider".to_string(),
+            "Source Provider".to_string(),
+            json!({
+                "baseUrl": "https://api.example/v1",
+                "apiKey": "sk-demo",
+            }),
+            None,
+        );
+
+        let form = ProviderAddFormState::copy_from_provider_with_common_snippet(
+            app_type.clone(),
+            &provider,
+            "",
+            &[],
+        );
+        let fields = form.fields();
+
+        assert_eq!(form.copy_source_id.as_deref(), Some("source-provider"));
+        assert!(
+            !fields.contains(&ProviderAddField::Id),
+            "{app_type:?} copy form should not expose a provider key that is regenerated on save"
+        );
+        assert!(
+            !form.is_id_editable(),
+            "{app_type:?} copy form should not allow editing the regenerated provider key"
+        );
+    }
+}
+
+#[test]
 fn provider_add_form_openclaw_uses_upstream_default_api_protocol() {
     let mut form = ProviderAddFormState::new(AppType::OpenClaw);
     form.id.set("oclaw1");
@@ -2981,7 +3014,7 @@ fn provider_copy_form_uses_new_record_identity_without_queue_state() {
 
     assert!(matches!(form.mode, FormMode::Add));
     assert_eq!(form.copy_source_id.as_deref(), Some("test-provider"));
-    assert_eq!(copied["id"], "test-provider-copy-1");
+    assert_eq!(copied["id"], "test-provider-copy-2");
     assert_eq!(copied["name"], "Test Provider copy");
     assert!(copied.get("createdAt").is_none());
     assert_eq!(copied["sortIndex"], 7);

--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -2942,6 +2942,52 @@ fn provider_edit_form_roundtrip_no_duplicate_common_config_key() {
 }
 
 #[test]
+fn provider_copy_form_uses_new_record_identity_without_queue_state() {
+    use crate::provider::ProviderMeta;
+
+    let mut provider = Provider {
+        id: "test-provider".to_string(),
+        name: "Test Provider".to_string(),
+        settings_config: json!({
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": "sk-test"
+            }
+        }),
+        website_url: Some("https://example.com".to_string()),
+        category: Some("third_party".to_string()),
+        created_at: Some(123),
+        sort_index: Some(7),
+        notes: Some("Keep visible notes".to_string()),
+        meta: Some(ProviderMeta {
+            endpoint_auto_select: Some(true),
+            ..Default::default()
+        }),
+        icon: Some("anthropic".to_string()),
+        icon_color: Some("#111111".to_string()),
+        in_failover_queue: true,
+    };
+    provider.meta.as_mut().unwrap().apply_common_config = Some(true);
+
+    let form = ProviderAddFormState::copy_from_provider_with_common_snippet(
+        AppType::Claude,
+        &provider,
+        "",
+        &["test-provider".to_string()],
+    );
+    let copied = form.to_provider_json_value();
+
+    assert!(matches!(form.mode, FormMode::Add));
+    assert_ne!(copied["id"], "test-provider");
+    assert_eq!(copied["name"], "Test Provider copy");
+    assert!(copied.get("createdAt").is_none());
+    assert!(copied.get("sortIndex").is_none());
+    assert!(copied.get("inFailoverQueue").is_none());
+    assert_eq!(copied["notes"], "Keep visible notes");
+    assert_eq!(copied["category"], "third_party");
+    assert_eq!(copied["meta"]["endpointAutoSelect"], true);
+}
+
+#[test]
 fn provider_edit_form_roundtrip_preserves_upstream_meta_auth_and_type_fields() {
     let provider_value = json!({
         "id": "provider-1",

--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -2972,19 +2972,27 @@ fn provider_copy_form_uses_new_record_identity_without_queue_state() {
         AppType::Claude,
         &provider,
         "",
-        &["test-provider".to_string()],
+        &[
+            "test-provider".to_string(),
+            "test-provider-copy".to_string(),
+        ],
     );
     let copied = form.to_provider_json_value();
 
     assert!(matches!(form.mode, FormMode::Add));
-    assert_ne!(copied["id"], "test-provider");
+    assert_eq!(copied["id"], "test-provider-copy-1");
     assert_eq!(copied["name"], "Test Provider copy");
     assert!(copied.get("createdAt").is_none());
     assert!(copied.get("sortIndex").is_none());
     assert!(copied.get("inFailoverQueue").is_none());
+    assert_eq!(
+        copied["settingsConfig"]["env"]["ANTHROPIC_AUTH_TOKEN"],
+        "sk-test"
+    );
     assert_eq!(copied["notes"], "Keep visible notes");
     assert_eq!(copied["category"], "third_party");
     assert_eq!(copied["meta"]["endpointAutoSelect"], true);
+    assert_eq!(copied["meta"]["commonConfigEnabled"], true);
 }
 
 #[test]

--- a/src-tauri/src/cli/tui/runtime_actions/claude_temp_launch.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/claude_temp_launch.rs
@@ -142,6 +142,7 @@ mod tests {
                     providers: ProvidersSnapshot {
                         current_id: current_id.to_string(),
                         rows,
+                        live_ids: Default::default(),
                     },
                     ..UiData::default()
                 },

--- a/src-tauri/src/cli/tui/runtime_actions/codex_temp_launch.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/codex_temp_launch.rs
@@ -137,6 +137,7 @@ mod tests {
                     providers: ProvidersSnapshot {
                         current_id: current_id.to_string(),
                         rows,
+                        live_ids: Default::default(),
                     },
                     ..UiData::default()
                 },

--- a/src-tauri/src/cli/tui/runtime_actions/editor.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/editor.rs
@@ -751,6 +751,10 @@ fn submit_provider_add(
             return Ok(());
         }
     };
+    let copy_source_id = match ctx.app.form.as_ref() {
+        Some(FormState::ProviderAdd(form)) => form.copy_source_id.clone(),
+        _ => None,
+    };
 
     if let Some(message) = validate_provider_submit(&ctx.app.app_type, &provider, false) {
         ctx.app.push_toast(message, ToastKind::Warning);
@@ -778,7 +782,19 @@ fn submit_provider_add(
     };
     provider.id = provider_id;
 
-    match ProviderService::add(&state, ctx.app.app_type.clone(), provider) {
+    let result = if let Some(copy_source_id) = copy_source_id {
+        ProviderService::duplicate(
+            &state,
+            ctx.app.app_type.clone(),
+            &copy_source_id,
+            Some(provider),
+        )
+        .map(|_| true)
+    } else {
+        ProviderService::add(&state, ctx.app.app_type.clone(), provider)
+    };
+
+    match result {
         Ok(true) => {
             ctx.app.editor = None;
             ctx.app.form = None;

--- a/src-tauri/src/cli/tui/runtime_actions/editor.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/editor.rs
@@ -1529,6 +1529,151 @@ mod tests {
 
     #[test]
     #[serial(home_settings)]
+    fn submit_provider_copy_after_settings_json_apply_keeps_duplicate_semantics() {
+        let mut fixture = runtime_ctx(AppType::OpenCode);
+
+        crate::opencode_config::set_provider(
+            "source",
+            json!({
+                "npm": "@ai-sdk/openai-compatible",
+                "options": {
+                    "baseURL": "https://live.example/v1",
+                    "apiKey": "sk-live"
+                },
+                "models": {
+                    "main": { "name": "Main" }
+                }
+            }),
+        )
+        .expect("seed live opencode provider");
+
+        let state = load_state().expect("load state");
+        {
+            let mut config = state.config.write().expect("lock config");
+            let manager = config
+                .get_manager_mut(&AppType::OpenCode)
+                .expect("opencode manager");
+            manager.providers.insert(
+                "source".to_string(),
+                Provider::with_id(
+                    "source".to_string(),
+                    "Source Provider".to_string(),
+                    json!({
+                        "npm": "@ai-sdk/openai-compatible",
+                        "options": {
+                            "baseURL": "https://source.example/v1",
+                            "apiKey": "sk-source"
+                        },
+                        "models": {
+                            "main": { "name": "Main" }
+                        }
+                    }),
+                    None,
+                ),
+            );
+        }
+        state.save().expect("persist source provider");
+        fixture.data = UiData::load(&AppType::OpenCode).expect("reload opencode ui data");
+
+        let source_provider = fixture
+            .data
+            .providers
+            .rows
+            .iter()
+            .find(|row| row.id == "source")
+            .expect("source provider row should exist")
+            .provider
+            .clone();
+        let copy_form =
+            crate::cli::tui::form::ProviderAddFormState::copy_from_provider_with_common_snippet(
+                AppType::OpenCode,
+                &source_provider,
+                "",
+                &fixture.data.existing_provider_ids(),
+            );
+        fixture.app.form = Some(FormState::ProviderAdd(copy_form));
+
+        let mut ctx = RuntimeActionContext {
+            terminal: &mut fixture.terminal,
+            app: &mut fixture.app,
+            data: &mut fixture.data,
+            speedtest_req_tx: None,
+            stream_check_req_tx: None,
+            skills_req_tx: None,
+            proxy_req_tx: None,
+            proxy_loading: &mut fixture.proxy_loading,
+            local_env_req_tx: None,
+            webdav_req_tx: None,
+            webdav_loading: &mut fixture.webdav_loading,
+            update_req_tx: None,
+            update_check: &mut fixture.update_check,
+            model_fetch_req_tx: None,
+        };
+
+        submit_provider_form_apply_json(
+            &mut ctx,
+            r#"{
+  "npm": "@ai-sdk/openai-compatible",
+  "options": {
+    "baseURL": "https://edited.example/v1",
+    "apiKey": "sk-source"
+  },
+  "models": {
+    "main": { "name": "Main" }
+  }
+}"#
+            .to_string(),
+        )
+        .expect("settings JSON apply should succeed");
+
+        let copy_payload = {
+            let FormState::ProviderAdd(form) = ctx
+                .app
+                .form
+                .as_ref()
+                .expect("provider copy form should remain open")
+            else {
+                panic!("expected provider copy form");
+            };
+            assert_eq!(form.copy_source_id.as_deref(), Some("source"));
+            serde_json::to_string_pretty(&form.to_provider_json_value())
+                .expect("serialize copied provider")
+        };
+
+        submit_provider_add(&mut ctx, copy_payload).expect("copy submit should succeed");
+
+        let copied = ctx
+            .data
+            .providers
+            .rows
+            .iter()
+            .find(|row| row.id == "source-copy")
+            .expect("copied provider should be saved with source copy id");
+        assert_eq!(
+            copied.provider.settings_config["options"]["baseURL"],
+            "https://edited.example/v1"
+        );
+        assert_eq!(
+            copied
+                .provider
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.live_config_managed),
+            Some(false),
+            "copy submit must keep additive duplicate addToLive=false semantics"
+        );
+
+        let live_providers =
+            crate::opencode_config::get_providers().expect("read opencode live providers");
+        assert!(live_providers.contains_key("source"));
+        assert!(
+            !live_providers.contains_key("source-copy"),
+            "copy submit after editing settings JSON must not write the duplicate into live config"
+        );
+    }
+
+    #[test]
+    #[serial(home_settings)]
     fn submit_provider_edit_updates_openclaw_live_backed_provider() {
         let home_dir = tempdir().expect("create temp home");
         let openclaw_dir = tempdir().expect("create temp openclaw dir");

--- a/src-tauri/src/cli/tui/ui/providers.rs
+++ b/src-tauri/src/cli/tui/ui/providers.rs
@@ -181,6 +181,7 @@ pub(super) fn render_providers(
             keys.push(("Enter", texts::tui_key_details()));
             keys.push(("Space", provider_switch_key_label(&app.app_type)));
             keys.push(("a", texts::tui_key_add()));
+            keys.push(("c", texts::tui_key_copy()));
             if let Some(row) = visible.get(app.provider_idx) {
                 if !data::provider_is_read_only(&app.app_type, row) {
                     keys.push(("e", texts::tui_key_edit()));

--- a/src-tauri/src/cli/tui/ui/providers.rs
+++ b/src-tauri/src/cli/tui/ui/providers.rs
@@ -181,6 +181,9 @@ pub(super) fn render_providers(
             keys.push(("Enter", texts::tui_key_details()));
             keys.push(("Space", provider_switch_key_label(&app.app_type)));
             keys.push(("a", texts::tui_key_add()));
+            // Theoretically we should use "duplicate" here.
+            // However this word is too long to fit in the key hint area,
+            // and key "d" is already used for delete, so we use "copy" here to make it shorter and avoid confusion.
             keys.push(("c", texts::tui_key_copy()));
             if let Some(row) = visible.get(app.provider_idx) {
                 if !data::provider_is_read_only(&app.app_type, row) {

--- a/src-tauri/src/cli/tui/ui/tests.rs
+++ b/src-tauri/src/cli/tui/ui/tests.rs
@@ -7437,6 +7437,7 @@ fn openclaw_provider_list_key_bar_uses_common_provider_actions() {
     }
 
     assert!(all.contains("Space add/remove"), "{all}");
+    assert!(all.contains("c copy"), "{all}");
     assert!(all.contains("t test"), "{all}");
     assert!(all.contains("x set default"), "{all}");
     assert!(!all.contains("s add/remove"), "{all}");

--- a/src-tauri/src/cli/tui/ui/tests.rs
+++ b/src-tauri/src/cli/tui/ui/tests.rs
@@ -611,6 +611,7 @@ pub(super) fn minimal_data(_app_type: &AppType) -> UiData {
     UiData {
         providers: ProvidersSnapshot {
             current_id: "p0".to_string(),
+            live_ids: Default::default(),
             rows: vec![ProviderRow {
                 id: "p1".to_string(),
                 provider,

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -156,6 +156,17 @@ impl ProviderService {
         duplicate
     }
 
+    fn normalize_duplicate_provider_snapshot(app_type: &AppType, provider: &mut Provider) {
+        if !matches!(app_type, AppType::Hermes) {
+            return;
+        }
+
+        if let Some(settings) = provider.settings_config.as_object_mut() {
+            settings.remove(crate::hermes_config::PROVIDER_SOURCE_FIELD);
+            settings.remove("provider_key");
+        }
+    }
+
     fn shift_sort_indices_for_duplicate(
         manager: &mut crate::provider::ProviderManager,
         source_id: &str,
@@ -212,6 +223,7 @@ impl ProviderService {
             existing_ids.extend(live_ids);
             let mut duplicate =
                 Self::duplicate_provider_with_overrides(&source, provider_override, &existing_ids);
+            Self::normalize_duplicate_provider_snapshot(&app_type_clone, &mut duplicate);
 
             Self::normalize_provider_if_claude(&app_type_clone, &mut duplicate);
             Self::inject_coding_plan_usage_script(&app_type_clone, &mut duplicate);

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -98,6 +98,143 @@ struct PostCommitAction {
 }
 
 impl ProviderService {
+    fn provider_copy_id(original_id: &str, existing_ids: &HashSet<String>) -> String {
+        let base_id = format!("{}-copy", original_id.trim());
+
+        if !existing_ids.contains(&base_id) {
+            return base_id;
+        }
+
+        let mut counter = 2;
+        loop {
+            let candidate = format!("{base_id}-{counter}");
+            if !existing_ids.contains(&candidate) {
+                return candidate;
+            }
+            counter += 1;
+        }
+    }
+
+    fn live_provider_ids(app_type: &AppType) -> Result<HashSet<String>, AppError> {
+        let ids = match app_type {
+            AppType::OpenCode => crate::opencode_config::get_providers()?
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect(),
+            AppType::Hermes => crate::hermes_config::get_providers()?
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect(),
+            AppType::OpenClaw => crate::openclaw_config::get_providers()?
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect(),
+            _ => HashSet::new(),
+        };
+        Ok(ids)
+    }
+
+    fn duplicate_provider_with_overrides(
+        source: &Provider,
+        provider: Option<Provider>,
+        existing_ids: &HashSet<String>,
+    ) -> Provider {
+        let mut duplicate = provider.unwrap_or_else(|| {
+            let mut duplicate = source.clone();
+            duplicate.name = format!("{} copy", source.name.trim());
+            duplicate
+        });
+        duplicate.id = Self::provider_copy_id(&source.id, existing_ids);
+        duplicate.name = if duplicate.name.trim().is_empty() {
+            format!("{} copy", source.name.trim())
+        } else {
+            duplicate.name.trim().to_string()
+        };
+        duplicate.created_at = Some(current_timestamp());
+        duplicate.in_failover_queue = false;
+        duplicate.sort_index = source.sort_index.map(|idx| idx + 1);
+        duplicate
+    }
+
+    fn shift_sort_indices_for_duplicate(
+        manager: &mut crate::provider::ProviderManager,
+        source_id: &str,
+        insert_sort_index: Option<usize>,
+    ) {
+        let Some(insert_sort_index) = insert_sort_index else {
+            return;
+        };
+
+        for (id, provider) in manager.providers.iter_mut() {
+            if id != source_id
+                && provider
+                    .sort_index
+                    .is_some_and(|idx| idx >= insert_sort_index)
+            {
+                provider.sort_index = provider.sort_index.map(|idx| idx + 1);
+            }
+        }
+    }
+
+    pub fn duplicate(
+        state: &AppState,
+        app_type: AppType,
+        source_id: &str,
+        provider_override: Option<Provider>,
+    ) -> Result<Provider, AppError> {
+        let app_type_clone = app_type.clone();
+        let source_id = source_id.to_string();
+        let live_ids = if app_type.is_additive_mode() {
+            Self::live_provider_ids(&app_type)?
+        } else {
+            HashSet::new()
+        };
+
+        Self::run_transaction(state, move |config| {
+            let common_config_snippet = config.common_config_snippets.get(&app_type_clone).cloned();
+            config.ensure_app(&app_type_clone);
+            let manager = config
+                .get_manager_mut(&app_type_clone)
+                .ok_or_else(|| Self::app_not_found(&app_type_clone))?;
+            let source = manager
+                .providers
+                .get(&source_id)
+                .ok_or_else(|| {
+                    AppError::localized(
+                        "provider.not_found",
+                        format!("供应商不存在: {source_id}"),
+                        format!("Provider not found: {source_id}"),
+                    )
+                })?
+                .clone();
+
+            let mut existing_ids = manager.providers.keys().cloned().collect::<HashSet<_>>();
+            existing_ids.extend(live_ids);
+            let mut duplicate =
+                Self::duplicate_provider_with_overrides(&source, provider_override, &existing_ids);
+
+            Self::normalize_provider_if_claude(&app_type_clone, &mut duplicate);
+            Self::inject_coding_plan_usage_script(&app_type_clone, &mut duplicate);
+            Self::validate_provider_settings(&app_type_clone, &duplicate)?;
+            Self::normalize_provider_for_storage(
+                &app_type_clone,
+                &mut duplicate,
+                common_config_snippet.as_deref(),
+            )?;
+
+            if app_type_clone.is_additive_mode() {
+                Self::set_provider_live_config_managed(&mut duplicate, false);
+            }
+
+            Self::shift_sort_indices_for_duplicate(manager, &source_id, duplicate.sort_index);
+            manager
+                .providers
+                .insert(duplicate.id.clone(), duplicate.clone());
+
+            Ok((duplicate, None))
+        })
+    }
+
     fn inject_coding_plan_usage_script(app_type: &AppType, provider: &mut Provider) {
         if !matches!(app_type, AppType::Claude) {
             return;

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -453,6 +453,72 @@ fn provider_duplicate_opencode_skips_live_write_and_avoids_live_only_id() {
 
 #[test]
 #[serial]
+fn provider_duplicate_hermes_clears_read_only_source_marker() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Hermes)
+            .expect("hermes manager");
+        manager.providers.insert(
+            "remote-provider".to_string(),
+            Provider::with_id(
+                "remote-provider".to_string(),
+                "Remote Provider".to_string(),
+                json!({
+                    "api_mode": "chat_completions",
+                    "base_url": "https://remote.example/v1",
+                    "api_key": "sk-remote",
+                    cc_switch_lib::hermes_config::PROVIDER_SOURCE_FIELD:
+                        cc_switch_lib::hermes_config::PROVIDER_SOURCE_DICT,
+                    "provider_key": "remote-provider",
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = state_from_config(config);
+    state.save().expect("persist test providers");
+    drop(state);
+
+    cc_switch_lib::cli::commands::provider::execute(
+        cc_switch_lib::cli::commands::provider::ProviderCommand::Duplicate {
+            id: "remote-provider".to_string(),
+        },
+        Some(AppType::Hermes),
+    )
+    .expect("duplicate command should succeed");
+
+    let refreshed = cc_switch_lib::AppState::try_new().expect("reload provider state");
+    let config = refreshed.config.read().expect("lock provider state");
+    let manager = config
+        .get_manager(&AppType::Hermes)
+        .expect("hermes manager after duplicate");
+    let copied = manager
+        .providers
+        .get("remote-provider-copy")
+        .expect("copy should use source id copy suffix");
+
+    assert!(copied
+        .settings_config
+        .get(cc_switch_lib::hermes_config::PROVIDER_SOURCE_FIELD)
+        .is_none());
+    assert!(copied.settings_config.get("provider_key").is_none());
+    assert_eq!(
+        copied
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.live_config_managed),
+        Some(false)
+    );
+}
+
+#[test]
+#[serial]
 fn provider_duplicate_missing_source_returns_error_without_creating_provider() {
     let _guard = lock_test_mutex();
     reset_test_fs();

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -278,15 +278,26 @@ fn provider_duplicate_persists_distinct_copy_and_skips_transient_state() {
         });
 
         manager.providers.insert(original.id.clone(), original);
-        manager.providers.insert(
-            "provider-one-copy".to_string(),
-            Provider::with_id(
+        manager.providers.insert("provider-one-copy".to_string(), {
+            let mut provider = Provider::with_id(
                 "provider-one-copy".to_string(),
                 "Existing Copy".to_string(),
                 json!({}),
                 None,
-            ),
-        );
+            );
+            provider.sort_index = Some(8);
+            provider
+        });
+        manager.providers.insert("later-provider".to_string(), {
+            let mut provider = Provider::with_id(
+                "later-provider".to_string(),
+                "Later Provider".to_string(),
+                json!({}),
+                None,
+            );
+            provider.sort_index = Some(9);
+            provider
+        });
     }
 
     let state = state_from_config(config);
@@ -312,7 +323,7 @@ fn provider_duplicate_persists_distinct_copy_and_skips_transient_state() {
         .expect("original provider remains");
     let copied = manager
         .providers
-        .get("provider-one-copy-1")
+        .get("provider-one-copy-2")
         .expect("copy uses a collision-free id");
 
     assert_eq!(original.name, "Provider One");
@@ -326,9 +337,118 @@ fn provider_duplicate_persists_distinct_copy_and_skips_transient_state() {
             .and_then(|meta| meta.endpoint_auto_select),
         Some(true)
     );
-    assert_eq!(copied.created_at, None);
-    assert_eq!(copied.sort_index, None);
+    assert!(copied.created_at.is_some());
+    assert_eq!(copied.sort_index, Some(8));
     assert!(!copied.in_failover_queue);
+    assert_eq!(
+        manager
+            .providers
+            .get("provider-one-copy")
+            .and_then(|provider| provider.sort_index),
+        Some(9)
+    );
+    assert_eq!(
+        manager
+            .providers
+            .get("later-provider")
+            .and_then(|provider| provider.sort_index),
+        Some(10)
+    );
+}
+
+#[test]
+#[serial]
+fn provider_duplicate_opencode_skips_live_write_and_avoids_live_only_id() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let live_path = home.join(".config").join("opencode").join("opencode.json");
+    std::fs::create_dir_all(live_path.parent().expect("live config parent"))
+        .expect("create opencode config dir");
+    std::fs::write(
+        &live_path,
+        serde_json::to_string_pretty(&json!({
+            "provider": {
+                "provider-one-copy": {
+                    "npm": "@ai-sdk/openai-compatible",
+                    "options": {
+                        "baseURL": "https://live.example",
+                        "apiKey": "sk-live"
+                    },
+                    "models": {
+                        "live-model": { "name": "Live Model" }
+                    }
+                }
+            }
+        }))
+        .expect("serialize live opencode config"),
+    )
+    .expect("seed live opencode config");
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::OpenCode)
+            .expect("opencode manager");
+        manager.providers.insert(
+            "provider-one".to_string(),
+            Provider::with_id(
+                "provider-one".to_string(),
+                "Provider One".to_string(),
+                json!({
+                    "npm": "@ai-sdk/openai-compatible",
+                    "options": {
+                        "baseURL": "https://one.example",
+                        "apiKey": "sk-one"
+                    },
+                    "models": {
+                        "model-one": { "name": "Model One" }
+                    }
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = state_from_config(config);
+    state.save().expect("persist test providers");
+    drop(state);
+
+    cc_switch_lib::cli::commands::provider::execute(
+        cc_switch_lib::cli::commands::provider::ProviderCommand::Duplicate {
+            id: "provider-one".to_string(),
+        },
+        Some(AppType::OpenCode),
+    )
+    .expect("duplicate command should succeed");
+
+    let refreshed = cc_switch_lib::AppState::try_new().expect("reload provider state");
+    let config = refreshed.config.read().expect("lock provider state");
+    let manager = config
+        .get_manager(&AppType::OpenCode)
+        .expect("opencode manager after duplicate");
+    let copied = manager
+        .providers
+        .get("provider-one-copy-2")
+        .expect("copy should avoid live-only id");
+
+    assert_eq!(
+        copied
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.live_config_managed),
+        Some(false)
+    );
+
+    let live_config: serde_json::Value =
+        read_json_file(&live_path).expect("read opencode live config");
+    let live_providers = live_config
+        .get("provider")
+        .and_then(|value| value.as_object())
+        .expect("live provider map");
+    assert!(live_providers.contains_key("provider-one-copy"));
+    assert!(!live_providers.contains_key("provider-one-copy-2"));
 }
 
 #[test]

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -5,7 +5,7 @@ use std::net::TcpListener;
 
 use cc_switch_lib::{
     get_claude_settings_path, get_codex_auth_path, get_codex_config_path, read_json_file,
-    write_codex_live_atomic, AppType, McpApps, McpServer, MultiAppConfig, Provider,
+    write_codex_live_atomic, AppType, McpApps, McpServer, MultiAppConfig, Provider, ProviderMeta,
     ProviderService,
 };
 
@@ -246,6 +246,118 @@ fn provider_export_rejects_non_claude_apps() {
         err.to_string().contains("supports only Claude"),
         "error should explain Claude-only support"
     );
+}
+
+#[test]
+#[serial]
+fn provider_duplicate_persists_distinct_copy_and_skips_transient_state() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "provider-one".to_string();
+
+        let mut original = Provider::with_id(
+            "provider-one".to_string(),
+            "Provider One".to_string(),
+            json!({"env": {"ANTHROPIC_AUTH_TOKEN": "sk-original"}}),
+            Some("https://example.com".to_string()),
+        );
+        original.created_at = Some(123);
+        original.sort_index = Some(7);
+        original.notes = Some("Retain this note".to_string());
+        original.in_failover_queue = true;
+        original.meta = Some(ProviderMeta {
+            endpoint_auto_select: Some(true),
+            ..Default::default()
+        });
+
+        manager.providers.insert(original.id.clone(), original);
+        manager.providers.insert(
+            "provider-one-copy".to_string(),
+            Provider::with_id(
+                "provider-one-copy".to_string(),
+                "Existing Copy".to_string(),
+                json!({}),
+                None,
+            ),
+        );
+    }
+
+    let state = state_from_config(config);
+    state.save().expect("persist test providers");
+    drop(state);
+
+    cc_switch_lib::cli::commands::provider::execute(
+        cc_switch_lib::cli::commands::provider::ProviderCommand::Duplicate {
+            id: "provider-one".to_string(),
+        },
+        Some(AppType::Claude),
+    )
+    .expect("duplicate command should succeed");
+
+    let refreshed = cc_switch_lib::AppState::try_new().expect("reload provider state");
+    let config = refreshed.config.read().expect("lock provider state");
+    let manager = config
+        .get_manager(&AppType::Claude)
+        .expect("claude manager after duplicate");
+    let original = manager
+        .providers
+        .get("provider-one")
+        .expect("original provider remains");
+    let copied = manager
+        .providers
+        .get("provider-one-copy-1")
+        .expect("copy uses a collision-free id");
+
+    assert_eq!(original.name, "Provider One");
+    assert_eq!(copied.name, "Provider One copy");
+    assert_eq!(copied.settings_config, original.settings_config);
+    assert_eq!(copied.notes.as_deref(), Some("Retain this note"));
+    assert_eq!(
+        copied
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.endpoint_auto_select),
+        Some(true)
+    );
+    assert_eq!(copied.created_at, None);
+    assert_eq!(copied.sort_index, None);
+    assert!(!copied.in_failover_queue);
+}
+
+#[test]
+#[serial]
+fn provider_duplicate_missing_source_returns_error_without_creating_provider() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    ensure_test_home();
+
+    let state = state_from_config(MultiAppConfig::default());
+    state.save().expect("persist empty test state");
+    drop(state);
+
+    let err = cc_switch_lib::cli::commands::provider::execute(
+        cc_switch_lib::cli::commands::provider::ProviderCommand::Duplicate {
+            id: "missing-provider".to_string(),
+        },
+        Some(AppType::Claude),
+    )
+    .expect_err("duplicating a missing provider should fail");
+    assert!(err.to_string().contains("missing-provider"), "{err}");
+
+    let refreshed = cc_switch_lib::AppState::try_new().expect("reload provider state");
+    let config = refreshed.config.read().expect("lock provider state");
+    assert!(config
+        .get_manager(&AppType::Claude)
+        .expect("claude manager after failed duplicate")
+        .providers
+        .is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add `c` keybinding in the TUI provider list to quickly duplicate an existing provider, pre-filling a new add form with the original's settings and a generated unique ID
- Implement the CLI `duplicate_provider` command (previously a stub)

## Changes

- **TUI provider list**: pressing `c` opens an add form pre-populated from the selected provider, with a new name (`{name} copy`), a generated ID, and identity/timestamp fields cleared
- **CLI**: `duplicate_provider` now reads the original provider, generates a unique ID, strips identity fields, and saves via `ProviderService::add`
- **i18n**: added `tui_key_copy()` text (中文: "复制", English: "copy")
- **Tests**: added `provider_copy_form_uses_new_record_identity_without_queue_state` to verify the copy form produces correct output
