### PR TITLE
feat(cli): add provider shortcut and start dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,10 @@ cc-switch
 ```bash
 cc-switch provider list              # List providers
 cc-switch provider switch <id>       # Switch provider
+cc-switch use <id>                   # Switch provider (shortcut)
 cc-switch provider export <id>       # Export a Claude provider to a standalone settings file
 cc-switch provider stream-check <id> # Check provider stream health
+cc-switch start <claude|codex> <id> --dry-run # Preview launch
 cc-switch config webdav show         # Inspect WebDAV sync settings
 cc-switch env tools                  # Check local CLI tools
 cc-switch mcp sync                   # Sync MCP servers
@@ -261,6 +263,7 @@ Manage API configurations for **Claude Code**, **Codex**, **Gemini**, **OpenCode
 cc-switch provider list              # List all providers
 cc-switch provider current           # Show current provider
 cc-switch provider switch <id>       # Switch provider
+cc-switch use <id>                   # Switch provider (shortcut)
 cc-switch provider add               # Add new provider
 cc-switch provider edit <id>         # Edit existing provider
 cc-switch provider duplicate <id>    # Duplicate a provider

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -113,8 +113,10 @@ cc-switch
 ```bash
 cc-switch provider list              # 列出供应商
 cc-switch provider switch <id>       # 切换供应商
+cc-switch use <id>                   # 切换供应商（快捷命令）
 cc-switch provider export <id>       # 导出 Claude 供应商为独立 settings 文件
 cc-switch provider stream-check <id> # 检查供应商流式健康
+cc-switch start <claude|codex> <id> --dry-run # 预览启动配置
 cc-switch config webdav show         # 查看 WebDAV 同步设置
 cc-switch env tools                  # 检查本地 CLI 工具
 cc-switch mcp sync                   # 同步 MCP 服务器
@@ -265,6 +267,7 @@ copy target\release\cc-switch.exe C:\Windows\System32\
 cc-switch provider list              # 列出所有供应商
 cc-switch provider current           # 显示当前供应商
 cc-switch provider switch <id>       # 切换供应商
+cc-switch use <id>                   # 切换供应商（快捷命令）
 cc-switch provider add               # 添加新供应商
 cc-switch provider edit <id>         # 编辑现有供应商
 cc-switch provider duplicate <id>    # 复制供应商

--- a/src-tauri/src/cli/claude_temp_launch.rs
+++ b/src-tauri/src/cli/claude_temp_launch.rs
@@ -66,7 +66,33 @@ where
     Resolve: FnOnce() -> Result<PathBuf, AppError>,
 {
     let executable = resolve_claude_binary()?;
+    let normalized_settings = normalize_launch_settings(provider_id, settings)?;
+    let settings_path = write_temp_settings_file(temp_dir, provider_id, &normalized_settings)?;
 
+    Ok(PreparedClaudeLaunch {
+        executable,
+        settings_path,
+    })
+}
+
+pub(crate) fn preview_launch_from_settings_with<Resolve>(
+    provider_id: &str,
+    settings: &Value,
+    temp_dir: &Path,
+    resolve_claude_binary: Resolve,
+) -> Result<PreparedClaudeLaunch, AppError>
+where
+    Resolve: FnOnce() -> Result<PathBuf, AppError>,
+{
+    let executable = resolve_claude_binary()?;
+    let _ = normalize_launch_settings(provider_id, settings)?;
+    Ok(PreparedClaudeLaunch {
+        executable,
+        settings_path: temp_settings_path(temp_dir, provider_id),
+    })
+}
+
+fn normalize_launch_settings(provider_id: &str, settings: &Value) -> Result<Value, AppError> {
     if settings.get("env").and_then(|v| v.as_object()).is_none() {
         return Err(AppError::localized(
             "claude.temp_launch_missing_env",
@@ -77,12 +103,7 @@ where
 
     let mut normalized_settings = settings.clone();
     let _ = ProviderService::normalize_claude_models_in_value(&mut normalized_settings);
-    let settings_path = write_temp_settings_file(temp_dir, provider_id, &normalized_settings)?;
-
-    Ok(PreparedClaudeLaunch {
-        executable,
-        settings_path,
-    })
+    Ok(normalized_settings)
 }
 
 pub(crate) fn resolve_claude_binary() -> Result<PathBuf, AppError> {
@@ -171,16 +192,7 @@ fn write_temp_settings_file_with<Finalize>(
 where
     Finalize: FnOnce(&Path) -> Result<(), AppError>,
 {
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let filename = format!(
-        "cc-switch-claude-{}-{}-{timestamp}.json",
-        sanitize_filename_fragment(provider_id),
-        std::process::id()
-    );
-    let path = temp_dir.join(filename);
+    let path = temp_settings_path(temp_dir, provider_id);
     let content =
         serde_json::to_vec_pretty(settings).map_err(|source| AppError::JsonSerialize { source })?;
 
@@ -210,6 +222,19 @@ where
             )),
         },
     }
+}
+
+fn temp_settings_path(temp_dir: &Path, provider_id: &str) -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let filename = format!(
+        "cc-switch-claude-{}-{}-{timestamp}.json",
+        sanitize_filename_fragment(provider_id),
+        std::process::id()
+    );
+    temp_dir.join(filename)
 }
 
 #[cfg(unix)]

