### PR TITLE
Update README for homebrew and Improve Homebrew update handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,19 @@ move cc-switch.exe C:\Windows\System32\
 
 </details>
 
-### Method 2: Build from Source
+### Method 2: Install via Homebrew
+If you are using Homebrew on your machine, you can use Homebrew to install cc-switch.
+```
+brew install cc-switch-cli
+```
+
+Update:
+```
+brew upgrade cc-switch-cli
+```
+Please avoid using built-in update feature in cc-switch if you install cc-switch with Homebrew, as this breaks Homebrew formulae’s own upgrade functionality.
+
+### Method 3: Build from Source
 
 **Prerequisites:**
 - Rust 1.85+ ([install via rustup](https://rustup.rs/))

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Update:
 ```
 brew upgrade cc-switch-cli
 ```
-If you installed cc-switch via Homebrew, please use brew upgrade cc-switch instead of the built-in update feature, as this breaks Homebrew formulae’s own upgrade functionality.
+If you installed cc-switch via Homebrew, please use Homebrew to upgrade cc-switch, instead of the built-in update feature, as this breaks Homebrew formulae’s own upgrade functionality.
 
 ### Method 3: Build from Source
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Update:
 ```
 brew upgrade cc-switch-cli
 ```
-Please avoid using built-in update feature in cc-switch if you install cc-switch with Homebrew, as this breaks Homebrew formulae’s own upgrade functionality.
+If you installed cc-switch via Homebrew, please use brew upgrade cc-switch instead of the built-in update feature, as this breaks Homebrew formulae’s own upgrade functionality.
 
 ### Method 3: Build from Source
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -212,7 +212,23 @@ move cc-switch.exe C:\Windows\System32\
 
 </details>
 
-### 方法 2：从源码构建
+### 方法 2：使用 Homebrew 安装
+
+如果你在使用 Homebrew，可以直接通过 Homebrew 安装 cc-switch。
+
+```bash
+brew install cc-switch-cli
+```
+
+更新：
+
+```bash
+brew upgrade cc-switch-cli
+```
+
+请注意，如果你通过 Homebrew 安装了 cc-switch，请避免使用 cc-switch 内置的更新功能，因为这会影响 Homebrew 自身的升级功能。
+
+### 方法 3：从源码构建
 
 **前提条件：**
 - Rust 1.85+（[通过 rustup 安装](https://rustup.rs/)）

--- a/src-tauri/src/cli/commands/update.rs
+++ b/src-tauri/src/cli/commands/update.rs
@@ -14,7 +14,7 @@ use tar::Archive;
 use tempfile::TempDir;
 use url::Url;
 
-use crate::cli::ui::{highlight, info, success};
+use crate::cli::ui::{highlight, info, success, warning};
 use crate::error::AppError;
 
 const REPO_URL: &str = env!("CARGO_PKG_REPOSITORY");
@@ -133,6 +133,20 @@ pub fn execute(cmd: UpdateCommand) -> Result<(), AppError> {
 }
 
 async fn execute_async(cmd: UpdateCommand) -> Result<(), AppError> {
+    // Block self-update when running from a Homebrew-managed prefix so we
+    // don't silently replace the brew-owned binary (which would break
+    // `brew upgrade` / `brew reinstall`).
+    #[cfg(not(windows))]
+    if is_homebrew_install() {
+        println!(
+            "{}",
+            warning(
+                "cc-switch was installed via Homebrew.\nPlease upgrade with: brew upgrade cc-switch",
+            )
+        );
+        return Ok(());
+    }
+
     let current_version = env!("CARGO_PKG_VERSION");
     let explicit_version = cmd.version.as_deref().is_some_and(|v| !v.trim().is_empty());
     let client = create_http_client()?;
@@ -1215,6 +1229,32 @@ fn replace_current_binary(new_binary_path: &Path) -> Result<(), AppError> {
     }
 }
 
+/// Returns `true` if the running binary lives inside the Homebrew prefix.
+///
+/// Prefers the `HOMEBREW_PREFIX` environment variable that Homebrew sets in
+/// its shell environment.  Falls back to the two well-known default prefixes
+/// (`/opt/homebrew` on Apple Silicon, `/home/linuxbrew/.linuxbrew` on Linux)
+/// so that detection still works when the variable is absent (e.g. the user
+/// launched the binary from a non-Homebrew shell).
+/// Here we ignore the default homebrew prefix on Intel Mac, as Intel homebrew 
+/// is retiring in 2026.
+#[cfg(not(windows))]
+fn is_homebrew_install() -> bool {
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    if let Ok(prefix) = std::env::var("HOMEBREW_PREFIX") {
+        if exe.starts_with(&prefix) {
+            return true;
+        }
+    }
+    const DEFAULT_PREFIXES: &[&str] = &["/opt/homebrew", "/home/linuxbrew/.linuxbrew"];
+    DEFAULT_PREFIXES
+        .iter()
+        .any(|prefix| exe.starts_with(prefix))
+}
+
 fn remove_file_if_present(path: &Path) -> Result<(), AppError> {
     match fs::remove_file(path) {
         Ok(()) => Ok(()),
@@ -1264,6 +1304,15 @@ pub(crate) async fn download_and_apply(
     target_tag: &str,
     on_progress: impl Fn(u64, Option<u64>),
 ) -> Result<(), AppError> {
+    // Same brew-prefix guard as the CLI path (see execute_async).
+    #[cfg(not(windows))]
+    if is_homebrew_install() {
+        return Err(AppError::Message(
+            "cc-switch was installed via Homebrew. Please upgrade with: brew upgrade cc-switch"
+                .to_string(),
+        ));
+    }
+
     let client = create_http_client()?;
     let release = resolve_target_release(&client, REPO_URL, Some(target_tag)).await?;
     let downloaded_asset = match release {

--- a/src-tauri/src/cli/commands/update.rs
+++ b/src-tauri/src/cli/commands/update.rs
@@ -133,22 +133,28 @@ pub fn execute(cmd: UpdateCommand) -> Result<(), AppError> {
 }
 
 async fn execute_async(cmd: UpdateCommand) -> Result<(), AppError> {
-    // Block self-update when running from a Homebrew-managed prefix so we
-    // don't silently replace the brew-owned binary (which would break
-    // `brew upgrade` / `brew reinstall`).
+    let current_version = env!("CARGO_PKG_VERSION");
+    let explicit_version = cmd.version.as_deref().is_some_and(|v| !v.trim().is_empty());
     #[cfg(not(windows))]
-    if is_homebrew_install() {
+    let is_homebrew_managed = is_homebrew_install();
+    #[cfg(windows)]
+    let is_homebrew_managed = false;
+
+    // If the user explicitly requested a specific version, and we're on a Homebrew-managed installation,
+    // block the update process since we should not replace the binary in-place.
+    // For non-Homebrew installations, allow updating to a specific version and replace the binary.
+    // For Homebrew-managed installations without an explicit version (i.e. just checking for updates),
+    // allow the check to proceed and show the user that an update is available, but they will still need to use Homebrew to perform the actual update.
+    if should_block_homebrew_before_update_check(is_homebrew_managed, explicit_version) {
         println!(
             "{}",
             warning(
-                "cc-switch was installed via Homebrew.\nPlease upgrade with: brew upgrade cc-switch",
+                "cc-switch was installed via Homebrew. Self-update to a specific version is not supported.\nPlease use: brew upgrade cc-switch",
             )
         );
         return Ok(());
     }
 
-    let current_version = env!("CARGO_PKG_VERSION");
-    let explicit_version = cmd.version.as_deref().is_some_and(|v| !v.trim().is_empty());
     let client = create_http_client()?;
     let release = resolve_target_release(&client, REPO_URL, cmd.version.as_deref()).await?;
     let target_tag = release.target_tag().to_string();
@@ -167,6 +173,16 @@ async fn execute_async(cmd: UpdateCommand) -> Result<(), AppError> {
             "{}",
             info(&format!(
                 "Current version v{current_version} is newer than target {target_tag}; skipping automatic downgrade. Use `cc-switch update --version {target_tag}` to force."
+            ))
+        );
+        return Ok(());
+    }
+
+    if is_homebrew_managed {
+        println!(
+            "{}",
+            warning(&format!(
+                "Update {target_tag} is available (current v{current_version}).\nPlease update with: brew upgrade cc-switch"
             ))
         );
         return Ok(());
@@ -243,6 +259,13 @@ async fn execute_async(cmd: UpdateCommand) -> Result<(), AppError> {
         )
     );
     Ok(())
+}
+
+fn should_block_homebrew_before_update_check(
+    is_homebrew_managed: bool,
+    explicit_version: bool,
+) -> bool {
+    is_homebrew_managed && explicit_version
 }
 
 fn create_runtime() -> Result<tokio::runtime::Runtime, AppError> {
@@ -1236,7 +1259,7 @@ fn replace_current_binary(new_binary_path: &Path) -> Result<(), AppError> {
 /// (`/opt/homebrew` on Apple Silicon, `/home/linuxbrew/.linuxbrew` on Linux)
 /// so that detection still works when the variable is absent (e.g. the user
 /// launched the binary from a non-Homebrew shell).
-/// Here we ignore the default homebrew prefix on Intel Mac, as Intel homebrew 
+/// Here we ignore the default homebrew prefix on Intel Mac, as Intel homebrew
 /// is retiring in 2026.
 #[cfg(not(windows))]
 fn is_homebrew_install() -> bool {
@@ -1278,26 +1301,51 @@ pub(crate) struct UpdateCheckInfo {
     pub target_tag: String,
     pub is_already_latest: bool,
     pub is_downgrade: bool,
+    pub is_homebrew_managed: bool,
 }
 
 pub(crate) async fn check_for_update() -> Result<UpdateCheckInfo, AppError> {
+    check_for_update_from_repo(REPO_URL).await
+}
+
+/// Accepts an explicit `repo_url` so tests can point at a local mock server
+/// instead of hitting the real GitHub API.
+async fn check_for_update_from_repo(repo_url: &str) -> Result<UpdateCheckInfo, AppError> {
+    #[cfg(not(windows))]
+    let is_homebrew_managed = is_homebrew_install();
+    #[cfg(windows)]
+    let is_homebrew_managed = false;
+
     let current_version = env!("CARGO_PKG_VERSION");
     let client = create_http_client()?;
-    let target_tag = resolve_target_release(&client, REPO_URL, None)
+    let target_tag = resolve_target_release(&client, repo_url, None)
         .await?
         .target_tag()
         .to_string();
+    Ok(build_update_check_info(
+        current_version,
+        target_tag,
+        is_homebrew_managed,
+    ))
+}
+
+fn build_update_check_info(
+    current_version: &str,
+    target_tag: String,
+    is_homebrew_managed: bool,
+) -> UpdateCheckInfo {
     let target_version = target_tag.trim_start_matches('v');
 
     let is_already_latest = target_version == current_version;
     let is_downgrade = should_skip_implicit_downgrade(current_version, target_version, false);
 
-    Ok(UpdateCheckInfo {
+    UpdateCheckInfo {
         current_version: current_version.to_string(),
         target_tag,
         is_already_latest,
         is_downgrade,
-    })
+        is_homebrew_managed,
+    }
 }
 
 pub(crate) async fn download_and_apply(

--- a/src-tauri/src/cli/commands/update.rs
+++ b/src-tauri/src/cli/commands/update.rs
@@ -135,10 +135,7 @@ pub fn execute(cmd: UpdateCommand) -> Result<(), AppError> {
 async fn execute_async(cmd: UpdateCommand) -> Result<(), AppError> {
     let current_version = env!("CARGO_PKG_VERSION");
     let explicit_version = cmd.version.as_deref().is_some_and(|v| !v.trim().is_empty());
-    #[cfg(not(windows))]
     let is_homebrew_managed = is_homebrew_install();
-    #[cfg(windows)]
-    let is_homebrew_managed = false;
 
     // If the user explicitly requested a specific version, and we're on a Homebrew-managed installation,
     // block the update process since we should not replace the binary in-place.
@@ -1253,6 +1250,7 @@ fn replace_current_binary(new_binary_path: &Path) -> Result<(), AppError> {
 }
 
 /// Returns `true` if the running binary lives inside the Homebrew prefix.
+/// Returns false on windows.
 ///
 /// Prefers the `HOMEBREW_PREFIX` environment variable that Homebrew sets in
 /// its shell environment.  Falls back to the two well-known default prefixes
@@ -1261,21 +1259,28 @@ fn replace_current_binary(new_binary_path: &Path) -> Result<(), AppError> {
 /// launched the binary from a non-Homebrew shell).
 /// Here we ignore the default homebrew prefix on Intel Mac, as Intel homebrew
 /// is retiring in 2026.
-#[cfg(not(windows))]
 fn is_homebrew_install() -> bool {
-    let exe = match std::env::current_exe() {
-        Ok(p) => p,
-        Err(_) => return false,
-    };
-    if let Ok(prefix) = std::env::var("HOMEBREW_PREFIX") {
-        if exe.starts_with(&prefix) {
-            return true;
-        }
+    #[cfg(windows)]
+    {
+        false
     }
-    const DEFAULT_PREFIXES: &[&str] = &["/opt/homebrew", "/home/linuxbrew/.linuxbrew"];
-    DEFAULT_PREFIXES
-        .iter()
-        .any(|prefix| exe.starts_with(prefix))
+
+    #[cfg(not(windows))]
+    {
+        let exe = match std::env::current_exe() {
+            Ok(p) => p,
+            Err(_) => return false,
+        };
+        if let Ok(prefix) = std::env::var("HOMEBREW_PREFIX") {
+            if exe.starts_with(&prefix) {
+                return true;
+            }
+        }
+        const DEFAULT_PREFIXES: &[&str] = &["/opt/homebrew", "/home/linuxbrew/.linuxbrew"];
+        DEFAULT_PREFIXES
+            .iter()
+            .any(|prefix| exe.starts_with(prefix))
+    }
 }
 
 fn remove_file_if_present(path: &Path) -> Result<(), AppError> {
@@ -1311,11 +1316,6 @@ pub(crate) async fn check_for_update() -> Result<UpdateCheckInfo, AppError> {
 /// Accepts an explicit `repo_url` so tests can point at a local mock server
 /// instead of hitting the real GitHub API.
 async fn check_for_update_from_repo(repo_url: &str) -> Result<UpdateCheckInfo, AppError> {
-    #[cfg(not(windows))]
-    let is_homebrew_managed = is_homebrew_install();
-    #[cfg(windows)]
-    let is_homebrew_managed = false;
-
     let current_version = env!("CARGO_PKG_VERSION");
     let client = create_http_client()?;
     let target_tag = resolve_target_release(&client, repo_url, None)
@@ -1325,7 +1325,7 @@ async fn check_for_update_from_repo(repo_url: &str) -> Result<UpdateCheckInfo, A
     Ok(build_update_check_info(
         current_version,
         target_tag,
-        is_homebrew_managed,
+        is_homebrew_install(),
     ))
 }
 
@@ -1353,7 +1353,6 @@ pub(crate) async fn download_and_apply(
     on_progress: impl Fn(u64, Option<u64>),
 ) -> Result<(), AppError> {
     // Same brew-prefix guard as the CLI path (see execute_async).
-    #[cfg(not(windows))]
     if is_homebrew_install() {
         return Err(AppError::Message(
             "cc-switch was installed via Homebrew. Please upgrade with: brew upgrade cc-switch"

--- a/src-tauri/src/cli/commands/update/tests.rs
+++ b/src-tauri/src/cli/commands/update/tests.rs
@@ -1,9 +1,83 @@
 use super::*;
 use axum::{response::Redirect, routing::get, Router};
 use minisign::KeyPair;
+use serial_test::serial;
 use std::collections::BTreeMap;
 use std::io::Cursor;
 use tokio::net::TcpListener;
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn force_homebrew_install_for_test() -> EnvVarGuard {
+    let exe = std::env::current_exe().expect("current test executable should resolve");
+    let prefix = exe
+        .parent()
+        .expect("executable must have a parent directory");
+    EnvVarGuard::set("HOMEBREW_PREFIX", prefix.as_os_str())
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+#[serial(homebrew_update)]
+async fn cli_explicit_update_exits_early_for_homebrew_install() {
+    let _homebrew = force_homebrew_install_for_test();
+
+    execute_async(UpdateCommand {
+        version: Some("v999.0.0".to_string()),
+    })
+    .await
+    .expect("homebrew-managed explicit CLI update should exit without querying releases");
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cli_default_homebrew_update_is_not_blocked_before_checking_latest() {
+    assert!(!should_block_homebrew_before_update_check(true, false));
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cli_explicit_homebrew_update_is_blocked_before_release_lookup() {
+    assert!(should_block_homebrew_before_update_check(true, true));
+}
+
+#[cfg(not(windows))]
+#[test]
+#[serial(homebrew_update)]
+fn tui_update_check_marks_homebrew_package_manager_update() {
+    let _homebrew = force_homebrew_install_for_test();
+
+    let info = build_update_check_info(
+        env!("CARGO_PKG_VERSION"),
+        "v999.0.0".to_string(),
+        is_homebrew_install(),
+    );
+
+    assert_eq!(info.target_tag, "v999.0.0");
+    assert!(!info.is_already_latest);
+    assert!(info.is_homebrew_managed);
+}
 
 #[test]
 fn normalize_tag_adds_prefix_when_missing() {

--- a/src-tauri/src/cli/commands/update/tests.rs
+++ b/src-tauri/src/cli/commands/update/tests.rs
@@ -17,6 +17,12 @@ impl EnvVarGuard {
         std::env::set_var(key, value);
         Self { key, previous }
     }
+
+    fn remove(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::remove_var(key);
+        Self { key, previous }
+    }
 }
 
 impl Drop for EnvVarGuard {
@@ -77,6 +83,87 @@ fn tui_update_check_marks_homebrew_package_manager_update() {
     assert_eq!(info.target_tag, "v999.0.0");
     assert!(!info.is_already_latest);
     assert!(info.is_homebrew_managed);
+}
+
+#[tokio::test]
+#[serial(homebrew_update)]
+async fn check_for_update_from_repo_uses_supplied_repo_url() {
+    let _homebrew = EnvVarGuard::remove("HOMEBREW_PREFIX");
+    let (repo_url, server) = spawn_update_manifest_server("v999.0.0").await;
+
+    let info = check_for_update_from_repo(&repo_url)
+        .await
+        .expect("update check should use supplied repo url");
+
+    assert_eq!(info.current_version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(info.target_tag, "v999.0.0");
+    assert!(!info.is_already_latest);
+    assert!(!info.is_downgrade);
+    assert!(!info.is_homebrew_managed);
+
+    server.abort();
+}
+
+#[test]
+fn non_homebrew_update_check_marks_newer_version_as_regular_update() {
+    let info = build_update_check_info(env!("CARGO_PKG_VERSION"), "v999.0.0".to_string(), false);
+
+    assert_eq!(info.target_tag, "v999.0.0");
+    assert!(!info.is_already_latest);
+    assert!(!info.is_downgrade);
+    assert!(!info.is_homebrew_managed);
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+#[serial(homebrew_update)]
+async fn check_for_update_from_repo_marks_homebrew_managed_install() {
+    let _homebrew = force_homebrew_install_for_test();
+    let (repo_url, server) = spawn_update_manifest_server("v999.0.1").await;
+
+    let info = check_for_update_from_repo(&repo_url)
+        .await
+        .expect("homebrew-managed check should still query supplied repo url");
+
+    assert_eq!(info.current_version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(info.target_tag, "v999.0.1");
+    assert!(!info.is_already_latest);
+    assert!(info.is_homebrew_managed);
+
+    server.abort();
+}
+
+async fn spawn_update_manifest_server(
+    version: &'static str,
+) -> (String, tokio::task::JoinHandle<()>) {
+    let platform_key = current_platform_key().expect("platform key should resolve");
+    let manifest = serde_json::json!({
+        "version": version,
+        "platforms": {
+            platform_key: {
+                "url": "https://example.com/cc-switch.tar.gz",
+                "signature": "fake-signature"
+            }
+        }
+    });
+    let app = Router::new().route(
+        "/team/cc-switch-cli/releases/latest/download/latest.json",
+        get(move || {
+            let manifest = manifest.clone();
+            async move { axum::Json(manifest) }
+        }),
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener should bind");
+    let addr = listener.local_addr().expect("local addr should resolve");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("server should run");
+    });
+
+    let repo_url = format!("http://{addr}/team/cc-switch-cli");
+    (repo_url, server)
 }
 
 #[test]

--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -10623,9 +10623,9 @@ pub mod texts {
 
     pub fn tui_toast_update_homebrew_required(current: &str, target: &str) -> String {
         if is_chinese() {
-            format!("发现新版本 {target}（当前 v{current}）。请使用 brew upgrade cc-switch 更新")
+            format!("发现新版本 {target}（当前 v{current}）\n请使用 brew upgrade cc-switch 更新")
         } else {
-            format!("Update {target} is available (current v{current}). Please update with: brew upgrade cc-switch")
+            format!("Update {target} is available (current v{current}).\nPlease update with: brew upgrade cc-switch")
         }
     }
 

--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -10621,6 +10621,14 @@ pub mod texts {
         }
     }
 
+    pub fn tui_toast_update_homebrew_required(current: &str, target: &str) -> String {
+        if is_chinese() {
+            format!("发现新版本 {target}（当前 v{current}）。请使用 brew upgrade cc-switch 更新")
+        } else {
+            format!("Update {target} is available (current v{current}). Please update with: brew upgrade cc-switch")
+        }
+    }
+
     pub fn tui_toast_update_check_failed(err: &str) -> String {
         if is_chinese() {
             format!("检查更新失败: {err}")

--- a/src-tauri/src/cli/i18n/texts/update.rs
+++ b/src-tauri/src/cli/i18n/texts/update.rs
@@ -121,6 +121,16 @@ pub fn tui_toast_update_downgrade(current: &str, target: &str) -> String {
     }
 }
 
+pub fn tui_toast_update_homebrew_required(current: &str, target: &str) -> String {
+    if is_chinese() {
+        format!("发现新版本 {target}（当前 v{current}）。请使用 brew upgrade cc-switch 更新")
+    } else {
+        format!(
+            "Update {target} is available (current v{current}). Please update with: brew upgrade cc-switch"
+        )
+    }
+}
+
 pub fn tui_toast_update_check_failed(err: &str) -> String {
     if is_chinese() {
         format!("检查更新失败: {err}")

--- a/src-tauri/src/cli/i18n/texts/update.rs
+++ b/src-tauri/src/cli/i18n/texts/update.rs
@@ -123,10 +123,10 @@ pub fn tui_toast_update_downgrade(current: &str, target: &str) -> String {
 
 pub fn tui_toast_update_homebrew_required(current: &str, target: &str) -> String {
     if is_chinese() {
-        format!("发现新版本 {target}（当前 v{current}）。请使用 brew upgrade cc-switch 更新")
+        format!("发现新版本 {target}（当前 v{current}）\n请使用 brew upgrade cc-switch 更新")
     } else {
         format!(
-            "Update {target} is available (current v{current}). Please update with: brew upgrade cc-switch"
+            "Update {target} is available (current v{current}).\nPlease update with: brew upgrade cc-switch"
         )
     }
 }

--- a/src-tauri/src/cli/tui/runtime_systems/handlers.rs
+++ b/src-tauri/src/cli/tui/runtime_systems/handlers.rs
@@ -753,6 +753,15 @@ pub(crate) fn handle_update_msg(app: &mut App, update_check: &mut RequestTracker
                             texts::tui_toast_already_latest(&info.current_version),
                             ToastKind::Success,
                         );
+                    } else if info.is_homebrew_managed {
+                        app.overlay = Overlay::None;
+                        app.push_toast(
+                            texts::tui_toast_update_homebrew_required(
+                                &info.current_version,
+                                &info.target_tag,
+                            ),
+                            ToastKind::Info,
+                        );
                     } else if info.is_downgrade {
                         app.overlay = Overlay::None;
                         app.push_toast(

--- a/src-tauri/src/cli/tui/tests.rs
+++ b/src-tauri/src/cli/tui/tests.rs
@@ -475,6 +475,7 @@ fn update_check_finished_is_ignored_when_canceled() {
         target_tag: "v9.9.9".to_string(),
         is_already_latest: false,
         is_downgrade: false,
+        is_homebrew_managed: false,
     };
 
     handle_update_msg(
@@ -508,6 +509,7 @@ fn update_check_finished_is_processed_when_request_id_matches() {
         target_tag: "v9.9.9".to_string(),
         is_already_latest: false,
         is_downgrade: false,
+        is_homebrew_managed: false,
     };
 
     handle_update_msg(
@@ -531,6 +533,42 @@ fn update_check_finished_is_processed_when_request_id_matches() {
 }
 
 #[test]
+fn update_check_finished_for_homebrew_update_shows_brew_toast() {
+    let mut app = App::new(None);
+    app.overlay = Overlay::Loading {
+        kind: LoadingKind::UpdateCheck,
+        title: texts::tui_update_checking_title().to_string(),
+        message: texts::tui_loading().to_string(),
+    };
+    let mut update_check = RequestTracker::default();
+    update_check.active = Some(7);
+
+    let info = crate::cli::commands::update::UpdateCheckInfo {
+        current_version: "4.7.0".to_string(),
+        target_tag: "v9.9.9".to_string(),
+        is_already_latest: false,
+        is_downgrade: false,
+        is_homebrew_managed: true,
+    };
+
+    handle_update_msg(
+        &mut app,
+        &mut update_check,
+        UpdateMsg::CheckFinished {
+            request_id: 7,
+            result: Ok(info),
+        },
+    );
+
+    assert_eq!(update_check.active, None);
+    assert!(matches!(app.overlay, Overlay::None));
+    let toast = app.toast.as_ref().expect("homebrew update should toast");
+    assert_eq!(toast.kind, ToastKind::Info);
+    assert!(toast.message.contains("v9.9.9"));
+    assert!(toast.message.contains("brew upgrade cc-switch"));
+}
+
+#[test]
 fn update_check_finished_is_ignored_when_request_id_mismatch() {
     let mut app = App::new(None);
     app.overlay = Overlay::None;
@@ -542,6 +580,7 @@ fn update_check_finished_is_ignored_when_request_id_mismatch() {
         target_tag: "v1.0.0".to_string(),
         is_already_latest: false,
         is_downgrade: false,
+        is_homebrew_managed: false,
     };
     handle_update_msg(
         &mut app,
@@ -560,6 +599,7 @@ fn update_check_finished_is_ignored_when_request_id_mismatch() {
         target_tag: "v9.9.9".to_string(),
         is_already_latest: false,
         is_downgrade: false,
+        is_homebrew_managed: false,
     };
     handle_update_msg(
         &mut app,


### PR DESCRIPTION
This PR updates the Homebrew installation guidance and prevents Homebrew-managed binaries from being replaced by the built-in updater. Follow up of #207.

**Changes**

- Updates the README installation instructions for Homebrew.
- Detects when `cc-switch` is running from a Homebrew-managed prefix.
- Allows `cc-switch update` to still check for the latest version under Homebrew.
- Shows a package-manager-specific message when an update is available:
  `brew upgrade cc-switch`
- Blocks explicit self-updates like `cc-switch update --version ...` for Homebrew-managed installs.
- Prevents TUI update confirmation/download flows from attempting to replace a Homebrew-managed binary.
- Shows the TUI Homebrew update message as two lines for readability.
- Adds tests for CLI update behavior, TUI update handling, Homebrew-managed installs, non-Homebrew update checks, and custom repo URL update checks.

**Testing**

- `cargo fmt --check`
- `cargo test --lib homebrew`
- `cargo test --lib check_for_update_from_repo`
- `cargo test --lib non_homebrew_update_check_marks_newer_version_as_regular_update`
- `cargo test --lib update_check_finished_for_homebrew_update_shows_brew_toast`