### PR TITLE
feat(tui): add session message filters

### DIFF
--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -7426,6 +7426,18 @@ pub mod texts {
         }
     }
 
+    pub fn tui_sessions_messages_title_with_filter(query: Option<&str>) -> String {
+        let mut title = tui_sessions_messages_title().to_string();
+        if let Some(query) = query.filter(|value| !value.trim().is_empty()) {
+            if is_chinese() {
+                title.push_str(&format!(" · 搜索: {}", query.trim()));
+            } else {
+                title.push_str(&format!(" · Search: {}", query.trim()));
+            }
+        }
+        title
+    }
+
     pub fn tui_sessions_empty_title() -> &'static str {
         if is_chinese() {
             "未找到本地会话"
@@ -7583,6 +7595,14 @@ pub mod texts {
             "此会话没有可显示的消息。"
         } else {
             "No messages available for this session."
+        }
+    }
+
+    pub fn tui_sessions_messages_filtered_empty() -> &'static str {
+        if is_chinese() {
+            "没有符合当前筛选/搜索的消息。"
+        } else {
+            "No messages match the current filters."
         }
     }
 

--- a/src-tauri/src/cli/tui/app.rs
+++ b/src-tauri/src/cli/tui/app.rs
@@ -40,9 +40,9 @@ pub(crate) use content_config::HERMES_MEMORY_ROW_COUNT;
 pub use editor_state::{EditorKind, EditorMode, EditorState, EditorSubmit};
 pub(crate) use helpers::*;
 pub use types::{
-    CommonSnippetViewSource, ConfirmAction, ConfirmOverlay, FilterState, Focus, LoadingKind,
-    ManagedAuthLoginState, Overlay, SessionsPane, SessionsState, TextInputState, TextSubmit,
-    TextViewAction, TextViewState, Toast, ToastKind,
+    CommonSnippetViewSource, ConfirmAction, ConfirmOverlay, FilterScope, FilterState, Focus,
+    LoadingKind, ManagedAuthLoginState, Overlay, SessionsPane, SessionsState, TextInputState,
+    TextSubmit, TextViewAction, TextViewState, Toast, ToastKind,
 };
 
 pub(crate) fn supports_failover_controls(app_type: &AppType) -> bool {

--- a/src-tauri/src/cli/tui/app/content_entities.rs
+++ b/src-tauri/src/cli/tui/app/content_entities.rs
@@ -31,7 +31,14 @@ impl App {
     }
 
     fn open_selected_session_detail(&mut self, data: &UiData) -> Action {
-        let visible = visible_sessions(&self.filter, &self.app_type, &self.sessions.rows);
+        let visible = visible_sessions_for_state(
+            &self.filter,
+            &self.app_type,
+            &self.sessions.rows,
+            self.sessions.detail_key.as_deref(),
+            self.sessions.messages_loaded,
+            &self.sessions.messages,
+        );
         let Some(session) = visible.get(self.sessions.selected_idx) else {
             return Action::None;
         };
@@ -495,7 +502,14 @@ impl App {
     }
 
     pub(crate) fn on_sessions_key(&mut self, key: KeyEvent, data: &UiData) -> Action {
-        let visible = visible_sessions(&self.filter, &self.app_type, &self.sessions.rows);
+        let visible = visible_sessions_for_state(
+            &self.filter,
+            &self.app_type,
+            &self.sessions.rows,
+            self.sessions.detail_key.as_deref(),
+            self.sessions.messages_loaded,
+            &self.sessions.messages,
+        );
         match key.code {
             KeyCode::Left => self.move_sessions_focus_left(),
             KeyCode::Right => self.move_sessions_focus_right(data),
@@ -505,7 +519,21 @@ impl App {
                         self.sessions.selected_idx = self.sessions.selected_idx.saturating_sub(1);
                     }
                     SessionsPane::Detail => {
-                        self.sessions.message_idx = self.sessions.message_idx.saturating_sub(1);
+                        let next_idx = {
+                            let messages = visible_session_messages(&self.sessions);
+                            if messages.is_empty() {
+                                Some(0)
+                            } else {
+                                let current = messages
+                                    .iter()
+                                    .position(|(index, _)| *index == self.sessions.message_idx)
+                                    .unwrap_or(0);
+                                Some(messages[current.saturating_sub(1)].0)
+                            }
+                        };
+                        if let Some(next_idx) = next_idx {
+                            self.sessions.message_idx = next_idx;
+                        }
                     }
                 }
                 Action::None
@@ -519,9 +547,20 @@ impl App {
                         }
                     }
                     SessionsPane::Detail => {
-                        if !self.sessions.messages.is_empty() {
-                            self.sessions.message_idx = (self.sessions.message_idx + 1)
-                                .min(self.sessions.messages.len() - 1);
+                        let next_idx = {
+                            let messages = visible_session_messages(&self.sessions);
+                            if messages.is_empty() {
+                                Some(0)
+                            } else {
+                                let current = messages
+                                    .iter()
+                                    .position(|(index, _)| *index == self.sessions.message_idx)
+                                    .unwrap_or(0);
+                                Some(messages[(current + 1).min(messages.len() - 1)].0)
+                            }
+                        };
+                        if let Some(next_idx) = next_idx {
+                            self.sessions.message_idx = next_idx;
                         }
                     }
                 }
@@ -530,8 +569,13 @@ impl App {
             KeyCode::Enter => match self.sessions.pane {
                 SessionsPane::List => self.open_selected_session_detail(data),
                 SessionsPane::Detail => {
-                    let Some(message) = self.sessions.messages.get(self.sessions.message_idx)
-                    else {
+                    let messages = visible_session_messages(&self.sessions);
+                    let message = messages
+                        .iter()
+                        .find(|(index, _)| *index == self.sessions.message_idx)
+                        .or_else(|| messages.first())
+                        .map(|(_, message)| *message);
+                    let Some(message) = message else {
                         return Action::None;
                     };
                     self.overlay = Overlay::TextView(TextViewState {

--- a/src-tauri/src/cli/tui/app/helpers.rs
+++ b/src-tauri/src/cli/tui/app/helpers.rs
@@ -768,6 +768,7 @@ pub(crate) fn session_key(session: &crate::session_manager::SessionMeta) -> Stri
     )
 }
 
+#[cfg(test)]
 pub(crate) fn visible_sessions<'a>(
     filter: &FilterState,
     app_type: &AppType,
@@ -784,6 +785,85 @@ pub(crate) fn visible_sessions<'a>(
         .collect()
 }
 
+pub(crate) fn visible_sessions_for_state<'a>(
+    filter: &FilterState,
+    app_type: &AppType,
+    rows: &'a [crate::session_manager::SessionMeta],
+    detail_key: Option<&str>,
+    messages_loaded: bool,
+    messages: &[crate::session_manager::SessionMessage],
+) -> Vec<&'a crate::session_manager::SessionMeta> {
+    let query = filter.query_lower();
+    let provider_id = app_type.as_str();
+    let message_match_key = query.as_deref().and_then(|_| {
+        loaded_detail_message_match_key(filter, detail_key, messages_loaded, messages)
+    });
+
+    rows.iter()
+        .filter(|row| row.provider_id == provider_id)
+        .filter(|row| match &query {
+            None => true,
+            Some(q) => {
+                session_matches_filter(row, q)
+                    || message_match_key
+                        .as_deref()
+                        .is_some_and(|key| session_key(row) == key)
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn visible_session_messages<'a>(
+    sessions: &'a SessionsState,
+) -> Vec<(usize, &'a crate::session_manager::SessionMessage)> {
+    let query = sessions.message_query_lower();
+    sessions
+        .messages
+        .iter()
+        .enumerate()
+        .filter(|(_, message)| match &query {
+            None => true,
+            Some(query) => session_message_matches_message_filter(message, query),
+        })
+        .collect()
+}
+
+pub(crate) fn clamp_session_message_selection(sessions: &mut SessionsState) {
+    let selected = {
+        let visible = visible_session_messages(sessions);
+        if visible.is_empty() {
+            Some(0)
+        } else if visible
+            .iter()
+            .any(|(index, _)| *index == sessions.message_idx)
+        {
+            None
+        } else {
+            Some(visible[0].0)
+        }
+    };
+    if let Some(selected) = selected {
+        sessions.message_idx = selected;
+    }
+}
+
+fn loaded_detail_message_match_key(
+    filter: &FilterState,
+    detail_key: Option<&str>,
+    messages_loaded: bool,
+    messages: &[crate::session_manager::SessionMessage],
+) -> Option<String> {
+    let key = detail_key?;
+    if !messages_loaded || messages.is_empty() {
+        return None;
+    }
+    let query = filter.query_lower()?;
+    messages
+        .iter()
+        .any(|message| session_message_matches_filter(message, &query))
+        .then(|| key.to_string())
+}
+
 fn session_matches_filter(session: &crate::session_manager::SessionMeta, query: &str) -> bool {
     filter_text_matches(&session.provider_id, query)
         || filter_text_matches(&session.session_id, query)
@@ -793,6 +873,41 @@ fn session_matches_filter(session: &crate::session_manager::SessionMeta, query: 
         || filter_option_path_matches(session.source_path.as_deref(), query)
         || filter_option_text_matches(session.resume_command.as_deref(), query)
         || filter_timestamp_matches(session.last_active_at.or(session.created_at), query)
+}
+
+fn session_message_matches_filter(
+    message: &crate::session_manager::SessionMessage,
+    query: &str,
+) -> bool {
+    filter_text_matches(&message.role, query)
+        || filter_text_matches(
+            &crate::cli::i18n::texts::tui_sessions_role_label(&message.role),
+            query,
+        )
+        || filter_text_matches(&message.content, query)
+        || filter_timestamp_matches(message.ts, query)
+}
+
+fn session_message_matches_message_filter(
+    message: &crate::session_manager::SessionMessage,
+    query: &str,
+) -> bool {
+    if let Some(role) = session_message_role_query(query) {
+        return message.role.eq_ignore_ascii_case(role);
+    }
+
+    session_message_matches_filter(message, query)
+}
+
+fn session_message_role_query(query: &str) -> Option<&'static str> {
+    match query.trim() {
+        "user" | "用户" => Some("user"),
+        "assistant" | "ai" | "助手" => Some("assistant"),
+        "system" | "系统" => Some("system"),
+        "tool" | "工具" => Some("tool"),
+        "developer" | "开发者" => Some("developer"),
+        _ => None,
+    }
 }
 
 fn filter_option_text_matches(value: Option<&str>, query: &str) -> bool {

--- a/src-tauri/src/cli/tui/app/menu.rs
+++ b/src-tauri/src/cli/tui/app/menu.rs
@@ -12,6 +12,38 @@ impl App {
         self.daily_memory_idx = 0;
     }
 
+    pub(crate) fn displayed_filter_input(&self) -> &TextInput {
+        match self.displayed_filter_scope() {
+            FilterScope::Global => &self.filter.input,
+            FilterScope::SessionMessages => &self.sessions.message_filter,
+        }
+    }
+
+    pub(crate) fn should_show_filter_bar(&self) -> bool {
+        self.filter.active || !self.displayed_filter_input().value.trim().is_empty()
+    }
+
+    fn displayed_filter_scope(&self) -> FilterScope {
+        if self.filter.active {
+            return self.filter.scope;
+        }
+        if matches!(self.route, Route::Sessions)
+            && matches!(self.focus, Focus::Content)
+            && matches!(self.sessions.pane, SessionsPane::Detail)
+            && !self.sessions.message_filter.value.trim().is_empty()
+        {
+            return FilterScope::SessionMessages;
+        }
+        FilterScope::Global
+    }
+
+    fn active_filter_input_mut(&mut self) -> &mut TextInput {
+        match self.filter.scope {
+            FilterScope::Global => &mut self.filter.input,
+            FilterScope::SessionMessages => &mut self.sessions.message_filter,
+        }
+    }
+
     pub fn new(app_override: Option<AppType>) -> Self {
         let app_type = app_override.unwrap_or(AppType::Claude);
         Self {
@@ -521,13 +553,15 @@ impl App {
     }
 
     pub(crate) fn on_filter_key(&mut self, key: KeyEvent, data: &UiData) -> Action {
-        let is_daily_memory = matches!(self.route, Route::ConfigOpenClawDailyMemory);
+        let scope = self.filter.scope;
+        let is_daily_memory = matches!(scope, FilterScope::Global)
+            && matches!(self.route, Route::ConfigOpenClawDailyMemory);
         let mut filter_changed = false;
         let action = match key.code {
             KeyCode::Esc => {
-                filter_changed = !self.filter.input.value.is_empty();
+                filter_changed = !self.active_filter_input_mut().value.is_empty();
                 self.filter.active = false;
-                self.filter.input.set("");
+                self.active_filter_input_mut().set("");
                 if is_daily_memory {
                     self.openclaw_daily_memory_search_results.clear();
                     self.daily_memory_idx = 0;
@@ -549,7 +583,7 @@ impl App {
                 }
             }
             _ => {
-                let Some(edit) = self.filter.input.apply_key(key) else {
+                let Some(edit) = self.active_filter_input_mut().apply_key(key) else {
                     return Action::None;
                 };
                 filter_changed = edit.changed;
@@ -562,7 +596,7 @@ impl App {
                 }
             }
         };
-        self.sync_after_filter_key(data, filter_changed);
+        self.sync_after_filter_key(data, filter_changed, scope);
         action
     }
 
@@ -623,17 +657,31 @@ impl App {
     }
 
     fn prepare_filter_focus(&mut self) {
-        if matches!(self.route, Route::Sessions) {
+        if matches!(self.route, Route::Sessions)
+            && matches!(self.focus, Focus::Content)
+            && matches!(self.sessions.pane, SessionsPane::Detail)
+        {
+            self.filter.scope = FilterScope::SessionMessages;
+        } else {
+            self.filter.scope = FilterScope::Global;
+        }
+        if matches!(self.route, Route::Sessions) && matches!(self.filter.scope, FilterScope::Global)
+        {
             self.sessions.pane = SessionsPane::List;
         }
     }
 
-    fn sync_after_filter_key(&mut self, data: &UiData, filter_changed: bool) {
+    fn sync_after_filter_key(&mut self, data: &UiData, filter_changed: bool, scope: FilterScope) {
+        if matches!(scope, FilterScope::SessionMessages) {
+            if filter_changed {
+                clamp_session_message_selection(&mut self.sessions);
+            }
+            return;
+        }
         if matches!(self.route, Route::Sessions) {
             self.sessions.pane = SessionsPane::List;
             if filter_changed {
                 self.sessions.selected_idx = 0;
-                self.sessions.clear_detail();
             }
         }
         self.clamp_selections(data);
@@ -661,8 +709,14 @@ impl App {
             self.prompt_idx = self.prompt_idx.min(prompt_len - 1);
         }
 
-        let visible_session_rows =
-            visible_sessions(&self.filter, &self.app_type, &self.sessions.rows);
+        let visible_session_rows = visible_sessions_for_state(
+            &self.filter,
+            &self.app_type,
+            &self.sessions.rows,
+            self.sessions.detail_key.as_deref(),
+            self.sessions.messages_loaded,
+            &self.sessions.messages,
+        );
         let sessions_len = visible_session_rows.len();
         if sessions_len == 0 {
             self.sessions.selected_idx = 0;
@@ -677,14 +731,7 @@ impl App {
         if session_detail_missing {
             self.sessions.clear_detail();
         }
-        if self.sessions.messages.is_empty() {
-            self.sessions.message_idx = 0;
-        } else {
-            self.sessions.message_idx = self
-                .sessions
-                .message_idx
-                .min(self.sessions.messages.len() - 1);
-        }
+        clamp_session_message_selection(&mut self.sessions);
 
         let skills_len = visible_skills_installed(&self.filter, data).len();
         if skills_len == 0 {

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -13776,7 +13776,7 @@ mod tests {
     }
 
     #[test]
-    fn sessions_filter_starts_on_list_pane_from_detail() {
+    fn sessions_filter_targets_messages_from_detail_pane() {
         let mut app = app_with_session_page();
         let data = UiData::default();
         app.sessions.pane = SessionsPane::Detail;
@@ -13784,7 +13784,8 @@ mod tests {
         app.on_key(key(KeyCode::Char('/')), &data);
 
         assert!(app.filter.active);
-        assert_eq!(app.sessions.pane, SessionsPane::List);
+        assert_eq!(app.filter.scope, FilterScope::SessionMessages);
+        assert_eq!(app.sessions.pane, SessionsPane::Detail);
     }
 
     #[test]
@@ -13836,7 +13837,7 @@ mod tests {
             content: "old detail".to_string(),
             ts: Some(1_735_689_900_000),
         }];
-        app.sessions.pane = SessionsPane::Detail;
+        app.sessions.pane = SessionsPane::List;
 
         app.on_key(key(KeyCode::Char('/')), &data);
         app.on_key(key(KeyCode::Char('b')), &data);

--- a/src-tauri/src/cli/tui/app/types.rs
+++ b/src-tauri/src/cli/tui/app/types.rs
@@ -4,6 +4,7 @@ use super::*;
 pub struct FilterState {
     pub active: bool,
     pub input: TextInput,
+    pub scope: FilterScope,
 }
 
 impl FilterState {
@@ -11,6 +12,7 @@ impl FilterState {
         Self {
             active: false,
             input: TextInput::new(""),
+            scope: FilterScope::Global,
         }
     }
 
@@ -21,6 +23,12 @@ impl FilterState {
         }
         Some(trimmed.to_lowercase())
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilterScope {
+    Global,
+    SessionMessages,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -51,6 +59,7 @@ pub struct SessionsState {
     pub detail_key: Option<String>,
     pub messages_key: Option<String>,
     pub messages: Vec<crate::session_manager::SessionMessage>,
+    pub message_filter: TextInput,
     pub messages_loading: bool,
     pub messages_loaded: bool,
     pub messages_error: Option<String>,
@@ -77,6 +86,7 @@ impl Default for SessionsState {
             detail_key: None,
             messages_key: None,
             messages: Vec::new(),
+            message_filter: TextInput::new(""),
             messages_loading: false,
             messages_loaded: false,
             messages_error: None,
@@ -152,6 +162,14 @@ impl SessionsState {
         }
         self.detail_key = Some(key);
         self.clear_messages();
+    }
+
+    pub(crate) fn message_query_lower(&self) -> Option<String> {
+        let trimmed = self.message_filter.value.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        Some(trimmed.to_lowercase())
     }
 
     pub(crate) fn clear_detail(&mut self) {

--- a/src-tauri/src/cli/tui/runtime_systems/handlers.rs
+++ b/src-tauri/src/cli/tui/runtime_systems/handlers.rs
@@ -110,10 +110,13 @@ pub(crate) fn handle_session_msg(app: &mut App, msg: SessionMsg) {
         SessionMsg::ScanFinished { request_id, result } => match result {
             Ok(rows) => {
                 if app.sessions.finish_scan(request_id, rows) {
-                    let visible_len = crate::cli::tui::app::visible_sessions(
+                    let visible_len = crate::cli::tui::app::visible_sessions_for_state(
                         &app.filter,
                         &app.app_type,
                         &app.sessions.rows,
+                        app.sessions.detail_key.as_deref(),
+                        app.sessions.messages_loaded,
+                        &app.sessions.messages,
                     )
                     .len();
                     if visible_len == 0 {
@@ -137,7 +140,9 @@ pub(crate) fn handle_session_msg(app: &mut App, msg: SessionMsg) {
             result,
         } => match result {
             Ok(messages) => {
-                app.sessions.finish_message_load(request_id, &key, messages);
+                if app.sessions.finish_message_load(request_id, &key, messages) {
+                    crate::cli::tui::app::clamp_session_message_selection(&mut app.sessions);
+                }
             }
             Err(error) => {
                 app.sessions
@@ -155,10 +160,13 @@ pub(crate) fn handle_session_msg(app: &mut App, msg: SessionMsg) {
         } => match result {
             Ok(()) => {
                 if app.sessions.finish_delete(request_id, &key) {
-                    let visible_len = crate::cli::tui::app::visible_sessions(
+                    let visible_len = crate::cli::tui::app::visible_sessions_for_state(
                         &app.filter,
                         &app.app_type,
                         &app.sessions.rows,
+                        app.sessions.detail_key.as_deref(),
+                        app.sessions.messages_loaded,
+                        &app.sessions.messages,
                     )
                     .len();
                     if visible_len == 0 {

--- a/src-tauri/src/cli/tui/ui.rs
+++ b/src-tauri/src/cli/tui/ui.rs
@@ -176,8 +176,7 @@ fn render_content(
 }
 
 fn split_filter_area(area: Rect, app: &App) -> (Option<Rect>, Rect) {
-    let show = app.filter.active || !app.filter.input.value.trim().is_empty();
-    if !show {
+    if !app.should_show_filter_bar() {
         return (None, area);
     }
 
@@ -205,6 +204,7 @@ mod effect_tests {
 }
 
 fn render_filter_bar(frame: &mut Frame<'_>, app: &App, area: Rect, theme: &super::theme::Theme) {
+    let input = app.displayed_filter_input();
     let outer = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Plain)
@@ -230,11 +230,8 @@ fn render_filter_bar(frame: &mut Frame<'_>, app: &App, area: Rect, theme: &super
 
     let input_inner = input_block.inner(inner);
     frame.render_widget(input_block, inner);
-    let (visible, cursor_x) = visible_text_window(
-        &app.filter.input.value,
-        app.filter.input.cursor,
-        input_inner.width as usize,
-    );
+    let (visible, cursor_x) =
+        visible_text_window(&input.value, input.cursor, input_inner.width as usize);
 
     frame.render_widget(
         Paragraph::new(Line::from(Span::raw(visible))).wrap(Wrap { trim: false }),

--- a/src-tauri/src/cli/tui/ui/sessions.rs
+++ b/src-tauri/src/cli/tui/ui/sessions.rs
@@ -9,7 +9,14 @@ pub(super) fn render_sessions(
     area: Rect,
     theme: &super::theme::Theme,
 ) {
-    let visible = app::visible_sessions(&app.filter, &app.app_type, &app.sessions.rows);
+    let visible = app::visible_sessions_for_state(
+        &app.filter,
+        &app.app_type,
+        &app.sessions.rows,
+        app.sessions.detail_key.as_deref(),
+        app.sessions.messages_loaded,
+        &app.sessions.messages,
+    );
 
     let outer = Block::default()
         .borders(Borders::ALL)
@@ -309,6 +316,7 @@ fn render_session_messages(
         return;
     }
 
+    let visible_messages = app::visible_session_messages(&app.sessions);
     if app.sessions.messages.is_empty() {
         render_centered_lines(
             frame,
@@ -321,12 +329,22 @@ fn render_session_messages(
         return;
     }
 
-    let visible = visible_message_window(
-        &app.sessions.messages,
-        app.sessions.message_idx,
-        inner.height,
-    );
-    let rows = visible.map(|message| {
+    if visible_messages.is_empty() {
+        render_centered_lines(
+            frame,
+            inner,
+            vec![Line::styled(
+                texts::tui_sessions_messages_filtered_empty(),
+                Style::default().fg(theme.comment),
+            )],
+        );
+        return;
+    }
+
+    let selected_visible_idx =
+        selected_message_visible_index(&visible_messages, app.sessions.message_idx).unwrap_or(0);
+    let visible = visible_message_window(&visible_messages, selected_visible_idx, inner.height);
+    let rows = visible.map(|(_, message)| {
         let role = texts::tui_sessions_role_label(&message.role);
         let preview = collapse_message_preview(&message.content);
         let time = message.ts.map(format_timestamp).unwrap_or_default();
@@ -351,12 +369,8 @@ fn render_session_messages(
 
     let mut state = TableState::default();
     if matches!(app.sessions.pane, SessionsPane::Detail) {
-        state.select(Some(app.sessions.message_idx.saturating_sub(
-            message_window_start(
-                app.sessions.messages.len(),
-                app.sessions.message_idx,
-                inner.height,
-            ),
+        state.select(Some(selected_visible_idx.saturating_sub(
+            message_window_start(visible_messages.len(), selected_visible_idx, inner.height),
         )));
     }
     frame.render_stateful_widget(table, inset_left(inner, CONTENT_INSET_LEFT), &mut state);
@@ -486,15 +500,24 @@ fn message_window_start(total: usize, selected: usize, height: u16) -> usize {
         .min(total - visible_rows)
 }
 
-fn visible_message_window(
-    messages: &[crate::session_manager::SessionMessage],
+fn selected_message_visible_index(
+    messages: &[(usize, &crate::session_manager::SessionMessage)],
+    selected: usize,
+) -> Option<usize> {
+    messages
+        .iter()
+        .position(|(message_idx, _)| *message_idx == selected)
+}
+
+fn visible_message_window<'a>(
+    messages: &'a [(usize, &'a crate::session_manager::SessionMessage)],
     selected: usize,
     height: u16,
-) -> impl Iterator<Item = &crate::session_manager::SessionMessage> {
+) -> impl Iterator<Item = (usize, &'a crate::session_manager::SessionMessage)> + 'a {
     let visible_rows = height.saturating_sub(1).max(1) as usize;
     let start = message_window_start(messages.len(), selected, height);
     let end = (start + visible_rows).min(messages.len());
-    messages[start..end].iter()
+    messages[start..end].iter().copied()
 }
 
 #[cfg(test)]

--- a/src-tauri/src/cli/tui/ui/tests.rs
+++ b/src-tauri/src/cli/tui/ui/tests.rs
@@ -101,6 +101,7 @@ fn tui_sessions_renders_split_detail_and_message_preview() {
     });
     app.sessions
         .open_detail(app::session_key(&app.sessions.rows[0]));
+    app.sessions.pane = app::SessionsPane::Detail;
     app.sessions.messages_loaded = true;
     app.sessions
         .messages
@@ -221,6 +222,220 @@ fn tui_sessions_filters_rows_by_current_app() {
     let codex = all_text(&render(&app, &minimal_data(&app.app_type)));
     assert!(!codex.contains("Claude visible"), "{codex}");
     assert!(codex.contains("Codex hidden"), "{codex}");
+}
+
+#[test]
+fn tui_sessions_slash_search_filters_user_role_messages() {
+    let _lang = use_test_language(Language::English);
+
+    let mut app = App::new(Some(AppType::Claude));
+    app.route = Route::Sessions;
+    app.focus = Focus::Content;
+    app.sessions.loaded_once = true;
+    app.sessions.rows.push(crate::session_manager::SessionMeta {
+        provider_id: "claude".to_string(),
+        session_id: "abcdef123456".to_string(),
+        title: Some("Debug deploy".to_string()),
+        summary: None,
+        project_dir: Some("/tmp/demo-project".to_string()),
+        created_at: Some(1_735_689_600_000),
+        last_active_at: Some(1_735_689_900_000),
+        source_path: Some("/tmp/session.jsonl".to_string()),
+        resume_command: Some("claude --resume abcdef123456".to_string()),
+    });
+    app.sessions
+        .open_detail(app::session_key(&app.sessions.rows[0]));
+    app.sessions.pane = app::SessionsPane::Detail;
+    app.sessions.messages_loaded = true;
+    app.sessions.messages = vec![
+        crate::session_manager::SessionMessage {
+            role: "user".to_string(),
+            content: "How do I deploy this service?".to_string(),
+            ts: Some(1_735_689_900_000),
+        },
+        crate::session_manager::SessionMessage {
+            role: "assistant".to_string(),
+            content: "The user should use the release workflow.".to_string(),
+            ts: Some(1_735_689_901_000),
+        },
+        crate::session_manager::SessionMessage {
+            role: "tool".to_string(),
+            content: "cargo test".to_string(),
+            ts: Some(1_735_689_902_000),
+        },
+    ];
+
+    let data = minimal_data(&app.app_type);
+    let action = app.on_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE), &data);
+    assert!(matches!(action, Action::None));
+    for ch in "User".chars() {
+        let action = app.on_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE), &data);
+        assert!(matches!(action, Action::None));
+    }
+
+    let all = all_text(&render_with_size(
+        &app,
+        &minimal_data(&app.app_type),
+        160,
+        40,
+    ));
+    assert!(!all.contains("Search: User"), "{all}");
+    assert!(all.contains("How do I deploy"), "{all}");
+    assert!(!all.contains("release workflow"), "{all}");
+    assert!(!all.contains("cargo test"), "{all}");
+}
+
+#[test]
+fn tui_sessions_search_filters_loaded_message_content() {
+    let _lang = use_test_language(Language::English);
+
+    let mut app = App::new(Some(AppType::Claude));
+    app.route = Route::Sessions;
+    app.focus = Focus::Content;
+    app.sessions.loaded_once = true;
+    app.sessions.rows.push(crate::session_manager::SessionMeta {
+        provider_id: "claude".to_string(),
+        session_id: "abcdef123456".to_string(),
+        title: Some("Debug deploy".to_string()),
+        summary: None,
+        project_dir: Some("/tmp/demo-project".to_string()),
+        created_at: Some(1_735_689_600_000),
+        last_active_at: Some(1_735_689_900_000),
+        source_path: Some("/tmp/session.jsonl".to_string()),
+        resume_command: Some("claude --resume abcdef123456".to_string()),
+    });
+    app.sessions
+        .open_detail(app::session_key(&app.sessions.rows[0]));
+    app.sessions.messages_loaded = true;
+    app.sessions.messages = vec![
+        crate::session_manager::SessionMessage {
+            role: "user".to_string(),
+            content: "How do I deploy this service?".to_string(),
+            ts: Some(1_735_689_900_000),
+        },
+        crate::session_manager::SessionMessage {
+            role: "assistant".to_string(),
+            content: "Use the release workflow.".to_string(),
+            ts: Some(1_735_689_901_000),
+        },
+    ];
+    app.sessions.message_filter.set("deploy");
+
+    let all = all_text(&render_with_size(
+        &app,
+        &minimal_data(&app.app_type),
+        160,
+        40,
+    ));
+    assert!(all.contains("How do I deploy"), "{all}");
+    assert!(!all.contains("Use the release workflow"), "{all}");
+}
+
+#[test]
+fn tui_sessions_search_matches_localized_user_role_label() {
+    let _lang = use_test_language(Language::Chinese);
+
+    let mut app = App::new(Some(AppType::Claude));
+    app.route = Route::Sessions;
+    app.focus = Focus::Content;
+    app.sessions.loaded_once = true;
+    app.sessions.rows.push(crate::session_manager::SessionMeta {
+        provider_id: "claude".to_string(),
+        session_id: "abcdef123456".to_string(),
+        title: Some("Debug deploy".to_string()),
+        summary: None,
+        project_dir: Some("/tmp/demo-project".to_string()),
+        created_at: Some(1_735_689_600_000),
+        last_active_at: Some(1_735_689_900_000),
+        source_path: Some("/tmp/session.jsonl".to_string()),
+        resume_command: Some("claude --resume abcdef123456".to_string()),
+    });
+    app.sessions
+        .open_detail(app::session_key(&app.sessions.rows[0]));
+    app.sessions.messages_loaded = true;
+    app.sessions.messages = vec![
+        crate::session_manager::SessionMessage {
+            role: "user".to_string(),
+            content: "How do I deploy this service?".to_string(),
+            ts: Some(1_735_689_900_000),
+        },
+        crate::session_manager::SessionMessage {
+            role: "assistant".to_string(),
+            content: "提醒用户使用发布流程。".to_string(),
+            ts: Some(1_735_689_901_000),
+        },
+    ];
+    app.sessions.message_filter.set("用户");
+
+    let all = all_text(&render_with_size(
+        &app,
+        &minimal_data(&app.app_type),
+        160,
+        40,
+    ));
+    assert!(all.contains("How do I deploy"), "{all}");
+    assert!(!all.contains("发布流程"), "{all}");
+}
+
+#[test]
+fn tui_sessions_session_and_message_filters_are_independent() {
+    let _lang = use_test_language(Language::English);
+
+    let mut app = App::new(Some(AppType::Claude));
+    app.route = Route::Sessions;
+    app.focus = Focus::Content;
+    app.sessions.loaded_once = true;
+    app.sessions.rows.push(crate::session_manager::SessionMeta {
+        provider_id: "claude".to_string(),
+        session_id: "ai-session".to_string(),
+        title: Some("AI incident".to_string()),
+        summary: None,
+        project_dir: Some("/tmp/ai-project".to_string()),
+        created_at: Some(1_735_689_600_000),
+        last_active_at: Some(1_735_689_900_000),
+        source_path: Some("/tmp/ai.jsonl".to_string()),
+        resume_command: Some("claude --resume ai-session".to_string()),
+    });
+    app.sessions.rows.push(crate::session_manager::SessionMeta {
+        provider_id: "claude".to_string(),
+        session_id: "billing-session".to_string(),
+        title: Some("Billing question".to_string()),
+        summary: None,
+        project_dir: Some("/tmp/billing-project".to_string()),
+        created_at: Some(1_735_689_600_000),
+        last_active_at: Some(1_735_689_800_000),
+        source_path: Some("/tmp/billing.jsonl".to_string()),
+        resume_command: Some("claude --resume billing-session".to_string()),
+    });
+    app.sessions
+        .open_detail(app::session_key(&app.sessions.rows[0]));
+    app.sessions.pane = app::SessionsPane::Detail;
+    app.sessions.messages_loaded = true;
+    app.sessions.messages = vec![
+        crate::session_manager::SessionMessage {
+            role: "user".to_string(),
+            content: "How do I inspect the deployment?".to_string(),
+            ts: Some(1_735_689_900_000),
+        },
+        crate::session_manager::SessionMessage {
+            role: "assistant".to_string(),
+            content: "AI response for the user.".to_string(),
+            ts: Some(1_735_689_901_000),
+        },
+    ];
+    app.filter.input.set("AI");
+    app.sessions.message_filter.set("User");
+
+    let all = all_text(&render_with_size(
+        &app,
+        &minimal_data(&app.app_type),
+        160,
+        40,
+    ));
+    assert!(all.contains("AI incident"), "{all}");
+    assert!(!all.contains("Billing question"), "{all}");
+    assert!(all.contains("How do I inspect"), "{all}");
+    assert!(!all.contains("AI response"), "{all}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a Sessions message role filter (`f`) that cycles All/User/AI/Tool/Developer/System
- extend Sessions search so loaded messages can be filtered by role, localized role label, content, or timestamp
- keep selection/navigation stable when the current role/search filter changes

## Reference
Addresses feedback from #206 requesting session filters such as “用户” and search support to find a prior question and its AI answer.

## Tests
- `cargo +1.91.1 test sessions_ --lib -- --nocapture`
- `cargo +1.91.1 check --all-targets`