--- a/src-tauri/src/cli/codex_temp_launch.rs
+++ b/src-tauri/src/cli/codex_temp_launch.rs
@@ -55,6 +55,31 @@ where
     })
 }
 
+pub(crate) fn preview_launch_with<Resolve>(
+    provider: &Provider,
+    temp_dir: &Path,
+    resolve_codex_binary: Resolve,
+) -> Result<PreparedCodexLaunch, AppError>
+where
+    Resolve: FnOnce() -> Result<PathBuf, AppError>,
+{
+    let executable = resolve_codex_binary()?;
+    let cc_switch_executable = std::env::current_exe().map_err(|err| {
+        AppError::localized(
+            "codex.temp_launch_current_exe_failed",
+            format!("解析当前 cc-switch 可执行文件路径失败: {err}"),
+            format!("Failed to resolve current cc-switch executable path: {err}"),
+        )
+    })?;
+    let _ = parse_launch_settings(provider)?;
+    Ok(PreparedCodexLaunch {
+        executable,
+        cc_switch_executable,
+        provider_id: provider.id.clone(),
+        codex_home: temp_codex_home_path(temp_dir, &provider.id),
+    })
+}
+
 pub(crate) fn resolve_codex_binary() -> Result<PathBuf, AppError> {
     which::which("codex").map_err(|_| {
         AppError::localized(
@@ -138,6 +163,47 @@ fn write_temp_codex_home_with<Finalize>(
 where
     Finalize: FnOnce(&Path) -> Result<(), AppError>,
 {
+    let launch_settings = parse_launch_settings(provider)?;
+    let codex_home = temp_codex_home_path(temp_dir, &provider.id);
+
+    let write_result = (|| {
+        fs::create_dir_all(&codex_home).map_err(|err| AppError::io(&codex_home, err))?;
+        finalize(&codex_home)?;
+
+        let config_path = codex_home.join("config.toml");
+        write_secret_file(&config_path, launch_settings.config_text.as_bytes())?;
+
+        if let Some(auth) = launch_settings.auth {
+            let auth_path = codex_home.join("auth.json");
+            let auth_text = serde_json::to_vec_pretty(&auth)
+                .map_err(|source| AppError::JsonSerialize { source })?;
+            write_secret_file(&auth_path, &auth_text)?;
+        }
+
+        Ok(())
+    })();
+
+    match write_result {
+        Ok(()) => Ok(codex_home),
+        Err(err) => match cleanup_temp_codex_home(&codex_home) {
+            Ok(()) => Err(err),
+            Err(cleanup_err) => Err(AppError::localized(
+                "codex.temp_launch_tempdir_cleanup_failed",
+                format!("写入临时 Codex 配置目录失败: {err}；同时清理失败: {cleanup_err}"),
+                format!(
+                    "Failed to write the temporary Codex home: {err}; also failed to clean it up: {cleanup_err}"
+                ),
+            )),
+        },
+    }
+}
+
+struct CodexLaunchSettings<'a> {
+    config_text: &'a str,
+    auth: Option<Value>,
+}
+
+fn parse_launch_settings(provider: &Provider) -> Result<CodexLaunchSettings<'_>, AppError> {
     let settings = provider.settings_config.as_object().ok_or_else(|| {
         AppError::localized(
             "codex.temp_launch_settings_not_object",
@@ -174,47 +240,20 @@ where
         }
     };
 
+    Ok(CodexLaunchSettings { config_text, auth })
+}
+
+fn temp_codex_home_path(temp_dir: &Path, provider_id: &str) -> PathBuf {
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
     let dir_name = format!(
         "cc-switch-codex-{}-{}-{timestamp}",
-        sanitize_filename_fragment(&provider.id),
+        sanitize_filename_fragment(provider_id),
         std::process::id()
     );
-    let codex_home = temp_dir.join(dir_name);
-
-    let write_result = (|| {
-        fs::create_dir_all(&codex_home).map_err(|err| AppError::io(&codex_home, err))?;
-        finalize(&codex_home)?;
-
-        let config_path = codex_home.join("config.toml");
-        write_secret_file(&config_path, config_text.as_bytes())?;
-
-        if let Some(auth) = auth {
-            let auth_path = codex_home.join("auth.json");
-            let auth_text = serde_json::to_vec_pretty(&auth)
-                .map_err(|source| AppError::JsonSerialize { source })?;
-            write_secret_file(&auth_path, &auth_text)?;
-        }
-
-        Ok(())
-    })();
-
-    match write_result {
-        Ok(()) => Ok(codex_home),
-        Err(err) => match cleanup_temp_codex_home(&codex_home) {
-            Ok(()) => Err(err),
-            Err(cleanup_err) => Err(AppError::localized(
-                "codex.temp_launch_tempdir_cleanup_failed",
-                format!("写入临时 Codex 配置目录失败: {err}；同时清理失败: {cleanup_err}"),
-                format!(
-                    "Failed to write the temporary Codex home: {err}; also failed to clean it up: {cleanup_err}"
-                ),
-            )),
-        },
-    }
+    temp_dir.join(dir_name)
 }
 
 #[cfg(unix)]
@@ -500,6 +539,33 @@ mod tests {
                 & 0o777;
             assert_eq!(auth_mode, 0o600);
         }
+    }
+
+    #[test]
+    fn preview_launch_does_not_write_codex_home_files() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let provider = provider_with(
+            "model_provider = \"demo\"\nmodel = \"gpt-5.2-codex\"\n",
+            Some(serde_json::json!({ "OPENAI_API_KEY": "sk-demo" })),
+        );
+
+        let prepared = preview_launch_with(&provider, temp_dir.path(), || {
+            Ok(PathBuf::from("/usr/bin/codex"))
+        })
+        .expect("preview launch");
+
+        assert_eq!(prepared.executable, PathBuf::from("/usr/bin/codex"));
+        assert!(
+            !prepared.codex_home.exists(),
+            "dry-run preview should not write CODEX_HOME"
+        );
+        assert!(
+            std::fs::read_dir(temp_dir.path())
+                .expect("read temp dir")
+                .next()
+                .is_none(),
+            "dry-run preview should leave no temp files"
+        );
     }
 
     #[test]

--- a/src-tauri/src/cli/commands/start.rs
+++ b/src-tauri/src/cli/commands/start.rs
@@ -6,12 +6,14 @@ use indexmap::IndexMap;
 use crate::app_config::AppType;
 use crate::cli::claude_temp_launch::{
     ensure_temp_launch_supported, exec_prepared_claude, prepare_launch_from_settings_with,
-    resolve_claude_binary, PreparedClaudeLaunch,
+    preview_launch_from_settings_with, resolve_claude_binary, PreparedClaudeLaunch,
 };
 use crate::cli::codex_temp_launch::{
     ensure_temp_launch_supported as ensure_codex_temp_launch_supported, exec_prepared_codex,
-    prepare_launch as prepare_codex_launch, PreparedCodexLaunch,
+    prepare_launch as prepare_codex_launch, preview_launch_with as preview_codex_launch_with,
+    resolve_codex_binary, PreparedCodexLaunch,
 };
+use crate::cli::ui::{highlight, info};
 use crate::error::AppError;
 use crate::provider::Provider;
 use crate::services::ProviderService;
@@ -21,11 +23,13 @@ const CLAUDE_RESERVED_NATIVE_ARGS: &[&str] = &["--settings"];
 const CLAUDE_START_AFTER_LONG_HELP: &str = "\
 Examples:
   cc-switch start claude demo
+  cc-switch start claude demo --dry-run
   cc-switch start claude demo -- --dangerously-skip-permissions";
 
 const CODEX_START_AFTER_LONG_HELP: &str = "\
 Examples:
   cc-switch start codex demo
+  cc-switch start codex demo --dry-run
   cc-switch start codex demo -- --model gpt-5.4";
 
 #[derive(Subcommand)]
@@ -35,6 +39,9 @@ pub enum StartCommand {
     Claude {
         /// Provider selector: exact ID first, then exact Name
         selector: String,
+        /// Preview the resolved launch without starting Claude
+        #[arg(long)]
+        dry_run: bool,
         /// Native Claude CLI arguments to pass through after `--`
         #[arg(last = true, value_name = "NATIVE_ARGS")]
         native_args: Vec<OsString>,
@@ -44,6 +51,9 @@ pub enum StartCommand {
     Codex {
         /// Provider selector: exact ID first, then exact Name
         selector: String,
+        /// Preview the resolved launch without starting Codex
+        #[arg(long)]
+        dry_run: bool,
         /// Native Codex CLI arguments to pass through after `--`
         #[arg(last = true, value_name = "NATIVE_ARGS")]
         native_args: Vec<OsString>,
@@ -54,12 +64,14 @@ pub fn execute(cmd: StartCommand) -> Result<(), AppError> {
     match cmd {
         StartCommand::Claude {
             selector,
+            dry_run,
             native_args,
-        } => start_claude(&selector, &native_args),
+        } => start_claude(&selector, dry_run, &native_args),
         StartCommand::Codex {
             selector,
+            dry_run,
             native_args,
-        } => start_codex(&selector, &native_args),
+        } => start_codex(&selector, dry_run, &native_args),
     }
 }
 
@@ -67,13 +79,22 @@ fn get_state() -> Result<AppState, AppError> {
     AppState::try_new()
 }
 
-fn start_claude(selector: &str, native_args: &[OsString]) -> Result<(), AppError> {
+fn start_claude(selector: &str, dry_run: bool, native_args: &[OsString]) -> Result<(), AppError> {
     reject_reserved_native_args(native_args, "Claude", CLAUDE_RESERVED_NATIVE_ARGS)?;
     let state = get_state()?;
     let providers = ProviderService::list(&state, AppType::Claude)?;
     let provider = resolve_provider_selector(&providers, selector, "Claude")?;
 
     ensure_temp_launch_supported()?;
+    if dry_run {
+        let prepared = preview_claude_launch_with(
+            &state,
+            &provider,
+            &std::env::temp_dir(),
+            resolve_claude_binary,
+        )?;
+        return print_claude_dry_run(&provider, &prepared, native_args);
+    }
     let prepared = prepare_claude_launch_with(
         &state,
         &provider,
@@ -83,7 +104,7 @@ fn start_claude(selector: &str, native_args: &[OsString]) -> Result<(), AppError
     handoff_claude_and_cleanup(&prepared, native_args)
 }
 
-fn start_codex(selector: &str, native_args: &[OsString]) -> Result<(), AppError> {
+fn start_codex(selector: &str, dry_run: bool, native_args: &[OsString]) -> Result<(), AppError> {
     start_with(
         selector,
         "Codex",
@@ -93,6 +114,14 @@ fn start_codex(selector: &str, native_args: &[OsString]) -> Result<(), AppError>
         },
         |provider| {
             ensure_codex_temp_launch_supported()?;
+            if dry_run {
+                let prepared = preview_codex_launch_with(
+                    provider,
+                    &std::env::temp_dir(),
+                    resolve_codex_binary,
+                )?;
+                return print_codex_dry_run(provider, &prepared, native_args);
+            }
             let prepared = prepare_codex_launch(provider, &std::env::temp_dir())?;
             handoff_codex_and_cleanup(&prepared, native_args)
         },
@@ -165,6 +194,23 @@ where
     prepare_launch_from_settings_with(&provider.id, &settings, temp_dir, resolve_claude_binary)
 }
 
+fn preview_claude_launch_with<Resolve>(
+    state: &AppState,
+    provider: &Provider,
+    temp_dir: &std::path::Path,
+    resolve_claude_binary: Resolve,
+) -> Result<PreparedClaudeLaunch, AppError>
+where
+    Resolve: FnOnce() -> Result<std::path::PathBuf, AppError>,
+{
+    let settings = ProviderService::build_effective_live_snapshot_from_state(
+        state,
+        AppType::Claude,
+        provider,
+    )?;
+    preview_launch_from_settings_with(&provider.id, &settings, temp_dir, resolve_claude_binary)
+}
+
 fn handoff_claude_and_cleanup(
     prepared: &PreparedClaudeLaunch,
     native_args: &[OsString],
@@ -191,6 +237,149 @@ fn handoff_codex_and_cleanup(
         "temporary config directory",
         "codex.temp_launch_cleanup_failed",
     )
+}
+
+fn print_claude_dry_run(
+    provider: &Provider,
+    prepared: &PreparedClaudeLaunch,
+    native_args: &[OsString],
+) -> Result<(), AppError> {
+    print_dry_run_header("Claude", provider);
+    println!(
+        "{} {}",
+        info(crate::t!("Executable:", "可执行文件：")),
+        prepared.executable.display()
+    );
+    println!(
+        "{} {}",
+        info(crate::t!("Settings path preview:", "设置文件路径预览：")),
+        prepared.settings_path.display()
+    );
+    println!(
+        "{} {}",
+        info(crate::t!("Launch command:", "启动命令：")),
+        format_command_preview(
+            &prepared.executable,
+            &[
+                OsString::from("--settings"),
+                prepared.settings_path.as_os_str().to_os_string(),
+            ],
+            native_args,
+        )
+    );
+    print_native_args(native_args);
+    print_dry_run_note()
+}
+
+fn print_codex_dry_run(
+    provider: &Provider,
+    prepared: &PreparedCodexLaunch,
+    native_args: &[OsString],
+) -> Result<(), AppError> {
+    print_dry_run_header("Codex", provider);
+    println!(
+        "{} {}",
+        info(crate::t!("Executable:", "可执行文件：")),
+        prepared.executable.display()
+    );
+    println!(
+        "{} {}",
+        info(crate::t!("CODEX_HOME preview:", "CODEX_HOME 预览：")),
+        prepared.codex_home.display()
+    );
+    println!(
+        "{} CODEX_HOME={}",
+        info(crate::t!("Environment:", "环境变量：")),
+        quote_display(&prepared.codex_home.as_os_str().to_string_lossy())
+    );
+    println!(
+        "{} {}",
+        info(crate::t!("Launch command:", "启动命令：")),
+        format_command_preview(&prepared.executable, &[], native_args)
+    );
+    println!(
+        "{} {} internal capture-codex-temp {} {}",
+        info(crate::t!("Persist command:", "持久化命令：")),
+        quote_display(&prepared.cc_switch_executable.as_os_str().to_string_lossy()),
+        quote_display(&prepared.provider_id),
+        quote_display(&prepared.codex_home.as_os_str().to_string_lossy())
+    );
+    print_native_args(native_args);
+    print_dry_run_note()
+}
+
+fn print_dry_run_header(app_name: &str, provider: &Provider) {
+    let title = if crate::cli::i18n::is_chinese() {
+        format!("{app_name} 启动预览")
+    } else {
+        format!("{app_name} dry run")
+    };
+    println!("{}", highlight(&title));
+    println!(
+        "{} {}",
+        info(crate::t!("Provider ID:", "供应商 ID：")),
+        provider.id
+    );
+    println!(
+        "{} {}",
+        info(crate::t!("Provider name:", "供应商名称：")),
+        provider.name
+    );
+}
+
+fn print_native_args(native_args: &[OsString]) {
+    let rendered = if native_args.is_empty() {
+        crate::t!("(none)", "（无）").to_string()
+    } else {
+        native_args
+            .iter()
+            .map(|arg| quote_display(&arg.to_string_lossy()))
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+    println!(
+        "{} {}",
+        info(crate::t!("Passthrough args:", "透传参数：")),
+        rendered
+    );
+}
+
+fn print_dry_run_note() -> Result<(), AppError> {
+    println!(
+        "{}",
+        info(crate::t!(
+            "Dry run only; no temporary files were written and the app was not started.",
+            "仅 dry-run；未写入临时文件，也未启动应用。"
+        ))
+    );
+    Ok(())
+}
+
+fn format_command_preview(
+    executable: &std::path::Path,
+    managed_args: &[OsString],
+    native_args: &[OsString],
+) -> String {
+    std::iter::once(executable.as_os_str())
+        .chain(managed_args.iter().map(OsString::as_os_str))
+        .chain(native_args.iter().map(OsString::as_os_str))
+        .map(|arg| quote_display(&arg.to_string_lossy()))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn quote_display(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-' | ':' | '='))
+    {
+        return value.to_string();
+    }
+
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn finish_launch(
@@ -449,6 +638,58 @@ mod tests {
             written, expected,
             "CLI temp launch should write the canonical effective snapshot"
         );
+    }
+
+    #[test]
+    fn dry_run_command_preview_quotes_space_and_single_quote_args() {
+        let preview = format_command_preview(
+            std::path::Path::new("/usr/local/bin/claude"),
+            &[
+                OsString::from("--settings"),
+                OsString::from("/tmp/demo settings.json"),
+            ],
+            &[OsString::from("fix Bob's bug")],
+        );
+
+        assert_eq!(
+            preview,
+            "/usr/local/bin/claude --settings '/tmp/demo settings.json' 'fix Bob'\\''s bug'"
+        );
+    }
+
+    #[test]
+    fn preview_claude_launch_with_does_not_write_temp_settings() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let mut config = crate::app_config::MultiAppConfig::default();
+        config.ensure_app(&AppType::Claude);
+        let state = state_from_config(config);
+        let provider = provider("demo", "Claude Demo");
+
+        let prepared = preview_claude_launch_with(&state, &provider, temp_dir.path(), || {
+            Ok(std::path::PathBuf::from("/usr/bin/claude"))
+        })
+        .expect("preview launch");
+
+        assert_eq!(
+            prepared.executable,
+            std::path::PathBuf::from("/usr/bin/claude")
+        );
+        assert!(
+            !prepared.settings_path.exists(),
+            "dry-run preview should not write settings"
+        );
+        assert!(
+            std::fs::read_dir(temp_dir.path())
+                .expect("read temp dir")
+                .next()
+                .is_none(),
+            "dry-run preview should leave no temp files"
+        );
+    }
+
+    #[test]
+    fn dry_run_note_succeeds() {
+        print_dry_run_note().expect("dry-run note should print without cleanup");
     }
 
     #[test]

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -48,6 +48,12 @@ pub enum Commands {
     #[command(subcommand)]
     Provider(commands::provider::ProviderCommand),
 
+    /// Switch to a provider (shortcut for `provider switch <id>`)
+    Use {
+        /// Provider ID to switch to
+        id: String,
+    },
+
     /// Manage MCP servers (list, add, edit, delete, sync)
     #[command(subcommand)]
     Mcp(commands::mcp::McpCommand),
@@ -168,6 +174,27 @@ mod tests {
                 assert_eq!(listen_port, Some(0));
             }
             _ => panic!("expected proxy serve command"),
+        }
+    }
+
+    #[test]
+    fn parses_use_shortcut_command() {
+        let cli = Cli::parse_from(["cc-switch", "use", "demo"]);
+
+        match cli.command {
+            Some(Commands::Use { id }) => assert_eq!(id, "demo"),
+            _ => panic!("expected use shortcut command"),
+        }
+    }
+
+    #[test]
+    fn parses_use_shortcut_with_app_global() {
+        let cli = Cli::parse_from(["cc-switch", "--app", "codex", "use", "demo"]);
+
+        assert_eq!(cli.app, Some(AppType::Codex));
+        match cli.command {
+            Some(Commands::Use { id }) => assert_eq!(id, "demo"),
+            _ => panic!("expected use shortcut command"),
         }
     }
 
@@ -599,12 +626,33 @@ mod tests {
         match cli.command {
             Some(Commands::Start(super::commands::start::StartCommand::Claude {
                 selector,
+                dry_run,
                 native_args,
             })) => {
                 assert_eq!(selector, "demo");
+                assert!(!dry_run);
                 assert!(native_args.is_empty());
             }
             _ => panic!("expected start claude command"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parses_start_claude_dry_run_option() {
+        let cli = Cli::parse_from(["cc-switch", "start", "claude", "demo", "--dry-run"]);
+
+        match cli.command {
+            Some(Commands::Start(super::commands::start::StartCommand::Claude {
+                selector,
+                dry_run,
+                native_args,
+            })) => {
+                assert_eq!(selector, "demo");
+                assert!(dry_run);
+                assert!(native_args.is_empty());
+            }
+            _ => panic!("expected start claude dry-run command"),
         }
     }
 
@@ -623,9 +671,11 @@ mod tests {
         match cli.command {
             Some(Commands::Start(super::commands::start::StartCommand::Claude {
                 selector,
+                dry_run,
                 native_args,
             })) => {
                 assert_eq!(selector, "demo");
+                assert!(!dry_run);
                 assert_eq!(
                     native_args,
                     vec![OsString::from("--dangerously-skip-permissions")]
@@ -661,12 +711,45 @@ mod tests {
         match cli.command {
             Some(Commands::Start(super::commands::start::StartCommand::Codex {
                 selector,
+                dry_run,
                 native_args,
             })) => {
                 assert_eq!(selector, "demo");
+                assert!(!dry_run);
                 assert!(native_args.is_empty());
             }
             _ => panic!("expected start codex command"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parses_start_codex_dry_run_with_native_args_after_double_dash() {
+        let cli = Cli::parse_from([
+            "cc-switch",
+            "start",
+            "codex",
+            "demo",
+            "--dry-run",
+            "--",
+            "--model",
+            "gpt-5.4",
+        ]);
+
+        match cli.command {
+            Some(Commands::Start(super::commands::start::StartCommand::Codex {
+                selector,
+                dry_run,
+                native_args,
+            })) => {
+                assert_eq!(selector, "demo");
+                assert!(dry_run);
+                assert_eq!(
+                    native_args,
+                    vec![OsString::from("--model"), OsString::from("gpt-5.4")]
+                );
+            }
+            _ => panic!("expected start codex dry-run command with native args"),
         }
     }
 
@@ -688,9 +771,11 @@ mod tests {
         match cli.command {
             Some(Commands::Start(super::commands::start::StartCommand::Codex {
                 selector,
+                dry_run,
                 native_args,
             })) => {
                 assert_eq!(selector, "demo");
+                assert!(!dry_run);
                 assert_eq!(
                     native_args,
                     vec![
@@ -717,7 +802,9 @@ mod tests {
             .expect("claude subcommand should exist");
         let help = claude.render_long_help().to_string();
 
+        assert!(help.contains("--dry-run"));
         assert!(help.contains("Native Claude CLI arguments to pass through after `--`"));
+        assert!(help.contains("cc-switch start claude demo --dry-run"));
         assert!(help.contains("cc-switch start claude demo -- --dangerously-skip-permissions"));
     }
 
@@ -733,7 +820,9 @@ mod tests {
             .expect("codex subcommand should exist");
         let help = codex.render_long_help().to_string();
 
+        assert!(help.contains("--dry-run"));
         assert!(help.contains("Native Codex CLI arguments to pass through after `--`"));
+        assert!(help.contains("cc-switch start codex demo --dry-run"));
         assert!(help.contains("cc-switch start codex demo -- --model gpt-5.4"));
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -50,6 +50,10 @@ fn run(cli: Cli) -> Result<(), AppError> {
         Some(Commands::Provider(cmd)) => {
             cc_switch_lib::cli::commands::provider::execute(cmd, cli.app)
         }
+        Some(Commands::Use { id }) => cc_switch_lib::cli::commands::provider::execute(
+            cc_switch_lib::cli::commands::provider::ProviderCommand::Switch { id },
+            cli.app,
+        ),
         Some(Commands::Mcp(cmd)) => cc_switch_lib::cli::commands::mcp::execute(cmd, cli.app),
         Some(Commands::Prompts(cmd)) => {
             cc_switch_lib::cli::commands::prompts::execute(cmd, cli.app)


### PR DESCRIPTION
## Summary
- add `cc-switch use <id>` as a shortcut for provider switching
- add `cc-switch start claude|codex <selector> --dry-run` for launch previews without starting apps
- keep README discovery concise for the new CLI shortcuts

## Tests
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `git diff --check`
- `cargo test --manifest-path src-tauri/Cargo.toml cli::commands::start::tests --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml cli::claude_temp_launch::tests --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml cli::codex_temp_launch::tests --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml cli::tests::parses_use_shortcut --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml cli::tests::parses_start --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml --bin cc-switch`