### PR TITLE
fix(tui): load ANTHROPIC_API_KEY when populating Claude provider form

### DIFF
--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -3267,6 +3267,71 @@ fn provider_add_form_openclaw_ignores_common_config_snippet() {
 }
 
 #[test]
+fn populate_claude_form_reads_anthropic_api_key_when_auth_token_missing() {
+    let provider = Provider {
+        id: "mimo".to_string(),
+        name: "Xiaomi Mimo".to_string(),
+        settings_config: json!({
+            "env": {
+                "ANTHROPIC_API_KEY": "sk-from-import",
+                "ANTHROPIC_BASE_URL": "https://api.example.com/anthropic"
+            }
+        }),
+        website_url: None,
+        category: None,
+        created_at: None,
+        sort_index: None,
+        notes: None,
+        meta: None,
+        icon: None,
+        icon_color: None,
+        in_failover_queue: false,
+    };
+
+    let form = ProviderAddFormState::from_provider(AppType::Claude, &provider);
+    assert_eq!(form.claude_api_key.value, "sk-from-import");
+    assert_eq!(
+        form.claude_api_key_field,
+        crate::provider::ClaudeApiKeyField::ApiKey
+    );
+}
+
+#[test]
+fn populate_claude_form_honors_auth_token_field_meta_over_api_key() {
+    use crate::provider::ProviderMeta;
+
+    let provider = Provider {
+        id: "claude".to_string(),
+        name: "Claude".to_string(),
+        settings_config: json!({
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": "sk-token",
+                "ANTHROPIC_API_KEY": "sk-key"
+            }
+        }),
+        website_url: None,
+        category: None,
+        created_at: None,
+        sort_index: None,
+        notes: None,
+        meta: Some(ProviderMeta {
+            api_key_field: Some("ANTHROPIC_AUTH_TOKEN".to_string()),
+            ..Default::default()
+        }),
+        icon: None,
+        icon_color: None,
+        in_failover_queue: false,
+    };
+
+    let form = ProviderAddFormState::from_provider(AppType::Claude, &provider);
+    assert_eq!(form.claude_api_key.value, "sk-token");
+    assert_eq!(
+        form.claude_api_key_field,
+        crate::provider::ClaudeApiKeyField::AuthToken
+    );
+}
+
+#[test]
 fn provider_edit_form_roundtrip_no_duplicate_common_config_key() {
     // Issue #71: editing a Claude provider and saving fails with
     // "duplicate field `commonConfigEnabled`" because extra (from


### PR DESCRIPTION
Closes #227

## Problem

TUI fetch-models sends no auth when editing a Claude provider whose key is stored in `ANTHROPIC_API_KEY` (common for configs imported from Claude Code). `populate_claude_form` only read `ANTHROPIC_AUTH_TOKEN`, leaving the form empty → HTTP 401.

Model fetch HTTP logic (headers, URL ordering) already lives in `fetch_provider_models_for_tui` (`runtime_systems/types.rs`); this PR does not change that path.

## Fix

Use `StreamCheckService::extract_claude_key` when populating the Claude API key field, matching CLI and stream-check behavior.

## Tests

- `populate_claude_form_reads_anthropic_api_key_when_auth_token_missing`
- `populate_claude_form_prefers_anthropic_auth_token_over_api_key`

## Verification

```bash
cd src-tauri
cargo fmt --check
cargo test populate_claude_form
```