### PR TITLE
feat(codex): expose local routing config

### DIFF
--- a/src-tauri/src/cli/commands/provider.rs
+++ b/src-tauri/src/cli/commands/provider.rs
@@ -30,17 +30,10 @@ const CLAUDE_API_FORMAT_CHOICES: [&str; 4] = [
     CLAUDE_API_FORMAT_OPENAI_RESPONSES,
     CLAUDE_API_FORMAT_GEMINI_NATIVE,
 ];
-
-fn is_codex_official_provider(provider: &Provider) -> bool {
-    provider
-        .meta
-        .as_ref()
-        .and_then(|meta| meta.codex_official)
-        .unwrap_or(false)
-        || provider.category.as_deref() == Some("official")
-        || provider.website_url.as_deref() == Some("https://chatgpt.com/codex")
-        || provider.name.trim().eq_ignore_ascii_case("OpenAI Official")
-}
+const CODEX_API_FORMAT_CHOICES: [&str; 2] = [
+    CLAUDE_API_FORMAT_OPENAI_RESPONSES,
+    CLAUDE_API_FORMAT_OPENAI_CHAT,
+];
 
 fn is_claude_official_provider(provider: &Provider) -> bool {
     provider
@@ -63,6 +56,18 @@ fn normalize_claude_api_format(raw: &str) -> &'static str {
         CLAUDE_API_FORMAT_OPENAI_RESPONSES => CLAUDE_API_FORMAT_OPENAI_RESPONSES,
         CLAUDE_API_FORMAT_GEMINI_NATIVE => CLAUDE_API_FORMAT_GEMINI_NATIVE,
         _ => CLAUDE_API_FORMAT_ANTHROPIC,
+    }
+}
+
+fn normalize_codex_api_format(raw: &str) -> &'static str {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "chat"
+        | "chat_completions"
+        | "chat-completions"
+        | CLAUDE_API_FORMAT_OPENAI_CHAT
+        | "openai-chat"
+        | "openai_chat_completions" => CLAUDE_API_FORMAT_OPENAI_CHAT,
+        _ => CLAUDE_API_FORMAT_OPENAI_RESPONSES,
     }
 }
 
@@ -103,6 +108,34 @@ fn effective_claude_api_format(provider: &Provider) -> &'static str {
         CLAUDE_API_FORMAT_OPENAI_CHAT
     } else {
         CLAUDE_API_FORMAT_ANTHROPIC
+    }
+}
+
+fn effective_codex_api_format(provider: &Provider) -> &'static str {
+    if let Some(api_format) = provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.api_format.as_deref())
+        .or_else(|| {
+            provider
+                .settings_config
+                .get("api_format")
+                .and_then(|value| value.as_str())
+        })
+        .or_else(|| {
+            provider
+                .settings_config
+                .get("apiFormat")
+                .and_then(|value| value.as_str())
+        })
+    {
+        return normalize_codex_api_format(api_format);
+    }
+
+    if crate::proxy::providers::codex_provider_uses_chat_completions(provider) {
+        CLAUDE_API_FORMAT_OPENAI_CHAT
+    } else {
+        CLAUDE_API_FORMAT_OPENAI_RESPONSES
     }
 }
 
@@ -165,6 +198,31 @@ fn strip_claude_api_format_legacy_settings(provider: &mut Provider) {
     settings_obj.remove("openrouter_compat_mode");
 }
 
+fn strip_codex_api_format_legacy_settings(provider: &mut Provider) {
+    let Some(settings_obj) = provider.settings_config.as_object_mut() else {
+        return;
+    };
+    settings_obj.remove("api_format");
+    settings_obj.remove("apiFormat");
+}
+
+fn normalize_codex_settings_wire_api(provider: &mut Provider) {
+    let Some(config_text) = provider
+        .settings_config
+        .get("config")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+    else {
+        return;
+    };
+    let normalized =
+        crate::codex_config::normalize_codex_config_wire_api_to_responses(&config_text);
+
+    if let Some(settings_obj) = provider.settings_config.as_object_mut() {
+        settings_obj.insert("config".to_string(), serde_json::Value::String(normalized));
+    }
+}
+
 fn apply_claude_api_format(provider: &mut Provider, api_format: &str) {
     let api_format = normalize_claude_api_format(api_format);
     if api_format == CLAUDE_API_FORMAT_ANTHROPIC {
@@ -179,6 +237,16 @@ fn apply_claude_api_format(provider: &mut Provider, api_format: &str) {
             .api_format = Some(api_format.to_string());
     }
     strip_claude_api_format_legacy_settings(provider);
+}
+
+fn apply_codex_api_format(provider: &mut Provider, api_format: &str) {
+    let api_format = normalize_codex_api_format(api_format);
+    provider
+        .meta
+        .get_or_insert_with(ProviderMeta::default)
+        .api_format = Some(api_format.to_string());
+    strip_codex_api_format_legacy_settings(provider);
+    normalize_codex_settings_wire_api(provider);
 }
 
 fn apply_fixed_claude_api_format_if_needed(app_type: &AppType, provider: &mut Provider) -> bool {
@@ -199,30 +267,71 @@ fn apply_fixed_claude_api_format_if_needed(app_type: &AppType, provider: &mut Pr
     false
 }
 
-fn prompt_claude_api_format(provider: &Provider) -> Result<&'static str, AppError> {
-    let current = effective_claude_api_format(provider);
-    let default_index = CLAUDE_API_FORMAT_CHOICES
+fn apply_fixed_codex_api_format_if_needed(app_type: &AppType, provider: &mut Provider) -> bool {
+    if !matches!(app_type, AppType::Codex) {
+        return true;
+    }
+
+    if provider.is_codex_official() {
+        if let Some(meta) = provider.meta.as_mut() {
+            meta.api_format = None;
+            meta.codex_chat_reasoning = None;
+        }
+        if let Some(settings_obj) = provider.settings_config.as_object_mut() {
+            settings_obj.remove("modelCatalog");
+        }
+        prune_empty_provider_meta(provider);
+        strip_codex_api_format_legacy_settings(provider);
+        normalize_codex_settings_wire_api(provider);
+        return true;
+    }
+
+    false
+}
+
+fn prompt_api_format(
+    choices: &'static [&'static str],
+    current: &str,
+    value_label: fn(&str) -> &'static str,
+    fallback: &'static str,
+) -> Result<&'static str, AppError> {
+    let default_index = choices
         .iter()
         .position(|api_format| *api_format == current)
         .unwrap_or(0);
-    let choices = CLAUDE_API_FORMAT_CHOICES
+    let labels = choices
         .iter()
-        .map(|api_format| texts::tui_claude_api_format_value(api_format).to_string())
+        .map(|api_format| value_label(api_format).to_string())
         .collect::<Vec<_>>();
 
-    let selected = Select::new(texts::tui_label_claude_api_format(), choices.clone())
+    let selected = Select::new(texts::tui_label_claude_api_format(), labels.clone())
         .with_starting_cursor(default_index)
         .prompt()
         .map_err(|e| AppError::Message(texts::input_failed_error(&e.to_string())))?;
-    let selected_index = choices
+    let selected_index = labels
         .iter()
-        .position(|choice| choice == &selected)
+        .position(|label| label == &selected)
         .unwrap_or(default_index);
 
-    Ok(CLAUDE_API_FORMAT_CHOICES
-        .get(selected_index)
-        .copied()
-        .unwrap_or(CLAUDE_API_FORMAT_ANTHROPIC))
+    Ok(choices.get(selected_index).copied().unwrap_or(fallback))
+}
+
+fn prompt_claude_api_format(provider: &Provider) -> Result<&'static str, AppError> {
+    prompt_api_format(
+        &CLAUDE_API_FORMAT_CHOICES,
+        effective_claude_api_format(provider),
+        texts::tui_claude_api_format_value,
+        CLAUDE_API_FORMAT_ANTHROPIC,
+    )
+}
+
+fn prompt_codex_api_format(provider: &Provider) -> Result<&'static str, AppError> {
+    prompt_api_format(
+        &CODEX_API_FORMAT_CHOICES,
+        effective_codex_api_format(provider),
+        texts::tui_codex_api_format_value,
+        CLAUDE_API_FORMAT_OPENAI_RESPONSES,
+    )
 }
 
 fn prompt_and_apply_claude_api_format(
@@ -236,6 +345,30 @@ fn prompt_and_apply_claude_api_format(
     let api_format = prompt_claude_api_format(provider)?;
     apply_claude_api_format(provider, api_format);
     Ok(())
+}
+
+fn prompt_and_apply_codex_api_format(
+    app_type: &AppType,
+    provider: &mut Provider,
+) -> Result<(), AppError> {
+    if apply_fixed_codex_api_format_if_needed(app_type, provider) {
+        return Ok(());
+    }
+
+    let api_format = prompt_codex_api_format(provider)?;
+    apply_codex_api_format(provider, api_format);
+    Ok(())
+}
+
+fn prompt_and_apply_provider_api_format(
+    app_type: &AppType,
+    provider: &mut Provider,
+) -> Result<(), AppError> {
+    match app_type {
+        AppType::Claude => prompt_and_apply_claude_api_format(app_type, provider),
+        AppType::Codex => prompt_and_apply_codex_api_format(app_type, provider),
+        AppType::Gemini | AppType::OpenCode | AppType::Hermes | AppType::OpenClaw => Ok(()),
+    }
 }
 
 fn normalize_optional_account_id(account_id: Option<String>) -> Option<String> {
@@ -718,7 +851,7 @@ fn add_provider(app_type: AppType, template: Option<ProviderAddTemplate>) -> Res
                 &app_type,
                 Some(&provider.settings_config),
                 provider.meta.as_ref(),
-                is_codex_official_provider(&provider),
+                provider.is_codex_official(),
             )?;
             provider.settings_config = prompt_result.settings_config.clone();
             settings_prompt_result = Some(prompt_result);
@@ -746,7 +879,7 @@ fn add_provider(app_type: AppType, template: Option<ProviderAddTemplate>) -> Res
         &mut provider,
         settings_prompt_result.as_ref(),
     );
-    prompt_and_apply_claude_api_format(&app_type, &mut provider)?;
+    prompt_and_apply_provider_api_format(&app_type, &mut provider)?;
     prompt_and_apply_codex_oauth_provider_options(&app_type, &mut provider)?;
     if let Some(enabled) = prompt_common_config_enabled(&app_type, common_snippet.as_deref(), None)?
     {
@@ -826,7 +959,7 @@ fn edit_provider(app_type: AppType, id: &str) -> Result<(), AppError> {
             &app_type,
             Some(&original.settings_config),
             original.meta.as_ref(),
-            matches!(app_type, AppType::Codex) && is_codex_official_provider(&original),
+            matches!(app_type, AppType::Codex) && original.is_codex_official(),
         )?)
     } else {
         None
@@ -863,7 +996,7 @@ fn edit_provider(app_type: AppType, id: &str) -> Result<(), AppError> {
         in_failover_queue: original.in_failover_queue, // 保留故障转移状态
     };
     apply_settings_prompt_result_metadata(&app_type, &mut updated, settings_prompt_result.as_ref());
-    prompt_and_apply_claude_api_format(&app_type, &mut updated)?;
+    prompt_and_apply_provider_api_format(&app_type, &mut updated)?;
     prompt_and_apply_codex_oauth_provider_options(&app_type, &mut updated)?;
     if let Some(enabled) =
         prompt_common_config_enabled(&app_type, common_snippet.as_deref(), Some(&updated))?
@@ -907,6 +1040,15 @@ mod tests {
         Provider::with_id(
             "provider-1".to_string(),
             "Provider One".to_string(),
+            settings_config,
+            None,
+        )
+    }
+
+    fn codex_provider(settings_config: serde_json::Value) -> Provider {
+        Provider::with_id(
+            "codex-provider".to_string(),
+            "Codex Provider".to_string(),
             settings_config,
             None,
         )
@@ -1145,6 +1287,122 @@ mod tests {
     }
 
     #[test]
+    fn codex_api_format_effective_value_prefers_meta_over_legacy_settings() {
+        let mut provider = codex_provider(json!({
+            "api_format": "openai_chat",
+            "apiFormat": "chat"
+        }));
+        provider.meta = Some(ProviderMeta {
+            api_format: Some(CLAUDE_API_FORMAT_OPENAI_RESPONSES.to_string()),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            effective_codex_api_format(&provider),
+            CLAUDE_API_FORMAT_OPENAI_RESPONSES
+        );
+    }
+
+    #[test]
+    fn codex_api_format_effective_value_reads_legacy_chat_wire_api() {
+        let provider = codex_provider(json!({
+            "config": r#"model_provider = "vendor"
+
+[model_providers.vendor]
+base_url = "https://vendor.example/v1"
+wire_api = "chat"
+"#
+        }));
+
+        assert_eq!(
+            effective_codex_api_format(&provider),
+            CLAUDE_API_FORMAT_OPENAI_CHAT
+        );
+    }
+
+    #[test]
+    fn codex_api_format_apply_writes_meta_and_normalizes_legacy_config() {
+        let mut provider = codex_provider(json!({
+            "api_format": "openai_responses",
+            "apiFormat": "openai_responses",
+            "config": r#"model_provider = "vendor"
+wire_api = "chat"
+
+[model_providers.vendor]
+base_url = "https://vendor.example/v1"
+wire_api = "chat"
+"#
+        }));
+
+        apply_codex_api_format(&mut provider, CLAUDE_API_FORMAT_OPENAI_CHAT);
+
+        assert_eq!(
+            provider
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.api_format.as_deref()),
+            Some(CLAUDE_API_FORMAT_OPENAI_CHAT)
+        );
+        assert!(provider.settings_config.get("api_format").is_none());
+        assert!(provider.settings_config.get("apiFormat").is_none());
+        let config_text = provider
+            .settings_config
+            .get("config")
+            .and_then(serde_json::Value::as_str)
+            .expect("config should remain a string");
+        assert!(config_text.contains("wire_api = \"responses\""));
+        assert!(
+            !config_text.contains("wire_api = \"chat\""),
+            "CLI should persist upstream Codex wire_api semantics"
+        );
+    }
+
+    #[test]
+    fn codex_api_format_fixed_provider_clears_overrides_and_normalizes_config() {
+        let mut provider = codex_provider(json!({
+            "api_format": "openai_chat",
+            "apiFormat": "chat",
+            "config": r#"model_provider = "openai"
+
+[model_providers.openai]
+base_url = "https://api.openai.com/v1"
+wire_api = "chat"
+"#,
+            "modelCatalog": {
+                "models": [
+                    { "model": "stale-chat-model" }
+                ]
+            }
+        }));
+        provider.category = Some("official".to_string());
+        provider.meta = Some(ProviderMeta {
+            api_format: Some(CLAUDE_API_FORMAT_OPENAI_CHAT.to_string()),
+            codex_chat_reasoning: Some(crate::provider::CodexChatReasoningConfig {
+                supports_thinking: Some(true),
+                supports_effort: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        assert!(apply_fixed_codex_api_format_if_needed(
+            &AppType::Codex,
+            &mut provider
+        ));
+        assert!(provider.meta.is_none());
+        assert!(provider.settings_config.get("api_format").is_none());
+        assert!(provider.settings_config.get("apiFormat").is_none());
+        assert!(provider.settings_config.get("modelCatalog").is_none());
+        let config_text = provider
+            .settings_config
+            .get("config")
+            .and_then(serde_json::Value::as_str)
+            .expect("config should remain a string");
+        assert!(config_text.contains("wire_api = \"responses\""));
+        assert!(!config_text.contains("wire_api = \"chat\""));
+    }
+
+    #[test]
     fn codex_oauth_provider_options_write_upstream_managed_account_shape() {
         let mut provider = claude_provider(json!({
             "env": {
@@ -1361,7 +1619,7 @@ fn duplicate_provider_interactive(app_type: AppType, id: &str) -> Result<(), App
             &app_type,
             Some(&draft.settings_config),
             draft.meta.as_ref(),
-            matches!(app_type, AppType::Codex) && is_codex_official_provider(&source),
+            matches!(app_type, AppType::Codex) && source.is_codex_official(),
         )?)
     } else {
         None
@@ -1396,7 +1654,7 @@ fn duplicate_provider_interactive(app_type: AppType, id: &str) -> Result<(), App
         in_failover_queue: false,
     };
     apply_settings_prompt_result_metadata(&app_type, &mut copied, settings_prompt_result.as_ref());
-    prompt_and_apply_claude_api_format(&app_type, &mut copied)?;
+    prompt_and_apply_provider_api_format(&app_type, &mut copied)?;
     prompt_and_apply_codex_oauth_provider_options(&app_type, &mut copied)?;
     if let Some(enabled) =
         prompt_common_config_enabled(&app_type, common_snippet.as_deref(), Some(&copied))?

--- a/src-tauri/src/cli/commands/provider_input.rs
+++ b/src-tauri/src/cli/commands/provider_input.rs
@@ -3814,6 +3814,19 @@ pub fn display_provider_summary(provider: &Provider, app_type: &AppType) {
             }
         }
         AppType::Codex => {
+            if !provider.is_codex_official() {
+                let api_format =
+                    if crate::proxy::providers::codex_provider_uses_chat_completions(provider) {
+                        "openai_chat"
+                    } else {
+                        "openai_responses"
+                    };
+                println!(
+                    "  {}: {}",
+                    texts::tui_label_claude_api_format(),
+                    texts::tui_codex_api_format_value(api_format)
+                );
+            }
             if let Some(auth) = provider.settings_config.get("auth") {
                 if let Some(api_key) = auth.get("OPENAI_API_KEY").and_then(|v| v.as_str()) {
                     println!(

--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -1595,6 +1595,25 @@ pub mod texts {
         }
     }
 
+    pub fn tui_codex_api_format_value(api_format: &str) -> &'static str {
+        match api_format {
+            "openai_chat" => {
+                if is_chinese() {
+                    "OpenAI Chat Completions (需本地路由)"
+                } else {
+                    "OpenAI Chat Completions (Local routing)"
+                }
+            }
+            _ => {
+                if is_chinese() {
+                    "OpenAI Responses API (原生)"
+                } else {
+                    "OpenAI Responses API (Native)"
+                }
+            }
+        }
+    }
+
     pub fn tui_claude_api_format_requires_proxy_title() -> &'static str {
         if is_chinese() {
             "需开启代理"
@@ -1609,6 +1628,144 @@ pub mod texts {
             format!("已切换为 {label}。\n该格式需开启本地代理使用。\n请在主页按 P 打开本地代理。")
         } else {
             format!("Switched to {label}.\nThis format requires the local proxy.\nPress P on the home page to open local proxy.")
+        }
+    }
+
+    pub fn tui_codex_api_format_requires_proxy_message(api_format: &str) -> String {
+        let label = tui_codex_api_format_value(api_format);
+        if is_chinese() {
+            format!(
+                "已切换为 {label}。\n该格式需要本地路由映射。\n使用此供应商时请保持本地代理开启。"
+            )
+        } else {
+            format!("Switched to {label}.\nThis format requires local route mapping.\nKeep the local proxy enabled while using this provider.")
+        }
+    }
+
+    pub fn tui_label_codex_local_routing() -> &'static str {
+        if is_chinese() {
+            "本地路由"
+        } else {
+            "Local Routing"
+        }
+    }
+
+    pub fn tui_codex_local_routing_title(provider: &str) -> String {
+        let title = tui_label_codex_local_routing();
+        if provider.trim().is_empty() {
+            title.to_string()
+        } else {
+            format!("{title} - {provider}")
+        }
+    }
+
+    pub fn tui_codex_local_routing_enable() -> &'static str {
+        if is_chinese() {
+            "启用本地路由"
+        } else {
+            "Enable Local Routing"
+        }
+    }
+
+    pub fn tui_codex_reasoning_supports_thinking() -> &'static str {
+        if is_chinese() {
+            "支持思考模式"
+        } else {
+            "Supports Thinking"
+        }
+    }
+
+    pub fn tui_codex_reasoning_supports_effort() -> &'static str {
+        if is_chinese() {
+            "支持思考等级"
+        } else {
+            "Supports Reasoning Effort"
+        }
+    }
+
+    pub fn tui_codex_model_catalog() -> &'static str {
+        if is_chinese() {
+            "模型映射"
+        } else {
+            "Model Mapping"
+        }
+    }
+
+    pub fn tui_codex_model_catalog_title(provider: &str) -> String {
+        if is_chinese() {
+            if provider.trim().is_empty() {
+                "模型映射".to_string()
+            } else {
+                format!("模型映射 - {provider}")
+            }
+        } else if provider.trim().is_empty() {
+            "Model Mapping".to_string()
+        } else {
+            format!("Model Mapping - {provider}")
+        }
+    }
+
+    pub fn tui_codex_model_catalog_model_header() -> &'static str {
+        if is_chinese() {
+            "模型"
+        } else {
+            "Model"
+        }
+    }
+
+    pub fn tui_codex_model_catalog_display_header() -> &'static str {
+        if is_chinese() {
+            "显示名称"
+        } else {
+            "Display"
+        }
+    }
+
+    pub fn tui_codex_model_catalog_context_header() -> &'static str {
+        if is_chinese() {
+            "上下文"
+        } else {
+            "Context"
+        }
+    }
+
+    pub fn tui_codex_model_catalog_empty() -> &'static str {
+        if is_chinese() {
+            "暂无模型映射"
+        } else {
+            "No model mappings"
+        }
+    }
+
+    pub fn tui_codex_model_catalog_model_prompt() -> &'static str {
+        if is_chinese() {
+            "模型 ID"
+        } else {
+            "Model ID"
+        }
+    }
+
+    pub fn tui_codex_model_catalog_display_prompt() -> &'static str {
+        if is_chinese() {
+            "显示名称"
+        } else {
+            "Display Name"
+        }
+    }
+
+    pub fn tui_codex_model_catalog_context_prompt() -> &'static str {
+        if is_chinese() {
+            "上下文窗口"
+        } else {
+            "Context Window"
+        }
+    }
+
+    pub fn tui_codex_model_catalog_preview_title() -> &'static str {
+        if is_chinese() {
+            "模型映射"
+        } else {
+            "Model Mapping"
         }
     }
 

--- a/src-tauri/src/cli/i18n/texts/core.rs
+++ b/src-tauri/src/cli/i18n/texts/core.rs
@@ -1425,6 +1425,25 @@ pub fn tui_claude_api_format_value(api_format: &str) -> &'static str {
     }
 }
 
+pub fn tui_codex_api_format_value(api_format: &str) -> &'static str {
+    match api_format {
+        "openai_chat" => {
+            if is_chinese() {
+                "OpenAI Chat Completions (需本地路由)"
+            } else {
+                "OpenAI Chat Completions (Local routing)"
+            }
+        }
+        _ => {
+            if is_chinese() {
+                "OpenAI Responses API (原生)"
+            } else {
+                "OpenAI Responses API (Native)"
+            }
+        }
+    }
+}
+
 pub fn tui_claude_api_format_requires_proxy_title() -> &'static str {
     if is_chinese() {
         "需开启代理"
@@ -1439,5 +1458,141 @@ pub fn tui_claude_api_format_requires_proxy_message(api_format: &str) -> String 
         format!("已切换为 {label}。\n该格式需开启本地代理使用。\n请在主页按 P 打开本地代理。")
     } else {
         format!("Switched to {label}.\nThis format requires the local proxy.\nPress P on the home page to open local proxy.")
+    }
+}
+
+pub fn tui_codex_api_format_requires_proxy_message(api_format: &str) -> String {
+    let label = tui_codex_api_format_value(api_format);
+    if is_chinese() {
+        format!("已切换为 {label}。\n该格式需要本地路由映射。\n使用此供应商时请保持本地代理开启。")
+    } else {
+        format!("Switched to {label}.\nThis format requires local route mapping.\nKeep the local proxy enabled while using this provider.")
+    }
+}
+
+pub fn tui_label_codex_local_routing() -> &'static str {
+    if is_chinese() {
+        "本地路由"
+    } else {
+        "Local Routing"
+    }
+}
+
+pub fn tui_codex_local_routing_title(provider: &str) -> String {
+    let title = tui_label_codex_local_routing();
+    if provider.trim().is_empty() {
+        title.to_string()
+    } else {
+        format!("{title} - {provider}")
+    }
+}
+
+pub fn tui_codex_local_routing_enable() -> &'static str {
+    if is_chinese() {
+        "启用本地路由"
+    } else {
+        "Enable Local Routing"
+    }
+}
+
+pub fn tui_codex_reasoning_supports_thinking() -> &'static str {
+    if is_chinese() {
+        "支持思考模式"
+    } else {
+        "Supports Thinking"
+    }
+}
+
+pub fn tui_codex_reasoning_supports_effort() -> &'static str {
+    if is_chinese() {
+        "支持思考等级"
+    } else {
+        "Supports Reasoning Effort"
+    }
+}
+
+pub fn tui_codex_model_catalog() -> &'static str {
+    if is_chinese() {
+        "模型映射"
+    } else {
+        "Model Mapping"
+    }
+}
+
+pub fn tui_codex_model_catalog_title(provider: &str) -> String {
+    if is_chinese() {
+        if provider.trim().is_empty() {
+            "模型映射".to_string()
+        } else {
+            format!("模型映射 - {provider}")
+        }
+    } else if provider.trim().is_empty() {
+        "Model Mapping".to_string()
+    } else {
+        format!("Model Mapping - {provider}")
+    }
+}
+
+pub fn tui_codex_model_catalog_model_header() -> &'static str {
+    if is_chinese() {
+        "模型"
+    } else {
+        "Model"
+    }
+}
+
+pub fn tui_codex_model_catalog_display_header() -> &'static str {
+    if is_chinese() {
+        "显示名称"
+    } else {
+        "Display"
+    }
+}
+
+pub fn tui_codex_model_catalog_context_header() -> &'static str {
+    if is_chinese() {
+        "上下文"
+    } else {
+        "Context"
+    }
+}
+
+pub fn tui_codex_model_catalog_empty() -> &'static str {
+    if is_chinese() {
+        "暂无模型映射"
+    } else {
+        "No model mappings"
+    }
+}
+
+pub fn tui_codex_model_catalog_model_prompt() -> &'static str {
+    if is_chinese() {
+        "模型 ID"
+    } else {
+        "Model ID"
+    }
+}
+
+pub fn tui_codex_model_catalog_display_prompt() -> &'static str {
+    if is_chinese() {
+        "显示名称"
+    } else {
+        "Display Name"
+    }
+}
+
+pub fn tui_codex_model_catalog_context_prompt() -> &'static str {
+    if is_chinese() {
+        "上下文窗口"
+    } else {
+        "Context Window"
+    }
+}
+
+pub fn tui_codex_model_catalog_preview_title() -> &'static str {
+    if is_chinese() {
+        "模型映射"
+    } else {
+        "Model Mapping"
     }
 }

--- a/src-tauri/src/cli/tui/app/form_handlers/mod.rs
+++ b/src-tauri/src/cli/tui/app/form_handlers/mod.rs
@@ -43,6 +43,14 @@ impl App {
 
     fn handle_form_exit_key(&mut self) -> Action {
         if let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() {
+            if matches!(provider.page, form::ProviderFormPage::CodexModelCatalog) {
+                provider.close_codex_model_catalog_page();
+                return Action::None;
+            }
+            if matches!(provider.page, form::ProviderFormPage::CodexLocalRouting) {
+                provider.close_codex_local_routing_page();
+                return Action::None;
+            }
             if matches!(provider.page, form::ProviderFormPage::UsageQuery) {
                 provider.close_usage_query_page();
                 return Action::None;

--- a/src-tauri/src/cli/tui/app/form_handlers/provider.rs
+++ b/src-tauri/src/cli/tui/app/form_handlers/provider.rs
@@ -52,6 +52,12 @@ impl App {
         if matches!(provider.page, form::ProviderFormPage::UsageQuery) {
             return self.handle_usage_query_page_key(key);
         }
+        if matches!(provider.page, form::ProviderFormPage::CodexModelCatalog) {
+            return self.handle_codex_model_catalog_page_key(key);
+        }
+        if matches!(provider.page, form::ProviderFormPage::CodexLocalRouting) {
+            return self.handle_codex_local_routing_page_key(key, data);
+        }
 
         match provider.focus {
             FormFocus::Fields => self.handle_provider_fields_key(key, data),
@@ -228,7 +234,9 @@ impl App {
                     return Action::None;
                 };
                 self.overlay = Overlay::ClaudeApiFormatPicker {
-                    selected: provider.claude_api_format.picker_index(),
+                    selected: provider
+                        .claude_api_format
+                        .picker_index_for_app(&provider.app_type),
                 };
                 Action::None
             }
@@ -385,6 +393,15 @@ impl App {
                 }
                 Action::None
             }
+            ProviderAddField::CodexLocalRouting => {
+                if matches!(key.code, KeyCode::Enter) {
+                    let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                        return Action::None;
+                    };
+                    provider.open_codex_local_routing_page();
+                }
+                Action::None
+            }
             ProviderAddField::CodexModel
             | ProviderAddField::GeminiModel
             | ProviderAddField::OpenCodeModelId => {
@@ -402,6 +419,229 @@ impl App {
                 }
                 Action::None
             }
+        }
+    }
+
+    fn handle_codex_local_routing_page_key(
+        &mut self,
+        key: KeyEvent,
+        data: &UiData,
+    ) -> Option<Action> {
+        let (fields, selected) = self.prepare_codex_local_routing_field_selection()?;
+
+        match key.code {
+            KeyCode::Esc => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return None;
+                };
+                provider.close_codex_local_routing_page();
+                Some(Action::None)
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return None;
+                };
+                provider.codex_local_routing_field_idx =
+                    provider.codex_local_routing_field_idx.saturating_sub(1);
+                Some(Action::None)
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return None;
+                };
+                provider.codex_local_routing_field_idx =
+                    (provider.codex_local_routing_field_idx + 1).min(fields.len() - 1);
+                Some(Action::None)
+            }
+            KeyCode::Char(' ') | KeyCode::Enter => {
+                Some(self.handle_codex_local_routing_field_activate(selected, data))
+            }
+            _ => None,
+        }
+    }
+
+    fn handle_codex_local_routing_field_activate(
+        &mut self,
+        selected: form::CodexLocalRoutingField,
+        data: &UiData,
+    ) -> Action {
+        match selected {
+            form::CodexLocalRoutingField::Enabled => {
+                let enabled = {
+                    let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                        return Action::None;
+                    };
+                    provider.toggle_codex_local_routing_enabled();
+                    provider.codex_local_routing_enabled()
+                };
+                if enabled
+                    && !data
+                        .proxy
+                        .routes_current_app_through_proxy(&AppType::Codex)
+                        .unwrap_or(false)
+                {
+                    self.overlay = Overlay::Confirm(ConfirmOverlay {
+                        title: texts::tui_claude_api_format_requires_proxy_title().to_string(),
+                        message: texts::tui_codex_api_format_requires_proxy_message("openai_chat"),
+                        action: ConfirmAction::ProviderApiFormatProxyNotice,
+                    });
+                }
+                Action::None
+            }
+            form::CodexLocalRoutingField::SupportsThinking => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return Action::None;
+                };
+                if provider.codex_local_routing_enabled() {
+                    provider.toggle_codex_reasoning_thinking();
+                }
+                Action::None
+            }
+            form::CodexLocalRoutingField::SupportsEffort => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return Action::None;
+                };
+                if provider.codex_local_routing_enabled() {
+                    provider.toggle_codex_reasoning_effort();
+                }
+                Action::None
+            }
+            form::CodexLocalRoutingField::ModelCatalog => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return Action::None;
+                };
+                if !provider.codex_local_routing_enabled() {
+                    return Action::None;
+                }
+                provider.open_codex_model_catalog_page();
+                Action::None
+            }
+        }
+    }
+
+    fn handle_codex_model_catalog_page_key(&mut self, key: KeyEvent) -> Option<Action> {
+        match key.code {
+            KeyCode::Esc => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return None;
+                };
+                provider.close_codex_model_catalog_page();
+                Some(Action::None)
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return None;
+                };
+                provider.codex_model_catalog_idx =
+                    provider.codex_model_catalog_idx.saturating_sub(1);
+                Some(Action::None)
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return None;
+                };
+                if !provider.codex_model_catalog.is_empty() {
+                    provider.codex_model_catalog_idx = (provider.codex_model_catalog_idx + 1)
+                        .min(provider.codex_model_catalog.len() - 1);
+                }
+                Some(Action::None)
+            }
+            KeyCode::Left => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return None;
+                };
+                provider.codex_model_catalog_field = form::CodexModelCatalogField::from_index(
+                    provider.codex_model_catalog_field.index().saturating_sub(1),
+                );
+                Some(Action::None)
+            }
+            KeyCode::Right => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return None;
+                };
+                provider.codex_model_catalog_field = form::CodexModelCatalogField::from_index(
+                    (provider.codex_model_catalog_field.index() + 1)
+                        .min(form::CodexModelCatalogField::ALL.len().saturating_sub(1)),
+                );
+                Some(Action::None)
+            }
+            KeyCode::Char('f') => Some(self.build_codex_model_catalog_fetch_action()),
+            KeyCode::Char('+') | KeyCode::Char('a') => {
+                self.open_codex_model_catalog_field_input(
+                    None,
+                    form::CodexModelCatalogField::Model,
+                    "",
+                );
+                Some(Action::None)
+            }
+            KeyCode::Enter => {
+                let (row, field, current) = match self.form.as_ref() {
+                    Some(FormState::ProviderAdd(provider))
+                        if !provider.codex_model_catalog.is_empty() =>
+                    {
+                        let row = provider.codex_model_catalog_idx;
+                        let field = provider.codex_model_catalog_field;
+                        let current = provider.selected_codex_model_catalog_field_value(field);
+                        (Some(row), field, current)
+                    }
+                    _ => (None, form::CodexModelCatalogField::Model, String::new()),
+                };
+                self.open_codex_model_catalog_field_input(row, field, &current);
+                Some(Action::None)
+            }
+            KeyCode::Delete | KeyCode::Backspace => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return None;
+                };
+                provider.remove_selected_codex_model_catalog_model();
+                Some(Action::None)
+            }
+            _ => None,
+        }
+    }
+
+    fn open_codex_model_catalog_field_input(
+        &mut self,
+        row: Option<usize>,
+        field: form::CodexModelCatalogField,
+        value: &str,
+    ) {
+        let prompt = match field {
+            form::CodexModelCatalogField::Model => texts::tui_codex_model_catalog_model_prompt(),
+            form::CodexModelCatalogField::DisplayName => {
+                texts::tui_codex_model_catalog_display_prompt()
+            }
+            form::CodexModelCatalogField::ContextWindow => {
+                texts::tui_codex_model_catalog_context_prompt()
+            }
+        };
+        self.overlay = Overlay::TextInput(TextInputState {
+            title: texts::tui_codex_model_catalog().to_string(),
+            prompt: prompt.to_string(),
+            input: TextInput::new(value),
+            submit: TextSubmit::CodexModelCatalogField { row, field },
+            secret: false,
+        });
+    }
+
+    fn build_codex_model_catalog_fetch_action(&mut self) -> Action {
+        let Some(FormState::ProviderAdd(provider)) = self.form.as_ref() else {
+            return Action::None;
+        };
+        let base_url = provider.codex_base_url.value.trim();
+        if base_url.is_empty() {
+            self.push_toast(texts::tui_model_fetch_need_endpoint(), ToastKind::Warning);
+            return Action::None;
+        }
+
+        Action::ProviderModelFetch {
+            base_url: provider.codex_base_url.value.clone(),
+            api_key: (!provider.codex_api_key.value.trim().is_empty())
+                .then(|| provider.codex_api_key.value.clone()),
+            codex_oauth: false,
+            codex_oauth_account_id: None,
+            field: ProviderAddField::CodexLocalRouting,
+            claude_idx: None,
         }
     }
 
@@ -889,6 +1129,34 @@ impl App {
 
         let selected = fields.get(provider.usage_query_field_idx).copied()?;
         Some((fields, selected, provider.usage_query_editing))
+    }
+
+    fn prepare_codex_local_routing_field_selection(
+        &mut self,
+    ) -> Option<(
+        Vec<form::CodexLocalRoutingField>,
+        form::CodexLocalRoutingField,
+    )> {
+        let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+            return None;
+        };
+        if !matches!(provider.page, form::ProviderFormPage::CodexLocalRouting) {
+            return None;
+        }
+        if !matches!(provider.focus, FormFocus::Fields) {
+            return None;
+        }
+
+        let fields = provider.codex_local_routing_fields();
+        if !fields.is_empty() {
+            provider.codex_local_routing_field_idx =
+                provider.codex_local_routing_field_idx.min(fields.len() - 1);
+        } else {
+            provider.codex_local_routing_field_idx = 0;
+        }
+
+        let selected = provider.selected_codex_local_routing_field()?;
+        Some((fields, selected))
     }
 
     fn finish_provider_input_change(

--- a/src-tauri/src/cli/tui/app/form_handlers/tab.rs
+++ b/src-tauri/src/cli/tui/app/form_handlers/tab.rs
@@ -15,6 +15,20 @@ impl App {
 
         match form {
             FormState::ProviderAdd(provider) => {
+                if matches!(provider.page, form::ProviderFormPage::CodexLocalRouting) {
+                    if is_backtab {
+                        return false;
+                    }
+                    provider.focus = FormFocus::Fields;
+                    return true;
+                }
+                if matches!(provider.page, form::ProviderFormPage::CodexModelCatalog) {
+                    if is_backtab {
+                        return false;
+                    }
+                    provider.focus = FormFocus::Fields;
+                    return true;
+                }
                 if matches!(provider.page, form::ProviderFormPage::UsageQuery) {
                     if is_backtab {
                         return false;

--- a/src-tauri/src/cli/tui/app/overlay_handlers/dialogs.rs
+++ b/src-tauri/src/cli/tui/app/overlay_handlers/dialogs.rs
@@ -329,9 +329,42 @@ impl App {
             TextSubmit::OpenClawToolsRule { section, row } => {
                 self.handle_openclaw_tools_rule_submit(section, row, raw, data)
             }
+            TextSubmit::CodexModelCatalogField { row, field } => {
+                self.handle_codex_model_catalog_field_submit(row, field, raw)
+            }
             TextSubmit::WebDavJianguoyunUsername => self.handle_webdav_username_submit(raw),
             TextSubmit::WebDavJianguoyunPassword => self.handle_webdav_password_submit(raw),
         }
+    }
+
+    fn handle_codex_model_catalog_field_submit(
+        &mut self,
+        row: Option<usize>,
+        field: form::CodexModelCatalogField,
+        raw: String,
+    ) -> Action {
+        let trimmed = raw.trim().to_string();
+        if matches!(field, form::CodexModelCatalogField::Model) && trimmed.is_empty() {
+            self.push_toast(
+                texts::tui_toast_provider_add_missing_fields(),
+                ToastKind::Warning,
+            );
+            self.overlay = Overlay::TextInput(TextInputState {
+                title: texts::tui_codex_model_catalog().to_string(),
+                prompt: codex_model_catalog_field_prompt(field).to_string(),
+                input: TextInput::new(trimmed),
+                submit: TextSubmit::CodexModelCatalogField { row, field },
+                secret: false,
+            });
+            return Action::None;
+        }
+
+        let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+            return Action::None;
+        };
+        provider.codex_model_catalog_field = field;
+        provider.set_codex_model_catalog_field(row, field, &trimmed);
+        Action::None
     }
 
     fn handle_openclaw_agents_runtime_submit(
@@ -487,5 +520,17 @@ impl App {
         }
 
         Action::SetProxyListenPort { port }
+    }
+}
+
+fn codex_model_catalog_field_prompt(field: form::CodexModelCatalogField) -> &'static str {
+    match field {
+        form::CodexModelCatalogField::Model => texts::tui_codex_model_catalog_model_prompt(),
+        form::CodexModelCatalogField::DisplayName => {
+            texts::tui_codex_model_catalog_display_prompt()
+        }
+        form::CodexModelCatalogField::ContextWindow => {
+            texts::tui_codex_model_catalog_context_prompt()
+        }
     }
 }

--- a/src-tauri/src/cli/tui/app/overlay_handlers/pickers.rs
+++ b/src-tauri/src/cli/tui/app/overlay_handlers/pickers.rs
@@ -199,6 +199,14 @@ impl App {
         key: KeyEvent,
         data: &UiData,
     ) -> Option<Action> {
+        let app_type = self
+            .form
+            .as_ref()
+            .and_then(|form| match form {
+                FormState::ProviderAdd(provider) => Some(provider.app_type.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| self.app_type.clone());
         let Overlay::ClaudeApiFormatPicker { selected } = &mut self.overlay else {
             return None;
         };
@@ -214,15 +222,16 @@ impl App {
             }
             KeyCode::Down => {
                 *selected = (*selected + 1).min(
-                    crate::cli::tui::form::ClaudeApiFormat::ALL
+                    crate::cli::tui::form::ClaudeApiFormat::choices_for_app(&app_type)
                         .len()
                         .saturating_sub(1),
                 );
                 Action::None
             }
             KeyCode::Enter => {
-                let next_format =
-                    crate::cli::tui::form::ClaudeApiFormat::from_picker_index(*selected);
+                let next_format = crate::cli::tui::form::ClaudeApiFormat::from_picker_index_for_app(
+                    *selected, &app_type,
+                );
                 let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
                     self.overlay = Overlay::None;
                     return Some(Action::None);
@@ -236,12 +245,17 @@ impl App {
                     .proxy
                     .routes_current_app_through_proxy(&provider.app_type)
                     .unwrap_or(false);
-                if changed && next_format.requires_proxy() && !proxy_ready {
+                if changed && next_format.requires_proxy_for_app(&provider.app_type) && !proxy_ready
+                {
+                    let message = if matches!(provider.app_type, crate::app_config::AppType::Codex)
+                    {
+                        texts::tui_codex_api_format_requires_proxy_message(next_format.as_str())
+                    } else {
+                        texts::tui_claude_api_format_requires_proxy_message(next_format.as_str())
+                    };
                     self.overlay = Overlay::Confirm(ConfirmOverlay {
                         title: texts::tui_claude_api_format_requires_proxy_title().to_string(),
-                        message: texts::tui_claude_api_format_requires_proxy_message(
-                            next_format.as_str(),
-                        ),
+                        message,
                         action: ConfirmAction::ProviderApiFormatProxyNotice,
                     });
                 }
@@ -699,6 +713,8 @@ impl App {
                         }
                     } else if field == ProviderAddField::HermesModels {
                         provider.set_selected_hermes_model_id_from_picker(&selected_model);
+                    } else if field == ProviderAddField::CodexLocalRouting {
+                        provider.upsert_codex_model_catalog_model(&selected_model);
                     } else if let Some(input_field) = provider.input_mut(field) {
                         input_field.set(selected_model);
                     }

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -12,7 +12,9 @@ mod tests {
 
     use crate::cli::i18n::{texts, use_test_language, Language};
     use crate::cli::tui::data::ProviderRow;
-    use crate::cli::tui::form::{McpEnvVarRow, McpTransport, ProviderAddFormState, TextInput};
+    use crate::cli::tui::form::{
+        CodexModelCatalogField, McpEnvVarRow, McpTransport, ProviderAddFormState, TextInput,
+    };
     use crate::cli::tui::runtime_actions::{
         handle_action, run_external_editor_for_prompt_form_content,
     };
@@ -11963,6 +11965,257 @@ mod tests {
             app.overlay,
             Overlay::ClaudeApiFormatPicker { selected: 0 }
         ));
+    }
+
+    #[test]
+    fn provider_codex_local_routing_field_enter_opens_page() {
+        let mut app = App::new(Some(AppType::Codex));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+
+        let data = UiData::default();
+        app.on_key(key(KeyCode::Char('a')), &data);
+        app.on_key(key(KeyCode::Enter), &data);
+
+        if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
+            form.focus = super::super::form::FormFocus::Fields;
+            form.editing = false;
+            form.field_idx = form
+                .fields()
+                .iter()
+                .position(|field| *field == ProviderAddField::CodexLocalRouting)
+                .expect("Codex local routing field should exist");
+        } else {
+            panic!("expected ProviderAdd form");
+        }
+
+        let action = app.on_key(key(KeyCode::Enter), &data);
+        assert!(matches!(action, Action::None));
+
+        let page = match app.form.as_ref() {
+            Some(super::super::form::FormState::ProviderAdd(form)) => form.page,
+            other => panic!("expected ProviderAdd form, got: {other:?}"),
+        };
+        assert_eq!(
+            page,
+            super::super::form::ProviderFormPage::CodexLocalRouting
+        );
+        assert!(matches!(app.overlay, Overlay::None));
+    }
+
+    #[test]
+    fn provider_codex_local_routing_toggle_warns_when_proxy_not_enabled() {
+        let mut app = App::new(Some(AppType::Codex));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+
+        let data = UiData::default();
+        app.on_key(key(KeyCode::Char('a')), &data);
+        app.on_key(key(KeyCode::Enter), &data);
+
+        if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
+            form.focus = super::super::form::FormFocus::Fields;
+            form.editing = false;
+            form.codex_base_url.set("https://api.example.com/v1");
+            form.field_idx = form
+                .fields()
+                .iter()
+                .position(|field| *field == ProviderAddField::CodexLocalRouting)
+                .expect("Codex local routing field should exist");
+        } else {
+            panic!("expected ProviderAdd form");
+        }
+
+        app.on_key(key(KeyCode::Enter), &data);
+        let action = app.on_key(key(KeyCode::Enter), &data);
+
+        assert!(matches!(action, Action::None));
+        assert!(matches!(
+            app.overlay,
+            Overlay::Confirm(ConfirmOverlay {
+                action: ConfirmAction::ProviderApiFormatProxyNotice,
+                ..
+            })
+        ));
+        let format = match app.form.as_ref() {
+            Some(super::super::form::FormState::ProviderAdd(form)) => form.claude_api_format,
+            other => panic!("expected ProviderAdd form, got: {other:?}"),
+        };
+        assert_eq!(format, super::super::form::ClaudeApiFormat::OpenAiChat);
+    }
+
+    #[test]
+    fn provider_codex_local_routing_toggle_does_not_warn_when_proxy_routes_current_app() {
+        let mut app = App::new(Some(AppType::Codex));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+
+        let mut data = UiData::default();
+        data.proxy.running = true;
+        data.proxy.codex_takeover = true;
+
+        app.on_key(key(KeyCode::Char('a')), &data);
+        app.on_key(key(KeyCode::Enter), &data);
+
+        if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
+            form.focus = super::super::form::FormFocus::Fields;
+            form.editing = false;
+            form.codex_base_url.set("https://api.example.com/v1");
+            form.field_idx = form
+                .fields()
+                .iter()
+                .position(|field| *field == ProviderAddField::CodexLocalRouting)
+                .expect("Codex local routing field should exist");
+        } else {
+            panic!("expected ProviderAdd form");
+        }
+
+        app.on_key(key(KeyCode::Enter), &data);
+        let action = app.on_key(key(KeyCode::Enter), &data);
+
+        assert!(matches!(action, Action::None));
+        assert!(matches!(app.overlay, Overlay::None));
+        let format = match app.form.as_ref() {
+            Some(super::super::form::FormState::ProviderAdd(form)) => form.claude_api_format,
+            other => panic!("expected ProviderAdd form, got: {other:?}"),
+        };
+        assert_eq!(format, super::super::form::ClaudeApiFormat::OpenAiChat);
+    }
+
+    #[test]
+    fn provider_codex_local_routing_model_catalog_opens_list_page_and_adds_models() {
+        let mut app = App::new(Some(AppType::Codex));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+
+        let mut data = UiData::default();
+        data.proxy.running = true;
+        data.proxy.codex_takeover = true;
+
+        app.on_key(key(KeyCode::Char('a')), &data);
+        app.on_key(key(KeyCode::Enter), &data);
+
+        if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
+            form.focus = super::super::form::FormFocus::Fields;
+            form.editing = false;
+            form.codex_base_url.set("https://api.example.com/v1");
+            form.field_idx = form
+                .fields()
+                .iter()
+                .position(|field| *field == ProviderAddField::CodexLocalRouting)
+                .expect("Codex local routing field should exist");
+        } else {
+            panic!("expected ProviderAdd form");
+        }
+
+        app.on_key(key(KeyCode::Enter), &data); // open local routing page
+        app.on_key(key(KeyCode::Enter), &data); // enable local routing
+        app.on_key(key(KeyCode::Down), &data);
+        app.on_key(key(KeyCode::Down), &data);
+        app.on_key(key(KeyCode::Down), &data);
+
+        let action = app.on_key(key(KeyCode::Enter), &data);
+        assert!(matches!(action, Action::None));
+        assert!(app.editor.is_none());
+        assert!(matches!(
+            app.form,
+            Some(super::super::form::FormState::ProviderAdd(ref form))
+                if matches!(form.page, super::super::form::ProviderFormPage::CodexModelCatalog)
+        ));
+
+        app.on_key(key(KeyCode::Char('+')), &data);
+        assert!(matches!(
+            app.overlay,
+            Overlay::TextInput(TextInputState {
+                submit: TextSubmit::CodexModelCatalogField {
+                    row: None,
+                    field: CodexModelCatalogField::Model,
+                },
+                ..
+            })
+        ));
+        for ch in "deepseek-chat".chars() {
+            app.on_key(key(KeyCode::Char(ch)), &data);
+        }
+        app.on_key(key(KeyCode::Enter), &data);
+
+        let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_ref() else {
+            panic!("expected ProviderAdd form");
+        };
+        assert_eq!(form.codex_model_catalog.len(), 1);
+        assert_eq!(form.codex_model_catalog[0].model, "deepseek-chat");
+
+        app.on_key(key(KeyCode::Right), &data);
+        app.on_key(key(KeyCode::Enter), &data);
+        assert!(matches!(
+            app.overlay,
+            Overlay::TextInput(TextInputState {
+                submit: TextSubmit::CodexModelCatalogField {
+                    row: Some(0),
+                    field: CodexModelCatalogField::DisplayName,
+                },
+                ..
+            })
+        ));
+        for ch in "DeepSeek Chat".chars() {
+            app.on_key(key(KeyCode::Char(ch)), &data);
+        }
+        app.on_key(key(KeyCode::Enter), &data);
+
+        app.on_key(key(KeyCode::Right), &data);
+        app.on_key(key(KeyCode::Enter), &data);
+        assert!(matches!(
+            app.overlay,
+            Overlay::TextInput(TextInputState {
+                submit: TextSubmit::CodexModelCatalogField {
+                    row: Some(0),
+                    field: CodexModelCatalogField::ContextWindow,
+                },
+                ..
+            })
+        ));
+        for ch in "256k".chars() {
+            app.on_key(key(KeyCode::Char(ch)), &data);
+        }
+        app.on_key(key(KeyCode::Enter), &data);
+
+        let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_ref() else {
+            panic!("expected ProviderAdd form");
+        };
+        assert_eq!(form.codex_model_catalog[0].display_name, "DeepSeek Chat");
+        assert_eq!(form.codex_model_catalog[0].context_window, "256k");
+        assert_eq!(
+            form.codex_model_catalog_field,
+            CodexModelCatalogField::ContextWindow
+        );
+
+        let action = app.on_key(key(KeyCode::Char('f')), &data);
+        assert!(matches!(
+            action,
+            Action::ProviderModelFetch {
+                field: ProviderAddField::CodexLocalRouting,
+                ..
+            }
+        ));
+
+        app.overlay = Overlay::ModelFetchPicker {
+            request_id: 1,
+            field: ProviderAddField::CodexLocalRouting,
+            claude_idx: None,
+            input: TextInput::new("kimi-k2"),
+            query: "kimi-k2".to_string(),
+            fetching: false,
+            models: vec!["kimi-k2".to_string()],
+            error: None,
+            selected_idx: 0,
+        };
+        app.on_key(key(KeyCode::Enter), &data);
+
+        let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_ref() else {
+            panic!("expected ProviderAdd form");
+        };
+        assert_eq!(form.codex_model_catalog.len(), 2);
+        assert_eq!(form.codex_model_catalog[1].model, "kimi-k2");
     }
 
     #[test]

--- a/src-tauri/src/cli/tui/app/types.rs
+++ b/src-tauri/src/cli/tui/app/types.rs
@@ -388,6 +388,10 @@ pub enum TextSubmit {
     OpenClawAgentsRuntimeField {
         field: OpenClawAgentsRuntimeField,
     },
+    CodexModelCatalogField {
+        row: Option<usize>,
+        field: form::CodexModelCatalogField,
+    },
     WebDavJianguoyunUsername,
     WebDavJianguoyunPassword,
 }

--- a/src-tauri/src/cli/tui/form.rs
+++ b/src-tauri/src/cli/tui/form.rs
@@ -1,5 +1,5 @@
 use crate::app_config::{AppType, McpApps};
-use crate::provider::ClaudeApiKeyField;
+use crate::provider::{ClaudeApiKeyField, CodexChatReasoningConfig};
 use serde_json::Value;
 
 use super::app::EditorState;
@@ -78,6 +78,10 @@ impl ClaudeApiFormat {
         ClaudeApiFormat::OpenAiResponses,
         ClaudeApiFormat::GeminiNative,
     ];
+    pub const CODEX: [Self; 2] = [
+        ClaudeApiFormat::OpenAiResponses,
+        ClaudeApiFormat::OpenAiChat,
+    ];
 
     pub fn as_str(self) -> &'static str {
         match self {
@@ -97,20 +101,38 @@ impl ClaudeApiFormat {
         }
     }
 
-    pub fn picker_index(self) -> usize {
-        match self {
-            ClaudeApiFormat::Anthropic => 0,
-            ClaudeApiFormat::OpenAiChat => 1,
-            ClaudeApiFormat::OpenAiResponses => 2,
-            ClaudeApiFormat::GeminiNative => 3,
+    pub fn choices_for_app(app_type: &AppType) -> &'static [Self] {
+        match app_type {
+            AppType::Codex => &Self::CODEX,
+            _ => &Self::ALL,
         }
     }
 
-    pub fn from_picker_index(index: usize) -> Self {
-        Self::ALL
+    pub fn picker_index_for_app(self, app_type: &AppType) -> usize {
+        Self::choices_for_app(app_type)
+            .iter()
+            .position(|candidate| *candidate == self)
+            .unwrap_or(0)
+    }
+
+    pub fn from_picker_index_for_app(index: usize, app_type: &AppType) -> Self {
+        Self::choices_for_app(app_type)
             .get(index)
             .copied()
-            .unwrap_or(ClaudeApiFormat::Anthropic)
+            .unwrap_or_else(|| {
+                if matches!(app_type, AppType::Codex) {
+                    ClaudeApiFormat::OpenAiResponses
+                } else {
+                    ClaudeApiFormat::Anthropic
+                }
+            })
+    }
+
+    pub fn requires_proxy_for_app(self, app_type: &AppType) -> bool {
+        match app_type {
+            AppType::Codex => matches!(self, ClaudeApiFormat::OpenAiChat),
+            _ => self.requires_proxy(),
+        }
     }
 
     pub fn requires_proxy(self) -> bool {
@@ -169,6 +191,7 @@ pub enum ProviderAddField {
     CodexFastMode,
     CodexBaseUrl,
     CodexModel,
+    CodexLocalRouting,
     #[allow(dead_code)]
     CodexWireApi,
     #[allow(dead_code)]
@@ -206,6 +229,8 @@ pub enum ProviderAddField {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderFormPage {
     Main,
+    CodexLocalRouting,
+    CodexModelCatalog,
     UsageQuery,
 }
 
@@ -238,6 +263,113 @@ pub enum UsageQueryField {
     AutoInterval,
     CodingPlanProvider,
     Script,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexLocalRoutingField {
+    Enabled,
+    SupportsThinking,
+    SupportsEffort,
+    ModelCatalog,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexModelCatalogField {
+    Model,
+    DisplayName,
+    ContextWindow,
+}
+
+impl CodexModelCatalogField {
+    pub const ALL: [Self; 3] = [Self::Model, Self::DisplayName, Self::ContextWindow];
+
+    pub fn index(self) -> usize {
+        match self {
+            Self::Model => 0,
+            Self::DisplayName => 1,
+            Self::ContextWindow => 2,
+        }
+    }
+
+    pub fn from_index(index: usize) -> Self {
+        Self::ALL.get(index).copied().unwrap_or(Self::ContextWindow)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexModelCatalogRow {
+    pub model: String,
+    pub display_name: String,
+    pub context_window: String,
+}
+
+impl CodexModelCatalogRow {
+    pub(crate) fn summary_label(&self) -> String {
+        let model = self.model.trim();
+        let display_name = self.display_name.trim();
+        let mut label = if display_name.is_empty() || display_name == model {
+            model.to_string()
+        } else {
+            format!("{display_name} ({model})")
+        };
+
+        let context_window = codex_model_catalog_context_window_label(&self.context_window);
+        if !context_window.is_empty() {
+            label.push_str(&format!(" [{context_window}]"));
+        }
+        label
+    }
+}
+
+pub(crate) fn parse_codex_model_catalog_context_window(raw: &str) -> Option<u64> {
+    let compact = raw
+        .trim()
+        .chars()
+        .filter(|ch| !ch.is_whitespace() && *ch != ',' && *ch != '_')
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if compact.is_empty() {
+        return None;
+    }
+
+    let number_len = compact
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit() || *ch == '.')
+        .map(char::len_utf8)
+        .sum::<usize>();
+    if number_len == 0 {
+        return None;
+    }
+
+    let (number, suffix) = compact.split_at(number_len);
+    let value = number.parse::<f64>().ok()?;
+    if !value.is_finite() || value <= 0.0 {
+        return None;
+    }
+
+    let multiplier = if suffix.starts_with('k') {
+        1_000.0
+    } else if suffix.starts_with('m') {
+        1_000_000.0
+    } else {
+        1.0
+    };
+    let normalized = (value * multiplier).round();
+    (normalized > 0.0 && normalized <= u64::MAX as f64).then_some(normalized as u64)
+}
+
+pub(crate) fn codex_model_catalog_context_window_label(raw: &str) -> String {
+    if let Some(value) = parse_codex_model_catalog_context_window(raw) {
+        if value >= 1_000_000 && value % 1_000_000 == 0 {
+            format!("{}m", value / 1_000_000)
+        } else if value >= 1_000 && value % 1_000 == 0 {
+            format!("{}k", value / 1_000)
+        } else {
+            value.to_string()
+        }
+    } else {
+        raw.trim().to_string()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -289,6 +421,9 @@ pub struct ProviderAddFormState {
     pub usage_query_touched: bool,
     pub usage_query_field_idx: usize,
     pub usage_query_editing: bool,
+    pub codex_local_routing_field_idx: usize,
+    pub codex_model_catalog_idx: usize,
+    pub codex_model_catalog_field: CodexModelCatalogField,
     pub extra: Value,
     pub id: TextInput,
     pub id_is_manual: bool,
@@ -323,6 +458,8 @@ pub struct ProviderAddFormState {
     pub codex_requires_openai_auth: bool,
     pub codex_env_key: TextInput,
     pub codex_api_key: TextInput,
+    pub codex_chat_reasoning: CodexChatReasoningConfig,
+    pub codex_model_catalog: Vec<CodexModelCatalogRow>,
 
     pub gemini_auth_type: GeminiAuthType,
     pub gemini_api_key: TextInput,

--- a/src-tauri/src/cli/tui/form/provider_json.rs
+++ b/src-tauri/src/cli/tui/form/provider_json.rs
@@ -1,14 +1,16 @@
 use crate::app_config::AppType;
-use crate::provider::ClaudeApiKeyField;
+use crate::provider::{ClaudeApiKeyField, CodexChatReasoningConfig};
 use crate::services::ProviderService;
 use serde_json::{json, Value};
+use std::collections::HashSet;
 
 use super::codex_config::{
     build_codex_provider_config_toml, clean_codex_provider_key, update_codex_config_snippet,
 };
 use super::{
-    ClaudeApiFormat, GeminiAuthType, ProviderAddFormState, UsageQueryTemplate,
-    OPENCLAW_DEFAULT_API_PROTOCOL, OPENCLAW_DEFAULT_USER_AGENT,
+    parse_codex_model_catalog_context_window, ClaudeApiFormat, GeminiAuthType,
+    ProviderAddFormState, UsageQueryTemplate, OPENCLAW_DEFAULT_API_PROTOCOL,
+    OPENCLAW_DEFAULT_USER_AGENT,
 };
 
 impl ProviderAddFormState {
@@ -128,11 +130,15 @@ impl ProviderAddFormState {
                     if !auth_value.is_object() {
                         *auth_value = json!({});
                     }
+                    settings_obj.remove("modelCatalog");
                 } else {
                     let provider_key =
                         clean_codex_provider_key(self.id.value.trim(), self.name.value.trim());
                     let base_url = self.codex_base_url.value.trim().trim_end_matches('/');
-                    let model = if self.codex_model.is_blank() {
+                    let model_catalog = self.normalized_codex_model_catalog_for_save();
+                    let model = if self.codex_local_routing_enabled() && !model_catalog.is_empty() {
+                        model_catalog[0]["model"].as_str().unwrap_or("gpt-5.4")
+                    } else if self.codex_model.is_blank() {
                         "gpt-5.4"
                     } else {
                         self.codex_model.value.trim()
@@ -161,6 +167,14 @@ impl ProviderAddFormState {
                         self.codex_env_key.value.trim(),
                     );
                     settings_obj.insert("config".to_string(), Value::String(config_toml));
+                    if self.codex_local_routing_enabled() && !model_catalog.is_empty() {
+                        settings_obj.insert(
+                            "modelCatalog".to_string(),
+                            json!({ "models": model_catalog }),
+                        );
+                    } else {
+                        settings_obj.remove("modelCatalog");
+                    }
 
                     let api_key = self.codex_api_key.value.trim();
                     if api_key.is_empty() {
@@ -497,6 +511,8 @@ impl ProviderAddFormState {
                 | ClaudeApiFormat::GeminiNative
         ) && matches!(self.app_type, AppType::Claude)
             && !self.is_claude_official_provider();
+        let should_write_codex_api_format =
+            matches!(self.app_type, AppType::Codex) && !self.is_codex_official_provider();
         let should_write_claude_api_key_field = matches!(self.app_type, AppType::Claude)
             && !self.is_claude_official_provider()
             && !self.is_claude_codex_oauth_provider()
@@ -505,6 +521,7 @@ impl ProviderAddFormState {
 
         if !should_write_common_config_meta
             && !should_write_claude_api_format
+            && !should_write_codex_api_format
             && !should_write_claude_api_key_field
             && !is_codex_oauth
             && !self.has_usage_script_meta()
@@ -563,6 +580,30 @@ impl ProviderAddFormState {
                 );
             } else {
                 meta_obj.remove("apiKeyField");
+            }
+        }
+
+        if matches!(self.app_type, AppType::Codex) {
+            if self.is_codex_official_provider() {
+                meta_obj.remove("apiFormat");
+                meta_obj.remove("codexChatReasoning");
+            } else {
+                let api_format = match self.claude_api_format {
+                    ClaudeApiFormat::OpenAiChat => "openai_chat",
+                    _ => "openai_responses",
+                };
+                meta_obj.insert("apiFormat".to_string(), json!(api_format));
+                if self.codex_local_routing_enabled() {
+                    if let Some(reasoning) =
+                        normalize_codex_chat_reasoning_for_save(&self.codex_chat_reasoning)
+                    {
+                        meta_obj.insert("codexChatReasoning".to_string(), reasoning);
+                    } else {
+                        meta_obj.remove("codexChatReasoning");
+                    }
+                } else {
+                    meta_obj.remove("codexChatReasoning");
+                }
             }
         }
 
@@ -691,6 +732,89 @@ impl ProviderAddFormState {
             .and_then(Value::as_object)
             .is_some_and(|meta| meta.contains_key("usage_script"))
     }
+
+    fn normalized_codex_model_catalog_for_save(&self) -> Vec<Value> {
+        let mut seen = HashSet::new();
+        let mut models = Vec::new();
+
+        for row in &self.codex_model_catalog {
+            let model = row.model.trim();
+            if model.is_empty() || !seen.insert(model.to_string()) {
+                continue;
+            }
+
+            let mut obj = serde_json::Map::new();
+            obj.insert("model".to_string(), json!(model));
+
+            let display_name = row.display_name.trim();
+            if !display_name.is_empty() {
+                obj.insert("displayName".to_string(), json!(display_name));
+            }
+
+            if let Some(context_window) =
+                parse_codex_model_catalog_context_window(row.context_window.trim())
+            {
+                if context_window > 0 {
+                    obj.insert("contextWindow".to_string(), json!(context_window));
+                }
+            }
+
+            models.push(Value::Object(obj));
+        }
+
+        models
+    }
+}
+
+fn normalize_codex_chat_reasoning_for_save(value: &CodexChatReasoningConfig) -> Option<Value> {
+    let raw = serde_json::to_value(value).ok()?;
+    let has_explicit_config = raw.as_object().is_some_and(|obj| !obj.is_empty());
+    let supports_effort = value.supports_effort == Some(true);
+    let supports_thinking = value.supports_thinking == Some(true) || supports_effort;
+
+    if !supports_thinking && !supports_effort {
+        return has_explicit_config.then(|| {
+            json!({
+                "supportsThinking": false,
+                "supportsEffort": false,
+                "thinkingParam": "none",
+                "effortParam": "none",
+                "outputFormat": value.output_format.as_deref().unwrap_or("auto"),
+            })
+        });
+    }
+
+    let mut obj = serde_json::Map::new();
+    obj.insert("supportsThinking".to_string(), json!(supports_thinking));
+    obj.insert("supportsEffort".to_string(), json!(supports_effort));
+    obj.insert(
+        "thinkingParam".to_string(),
+        json!(if supports_thinking {
+            value.thinking_param.as_deref().unwrap_or("thinking")
+        } else {
+            "none"
+        }),
+    );
+    obj.insert(
+        "effortParam".to_string(),
+        json!(if supports_effort {
+            value.effort_param.as_deref().unwrap_or("reasoning_effort")
+        } else {
+            "none"
+        }),
+    );
+    if supports_effort {
+        obj.insert(
+            "effortValueMode".to_string(),
+            json!(value.effort_value_mode.as_deref().unwrap_or("passthrough")),
+        );
+    }
+    obj.insert(
+        "outputFormat".to_string(),
+        json!(value.output_format.as_deref().unwrap_or("auto")),
+    );
+
+    Some(Value::Object(obj))
 }
 
 pub(crate) fn normalize_usage_timeout(raw: &str) -> u64 {

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -1,6 +1,6 @@
 use crate::app_config::AppType;
 use crate::cli::i18n::texts;
-use crate::provider::{ClaudeApiKeyField, Provider};
+use crate::provider::{ClaudeApiKeyField, CodexChatReasoningConfig, Provider};
 use crate::services::ProviderService;
 use serde_json::{json, Value};
 
@@ -9,10 +9,10 @@ use super::provider_json::{
 };
 use super::provider_state_loading::populate_form_from_provider;
 use super::{
-    ClaudeApiFormat, CodexPreviewSection, CodexWireApi, FormFocus, FormMode, GeminiAuthType,
-    HermesModelField, ProviderAddField, ProviderAddFormState, ProviderFormPage, TextInput,
-    UsageQueryField, UsageQueryTemplate, HERMES_API_MODES, HERMES_DEFAULT_API_MODE,
-    OPENCLAW_DEFAULT_API_PROTOCOL,
+    ClaudeApiFormat, CodexLocalRoutingField, CodexModelCatalogField, CodexModelCatalogRow,
+    CodexPreviewSection, CodexWireApi, FormFocus, FormMode, GeminiAuthType, HermesModelField,
+    ProviderAddField, ProviderAddFormState, ProviderFormPage, TextInput, UsageQueryField,
+    UsageQueryTemplate, HERMES_API_MODES, HERMES_DEFAULT_API_MODE, OPENCLAW_DEFAULT_API_PROTOCOL,
 };
 
 fn provider_copy_id(original_id: &str, existing_ids: &[String]) -> String {
@@ -99,14 +99,16 @@ impl ProviderAddFormState {
     pub fn new_with_common_snippet(app_type: AppType, common_snippet: &str) -> Self {
         let include_common_config =
             Self::snippet_has_effective_common_config(&app_type, common_snippet);
+        let is_codex = matches!(app_type, AppType::Codex);
         let openclaw_api_default = match app_type {
             AppType::OpenClaw => OPENCLAW_DEFAULT_API_PROTOCOL,
             _ => "@ai-sdk/openai-compatible",
         };
 
-        let codex_defaults = match app_type {
-            AppType::Codex => ("", "gpt-5.4", CodexWireApi::Responses, true),
-            _ => ("", "", CodexWireApi::Responses, true),
+        let codex_defaults = if is_codex {
+            ("", "gpt-5.4", CodexWireApi::Responses, true)
+        } else {
+            ("", "", CodexWireApi::Responses, true)
         };
 
         let mut form = Self {
@@ -121,6 +123,9 @@ impl ProviderAddFormState {
             usage_query_touched: false,
             usage_query_field_idx: 0,
             usage_query_editing: false,
+            codex_local_routing_field_idx: 0,
+            codex_model_catalog_idx: 0,
+            codex_model_catalog_field: CodexModelCatalogField::Model,
             extra: json!({}),
             id: TextInput::new(""),
             id_is_manual: false,
@@ -137,7 +142,11 @@ impl ProviderAddFormState {
             claude_api_key: TextInput::new(""),
             claude_api_key_field: ClaudeApiKeyField::AuthToken,
             claude_base_url: TextInput::new(""),
-            claude_api_format: ClaudeApiFormat::Anthropic,
+            claude_api_format: if is_codex {
+                ClaudeApiFormat::OpenAiResponses
+            } else {
+                ClaudeApiFormat::Anthropic
+            },
             claude_model: TextInput::new(""),
             claude_reasoning_model: TextInput::new(""),
             claude_haiku_model: TextInput::new(""),
@@ -153,6 +162,8 @@ impl ProviderAddFormState {
             codex_requires_openai_auth: codex_defaults.3,
             codex_env_key: TextInput::new("OPENAI_API_KEY"),
             codex_api_key: TextInput::new(""),
+            codex_chat_reasoning: CodexChatReasoningConfig::default(),
+            codex_model_catalog: Vec::new(),
             gemini_auth_type: GeminiAuthType::ApiKey,
             gemini_api_key: TextInput::new(""),
             gemini_base_url: TextInput::new("https://generativelanguage.googleapis.com"),
@@ -360,6 +371,7 @@ impl ProviderAddFormState {
                 if !self.is_codex_official_provider() {
                     fields.push(ProviderAddField::CodexBaseUrl);
                     fields.push(ProviderAddField::CodexModel);
+                    fields.push(ProviderAddField::CodexLocalRouting);
                     fields.push(ProviderAddField::CodexApiKey);
                 }
             }
@@ -499,6 +511,7 @@ impl ProviderAddFormState {
             ProviderAddField::HermesRateLimitDelay => Some(&self.hermes_rate_limit_delay),
             ProviderAddField::CodexOAuthAccount
             | ProviderAddField::CodexFastMode
+            | ProviderAddField::CodexLocalRouting
             | ProviderAddField::CodexWireApi
             | ProviderAddField::CodexRequiresOpenaiAuth
             | ProviderAddField::ClaudeApiFormat
@@ -550,6 +563,7 @@ impl ProviderAddFormState {
             ProviderAddField::HermesRateLimitDelay => Some(&mut self.hermes_rate_limit_delay),
             ProviderAddField::CodexOAuthAccount
             | ProviderAddField::CodexFastMode
+            | ProviderAddField::CodexLocalRouting
             | ProviderAddField::CodexWireApi
             | ProviderAddField::CodexRequiresOpenaiAuth
             | ProviderAddField::ClaudeApiFormat
@@ -604,6 +618,239 @@ impl ProviderAddFormState {
         self.usage_query_editing = false;
         let len = self.usage_query_table_fields().len();
         self.usage_query_field_idx = self.usage_query_field_idx.min(len.saturating_sub(1));
+    }
+
+    pub fn open_codex_local_routing_page(&mut self) {
+        if !matches!(self.app_type, AppType::Codex) || self.is_codex_official_provider() {
+            return;
+        }
+        self.page = ProviderFormPage::CodexLocalRouting;
+        self.focus = FormFocus::Fields;
+        self.editing = false;
+        self.usage_query_editing = false;
+        let len = self.codex_local_routing_fields().len();
+        self.codex_local_routing_field_idx = self
+            .codex_local_routing_field_idx
+            .min(len.saturating_sub(1));
+    }
+
+    pub fn close_codex_local_routing_page(&mut self) {
+        self.page = ProviderFormPage::Main;
+        self.focus = FormFocus::Fields;
+        self.editing = false;
+    }
+
+    pub fn open_codex_model_catalog_page(&mut self) {
+        if !self.codex_local_routing_enabled() {
+            return;
+        }
+        self.page = ProviderFormPage::CodexModelCatalog;
+        self.focus = FormFocus::Fields;
+        self.editing = false;
+        self.usage_query_editing = false;
+        self.codex_model_catalog_idx = self
+            .codex_model_catalog_idx
+            .min(self.codex_model_catalog.len().saturating_sub(1));
+    }
+
+    pub fn close_codex_model_catalog_page(&mut self) {
+        self.page = ProviderFormPage::CodexLocalRouting;
+        self.focus = FormFocus::Fields;
+        self.editing = false;
+        self.codex_model_catalog_idx = self
+            .codex_model_catalog_idx
+            .min(self.codex_model_catalog.len().saturating_sub(1));
+    }
+
+    pub fn selected_codex_model_catalog_row(&self) -> Option<&CodexModelCatalogRow> {
+        self.codex_model_catalog.get(
+            self.codex_model_catalog_idx
+                .min(self.codex_model_catalog.len().saturating_sub(1)),
+        )
+    }
+
+    pub fn selected_codex_model_catalog_field_value(
+        &self,
+        field: CodexModelCatalogField,
+    ) -> String {
+        let Some(row) = self.selected_codex_model_catalog_row() else {
+            return String::new();
+        };
+        match field {
+            CodexModelCatalogField::Model => row.model.clone(),
+            CodexModelCatalogField::DisplayName => row.display_name.clone(),
+            CodexModelCatalogField::ContextWindow => row.context_window.clone(),
+        }
+    }
+
+    pub fn upsert_codex_model_catalog_model(&mut self, model: &str) -> bool {
+        let model = model.trim();
+        if model.is_empty() {
+            return false;
+        }
+
+        if let Some(index) = self
+            .codex_model_catalog
+            .iter()
+            .position(|row| row.model.eq_ignore_ascii_case(model))
+        {
+            self.codex_model_catalog_idx = index;
+            return false;
+        }
+
+        self.codex_model_catalog.push(CodexModelCatalogRow {
+            model: model.to_string(),
+            display_name: String::new(),
+            context_window: String::new(),
+        });
+        self.codex_model_catalog_idx = self.codex_model_catalog.len().saturating_sub(1);
+        true
+    }
+
+    pub fn set_selected_codex_model_catalog_model(&mut self, model: &str) -> bool {
+        let model = model.trim();
+        if model.is_empty() {
+            return false;
+        }
+
+        let idx = self
+            .codex_model_catalog_idx
+            .min(self.codex_model_catalog.len().saturating_sub(1));
+        if self.codex_model_catalog.get(idx).is_none() {
+            return self.upsert_codex_model_catalog_model(model);
+        }
+
+        if let Some(existing_idx) = self
+            .codex_model_catalog
+            .iter()
+            .position(|row| row.model.eq_ignore_ascii_case(model))
+        {
+            if existing_idx != idx {
+                self.codex_model_catalog.remove(idx);
+                self.codex_model_catalog_idx =
+                    existing_idx.min(self.codex_model_catalog.len().saturating_sub(1));
+                return true;
+            }
+        }
+
+        if let Some(row) = self.codex_model_catalog.get_mut(idx) {
+            row.model = model.to_string();
+            self.codex_model_catalog_idx = idx;
+            return true;
+        }
+        false
+    }
+
+    pub fn set_codex_model_catalog_field(
+        &mut self,
+        row: Option<usize>,
+        field: CodexModelCatalogField,
+        value: &str,
+    ) -> bool {
+        match (row, field) {
+            (None, CodexModelCatalogField::Model) => self.upsert_codex_model_catalog_model(value),
+            (None, _) => false,
+            (Some(index), CodexModelCatalogField::Model) => {
+                self.codex_model_catalog_idx =
+                    index.min(self.codex_model_catalog.len().saturating_sub(1));
+                self.set_selected_codex_model_catalog_model(value)
+            }
+            (Some(index), CodexModelCatalogField::DisplayName) => {
+                let Some(row) = self.codex_model_catalog.get_mut(index) else {
+                    return false;
+                };
+                row.display_name = value.trim().to_string();
+                self.codex_model_catalog_idx = index;
+                true
+            }
+            (Some(index), CodexModelCatalogField::ContextWindow) => {
+                let Some(row) = self.codex_model_catalog.get_mut(index) else {
+                    return false;
+                };
+                row.context_window = value.trim().to_string();
+                self.codex_model_catalog_idx = index;
+                true
+            }
+        }
+    }
+
+    pub fn remove_selected_codex_model_catalog_model(&mut self) -> bool {
+        if self.codex_model_catalog.is_empty() {
+            self.codex_model_catalog_idx = 0;
+            return false;
+        }
+        let idx = self
+            .codex_model_catalog_idx
+            .min(self.codex_model_catalog.len() - 1);
+        self.codex_model_catalog.remove(idx);
+        self.codex_model_catalog_idx = self
+            .codex_model_catalog_idx
+            .min(self.codex_model_catalog.len().saturating_sub(1));
+        true
+    }
+
+    pub fn codex_local_routing_fields(&self) -> Vec<CodexLocalRoutingField> {
+        let mut fields = vec![CodexLocalRoutingField::Enabled];
+        if self.codex_local_routing_enabled() {
+            fields.extend([
+                CodexLocalRoutingField::SupportsThinking,
+                CodexLocalRoutingField::SupportsEffort,
+                CodexLocalRoutingField::ModelCatalog,
+            ]);
+        }
+        fields
+    }
+
+    pub fn selected_codex_local_routing_field(&self) -> Option<CodexLocalRoutingField> {
+        let fields = self.codex_local_routing_fields();
+        fields
+            .get(
+                self.codex_local_routing_field_idx
+                    .min(fields.len().saturating_sub(1)),
+            )
+            .copied()
+    }
+
+    pub fn toggle_codex_local_routing_enabled(&mut self) {
+        self.claude_api_format = if self.codex_local_routing_enabled() {
+            ClaudeApiFormat::OpenAiResponses
+        } else {
+            ClaudeApiFormat::OpenAiChat
+        };
+        let len = self.codex_local_routing_fields().len();
+        self.codex_local_routing_field_idx = self
+            .codex_local_routing_field_idx
+            .min(len.saturating_sub(1));
+    }
+
+    pub fn toggle_codex_reasoning_thinking(&mut self) {
+        let next = !self.codex_reasoning_supports_thinking();
+        self.codex_chat_reasoning.supports_thinking = Some(next);
+        if !next {
+            self.codex_chat_reasoning.supports_effort = Some(false);
+        }
+    }
+
+    pub fn toggle_codex_reasoning_effort(&mut self) {
+        let next = !self.codex_reasoning_supports_effort();
+        self.codex_chat_reasoning.supports_effort = Some(next);
+        if next {
+            self.codex_chat_reasoning.supports_thinking = Some(true);
+            if self.codex_chat_reasoning.effort_param.is_none() {
+                self.codex_chat_reasoning.effort_param = Some("reasoning_effort".to_string());
+            }
+        } else {
+            self.codex_chat_reasoning.effort_param = Some("none".to_string());
+        }
+    }
+
+    pub fn codex_reasoning_supports_thinking(&self) -> bool {
+        self.codex_chat_reasoning.supports_thinking == Some(true)
+            || self.codex_chat_reasoning.supports_effort == Some(true)
+    }
+
+    pub fn codex_reasoning_supports_effort(&self) -> bool {
+        self.codex_chat_reasoning.supports_effort == Some(true)
     }
 
     pub fn refresh_default_usage_query_template(&mut self) {
@@ -1154,6 +1401,12 @@ impl ProviderAddFormState {
         meta_flag || category_flag || website_flag || name_flag
     }
 
+    pub fn codex_local_routing_enabled(&self) -> bool {
+        matches!(self.app_type, AppType::Codex)
+            && !self.is_codex_official_provider()
+            && matches!(self.claude_api_format, ClaudeApiFormat::OpenAiChat)
+    }
+
     pub fn apply_provider_json_to_fields(&mut self, provider: &Provider) {
         let previous_mode = self.mode.clone();
         let previous_focus = self.focus;
@@ -1162,6 +1415,8 @@ impl ProviderAddFormState {
         let previous_template_idx = self.template_idx;
         let previous_field_idx = self.field_idx;
         let previous_usage_query_field_idx = self.usage_query_field_idx;
+        let previous_codex_local_routing_field_idx = self.codex_local_routing_field_idx;
+        let previous_codex_model_catalog_field = self.codex_model_catalog_field;
         let previous_hermes_models_field_idx = self.hermes_models_field_idx;
         let previous_json_scroll = self.json_scroll;
         let previous_codex_preview_section = self.codex_preview_section;
@@ -1199,6 +1454,7 @@ impl ProviderAddFormState {
         next.codex_preview_section = previous_codex_preview_section;
         next.codex_auth_scroll = previous_codex_auth_scroll;
         next.codex_config_scroll = previous_codex_config_scroll;
+        next.codex_model_catalog_field = previous_codex_model_catalog_field;
         next.editing = false;
         next.usage_query_editing = false;
         next.hermes_models_editing = false;
@@ -1213,6 +1469,12 @@ impl ProviderAddFormState {
             0
         } else {
             previous_usage_query_field_idx.min(usage_fields_len - 1)
+        };
+        let codex_local_routing_fields_len = next.codex_local_routing_fields().len();
+        next.codex_local_routing_field_idx = if codex_local_routing_fields_len == 0 {
+            0
+        } else {
+            previous_codex_local_routing_field_idx.min(codex_local_routing_fields_len - 1)
         };
         let hermes_model_fields_len = next.hermes_model_fields().len();
         next.hermes_models_field_idx = if hermes_model_fields_len == 0 {
@@ -1242,6 +1504,8 @@ impl ProviderAddFormState {
         let previous_template_idx = self.template_idx;
         let previous_field_idx = self.field_idx;
         let previous_usage_query_field_idx = self.usage_query_field_idx;
+        let previous_codex_local_routing_field_idx = self.codex_local_routing_field_idx;
+        let previous_codex_model_catalog_field = self.codex_model_catalog_field;
         let previous_hermes_models_field_idx = self.hermes_models_field_idx;
         let previous_json_scroll = self.json_scroll;
         let previous_codex_preview_section = self.codex_preview_section;
@@ -1289,6 +1553,7 @@ impl ProviderAddFormState {
         next.codex_preview_section = previous_codex_preview_section;
         next.codex_auth_scroll = previous_codex_auth_scroll;
         next.codex_config_scroll = previous_codex_config_scroll;
+        next.codex_model_catalog_field = previous_codex_model_catalog_field;
         next.editing = false;
         next.usage_query_editing = false;
         next.hermes_models_editing = false;
@@ -1304,6 +1569,12 @@ impl ProviderAddFormState {
             0
         } else {
             previous_usage_query_field_idx.min(usage_fields_len - 1)
+        };
+        let codex_local_routing_fields_len = next.codex_local_routing_fields().len();
+        next.codex_local_routing_field_idx = if codex_local_routing_fields_len == 0 {
+            0
+        } else {
+            previous_codex_local_routing_field_idx.min(codex_local_routing_fields_len - 1)
         };
         let hermes_model_fields_len = next.hermes_model_fields().len();
         next.hermes_models_field_idx = if hermes_model_fields_len == 0 {
@@ -1398,6 +1669,38 @@ impl ProviderAddFormState {
         texts::tui_openclaw_models_summary(total)
     }
 
+    pub(crate) fn codex_model_catalog_summary(&self) -> String {
+        let count = self.codex_model_catalog.len();
+        if crate::cli::i18n::is_chinese() {
+            format!("{count} 个模型")
+        } else if count == 1 {
+            "1 model".to_string()
+        } else {
+            format!("{count} models")
+        }
+    }
+
+    #[cfg(test)]
+    pub fn apply_codex_model_catalog_value(&mut self, models_value: Value) -> Result<(), String> {
+        if !matches!(self.app_type, AppType::Codex) {
+            return Ok(());
+        }
+        let Some(models) = models_value.as_array() else {
+            return Err(texts::tui_toast_json_must_be_array().to_string());
+        };
+        self.codex_model_catalog = models
+            .iter()
+            .filter_map(codex_model_catalog_row_from_value)
+            .collect();
+        self.codex_model_catalog_idx = self
+            .codex_model_catalog_idx
+            .min(self.codex_model_catalog.len().saturating_sub(1));
+        if self.codex_model_catalog.is_empty() {
+            self.codex_model_catalog_field = CodexModelCatalogField::Model;
+        }
+        Ok(())
+    }
+
     pub(crate) fn openclaw_models_editor_text(&self) -> String {
         serde_json::to_string_pretty(&Value::Array(self.openclaw_models.clone()))
             .unwrap_or_else(|_| "[]".to_string())
@@ -1422,6 +1725,43 @@ impl ProviderAddFormState {
         settings_obj.insert("models".to_string(), models_value);
         self.apply_provider_json_value_to_fields(provider_value)
     }
+}
+
+pub(crate) fn codex_model_catalog_row_from_value(value: &Value) -> Option<CodexModelCatalogRow> {
+    let model = value
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if model.is_empty() {
+        return None;
+    }
+
+    let display_name = value
+        .get("displayName")
+        .or_else(|| value.get("display_name"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    let context_window = value
+        .get("contextWindow")
+        .or_else(|| value.get("context_window"))
+        .and_then(|value| {
+            value
+                .as_str()
+                .map(|value| value.trim().to_string())
+                .or_else(|| value.as_u64().map(|value| value.to_string()))
+                .or_else(|| value.as_i64().map(|value| value.to_string()))
+        })
+        .unwrap_or_default();
+
+    Some(CodexModelCatalogRow {
+        model,
+        display_name,
+        context_window,
+    })
 }
 
 pub(crate) fn detect_coding_plan_provider_for_usage_query(base_url: &str) -> Option<&'static str> {

--- a/src-tauri/src/cli/tui/form/provider_state_loading.rs
+++ b/src-tauri/src/cli/tui/form/provider_state_loading.rs
@@ -1,8 +1,9 @@
 use super::codex_config::parse_codex_config_snippet;
+use super::provider_state::codex_model_catalog_row_from_value;
 use super::{
     claude_hide_attribution_enabled, detect_balance_provider_for_usage_query,
-    detect_coding_plan_provider_for_usage_query, ClaudeApiFormat, ProviderAddFormState,
-    UsageQueryTemplate, OPENCLAW_DEFAULT_API_PROTOCOL,
+    detect_coding_plan_provider_for_usage_query, ClaudeApiFormat, CodexWireApi,
+    ProviderAddFormState, UsageQueryTemplate, OPENCLAW_DEFAULT_API_PROTOCOL,
 };
 use crate::app_config::AppType;
 use crate::provider::Provider;
@@ -168,6 +169,7 @@ fn populate_claude_form(form: &mut ProviderAddFormState, provider: &Provider) {
 }
 
 fn populate_codex_form(form: &mut ProviderAddFormState, provider: &Provider) {
+    let mut parsed_wire_api = None;
     if let Some(config) = provider
         .settings_config
         .get("config")
@@ -181,7 +183,7 @@ fn populate_codex_form(form: &mut ProviderAddFormState, provider: &Provider) {
             form.codex_model.set(model);
         }
         if let Some(wire_api) = parsed.wire_api {
-            form.codex_wire_api = wire_api;
+            parsed_wire_api = Some(wire_api);
         }
         if let Some(requires_openai_auth) = parsed.requires_openai_auth {
             form.codex_requires_openai_auth = requires_openai_auth;
@@ -199,6 +201,25 @@ fn populate_codex_form(form: &mut ProviderAddFormState, provider: &Provider) {
             form.codex_api_key.set(key);
         }
     }
+    form.claude_api_format = parse_codex_api_format(provider, parsed_wire_api);
+    form.codex_wire_api = CodexWireApi::Responses;
+    form.codex_chat_reasoning = provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.codex_chat_reasoning.clone())
+        .unwrap_or_default();
+    form.codex_model_catalog = provider
+        .settings_config
+        .get("modelCatalog")
+        .and_then(|catalog| catalog.get("models"))
+        .and_then(Value::as_array)
+        .map(|models| {
+            models
+                .iter()
+                .filter_map(codex_model_catalog_row_from_value)
+                .collect()
+        })
+        .unwrap_or_default();
 }
 
 fn populate_gemini_form(form: &mut ProviderAddFormState, provider: &Provider) {
@@ -409,6 +430,36 @@ fn parse_claude_api_format(provider: &Provider) -> ClaudeApiFormat {
         ClaudeApiFormat::OpenAiChat
     } else {
         ClaudeApiFormat::Anthropic
+    }
+}
+
+fn parse_codex_api_format(provider: &Provider, wire_api: Option<CodexWireApi>) -> ClaudeApiFormat {
+    if let Some(api_format) = provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.api_format.as_deref())
+        .or_else(|| {
+            provider
+                .settings_config
+                .get("api_format")
+                .and_then(|value| value.as_str())
+        })
+        .or_else(|| {
+            provider
+                .settings_config
+                .get("apiFormat")
+                .and_then(|value| value.as_str())
+        })
+    {
+        return match api_format {
+            "openai_chat" => ClaudeApiFormat::OpenAiChat,
+            _ => ClaudeApiFormat::OpenAiResponses,
+        };
+    }
+
+    match wire_api {
+        Some(CodexWireApi::Chat) => ClaudeApiFormat::OpenAiChat,
+        _ => ClaudeApiFormat::OpenAiResponses,
     }
 }
 

--- a/src-tauri/src/cli/tui/form/provider_templates.rs
+++ b/src-tauri/src/cli/tui/form/provider_templates.rs
@@ -1,10 +1,10 @@
 use crate::app_config::AppType;
-use crate::provider::ClaudeApiKeyField;
+use crate::provider::{ClaudeApiKeyField, CodexChatReasoningConfig};
 use serde_json::json;
 
 use super::{
-    ClaudeApiFormat, CodexWireApi, FormMode, GeminiAuthType, ProviderAddFormState,
-    HERMES_DEFAULT_API_MODE, OPENCLAW_DEFAULT_API_PROTOCOL,
+    ClaudeApiFormat, CodexModelCatalogField, CodexWireApi, FormMode, GeminiAuthType,
+    ProviderAddFormState, HERMES_DEFAULT_API_MODE, OPENCLAW_DEFAULT_API_PROTOCOL,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -289,6 +289,11 @@ impl ProviderAddFormState {
                     self.codex_requires_openai_auth = defaults.codex_requires_openai_auth;
                     self.codex_env_key = defaults.codex_env_key;
                     self.codex_api_key = defaults.codex_api_key;
+                    self.codex_chat_reasoning = defaults.codex_chat_reasoning;
+                    self.codex_model_catalog = defaults.codex_model_catalog;
+                    self.codex_local_routing_field_idx = defaults.codex_local_routing_field_idx;
+                    self.codex_model_catalog_idx = defaults.codex_model_catalog_idx;
+                    self.codex_model_catalog_field = defaults.codex_model_catalog_field;
                     self.gemini_auth_type = defaults.gemini_auth_type;
                     self.gemini_api_key = defaults.gemini_api_key;
                     self.gemini_base_url = defaults.gemini_base_url;
@@ -381,6 +386,7 @@ impl ProviderAddFormState {
                     self.codex_wire_api = CodexWireApi::Responses;
                     self.codex_requires_openai_auth = true;
                     self.codex_env_key.set("");
+                    self.reset_codex_local_routing_state();
                 }
                 ProviderTemplateId::GoogleOAuth => {
                     self.extra = json!({
@@ -427,6 +433,7 @@ impl ProviderAddFormState {
                 self.codex_model.set("gpt-5.4");
                 self.codex_wire_api = CodexWireApi::Responses;
                 self.codex_requires_openai_auth = true;
+                self.reset_codex_local_routing_state();
             }
             AppType::Gemini => {
                 self.gemini_auth_type = GeminiAuthType::ApiKey;
@@ -518,5 +525,14 @@ impl ProviderAddFormState {
                 }
             }
         }
+    }
+
+    fn reset_codex_local_routing_state(&mut self) {
+        self.claude_api_format = ClaudeApiFormat::OpenAiResponses;
+        self.codex_chat_reasoning = CodexChatReasoningConfig::default();
+        self.codex_model_catalog.clear();
+        self.codex_local_routing_field_idx = 0;
+        self.codex_model_catalog_idx = 0;
+        self.codex_model_catalog_field = CodexModelCatalogField::Model;
     }
 }

--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -780,6 +780,55 @@ fn provider_add_form_packycode_template_codex_sets_partner_meta_and_base_url() {
 }
 
 #[test]
+fn provider_add_form_codex_template_switch_clears_local_routing_state() {
+    let mut form = ProviderAddFormState::new(AppType::Codex);
+    form.claude_api_format = ClaudeApiFormat::OpenAiChat;
+    form.codex_chat_reasoning.supports_thinking = Some(true);
+    form.codex_chat_reasoning.supports_effort = Some(true);
+    form.codex_local_routing_field_idx = 3;
+    form.apply_codex_model_catalog_value(json!([
+        { "model": "deepseek-chat", "displayName": "DeepSeek Chat" }
+    ]))
+    .expect("catalog should apply");
+
+    form.apply_template(packycode_template_index(AppType::Codex), &[]);
+
+    assert!(!form.codex_local_routing_enabled());
+    assert_eq!(form.codex_local_routing_field_idx, 0);
+    assert_eq!(
+        form.codex_local_routing_fields(),
+        vec![CodexLocalRoutingField::Enabled]
+    );
+    assert_eq!(form.codex_chat_reasoning, Default::default());
+    assert!(form.codex_model_catalog.is_empty());
+
+    let provider = form.to_provider_json_value();
+    assert_eq!(provider["meta"]["apiFormat"], "openai_responses");
+    assert!(provider["meta"].get("codexChatReasoning").is_none());
+    assert!(provider["settingsConfig"].get("modelCatalog").is_none());
+
+    form.claude_api_format = ClaudeApiFormat::OpenAiChat;
+    form.codex_chat_reasoning.supports_thinking = Some(true);
+    form.apply_codex_model_catalog_value(json!([{ "model": "qwen-coder" }]))
+        .expect("catalog should apply");
+
+    form.apply_template(1, &[]);
+
+    assert!(form.is_codex_official_provider());
+    assert!(!form.codex_local_routing_enabled());
+    assert_eq!(form.codex_chat_reasoning, Default::default());
+    assert!(form.codex_model_catalog.is_empty());
+    let official_provider = form.to_provider_json_value();
+    assert!(official_provider["meta"].get("apiFormat").is_none());
+    assert!(official_provider["meta"]
+        .get("codexChatReasoning")
+        .is_none());
+    assert!(official_provider["settingsConfig"]
+        .get("modelCatalog")
+        .is_none());
+}
+
+#[test]
 fn provider_add_form_packycode_template_gemini_sets_partner_meta_and_base_url() {
     let mut form = ProviderAddFormState::new(AppType::Gemini);
     let existing_ids = Vec::<String>::new();
@@ -1214,6 +1263,14 @@ fn provider_add_form_codex_custom_includes_api_key_and_hides_advanced_fields() {
         "custom Codex provider should include API Key field"
     );
     assert!(
+        fields.contains(&ProviderAddField::CodexLocalRouting),
+        "custom Codex provider should expose Local Routing on its secondary page"
+    );
+    assert!(
+        !fields.contains(&ProviderAddField::ClaudeApiFormat),
+        "custom Codex provider should not expose the old API Format selector"
+    );
+    assert!(
         !fields.contains(&ProviderAddField::CodexWireApi),
         "Codex wire_api should not be configurable in the UI"
     );
@@ -1225,6 +1282,209 @@ fn provider_add_form_codex_custom_includes_api_key_and_hides_advanced_fields() {
         !fields.contains(&ProviderAddField::CodexEnvKey),
         "Codex env key should not be configurable in the UI"
     );
+}
+
+#[test]
+fn provider_add_form_codex_local_routing_writes_meta_without_chat_wire_api() {
+    let mut form = ProviderAddFormState::new(AppType::Codex);
+    form.id.set("custom");
+    form.name.set("Custom");
+    form.codex_base_url.set("https://api.example.com/v1");
+    form.codex_model.set("deepseek-chat");
+    form.claude_api_format = ClaudeApiFormat::OpenAiChat;
+
+    let provider = form.to_provider_json_value();
+    let config = provider["settingsConfig"]["config"]
+        .as_str()
+        .expect("Codex config should be serialized");
+
+    assert_eq!(provider["meta"]["apiFormat"], "openai_chat");
+    assert!(
+        config.contains("wire_api = \"responses\""),
+        "Codex wire_api should stay Responses; meta.apiFormat controls local route mapping"
+    );
+    assert!(
+        !config.contains("wire_api = \"chat\""),
+        "TUI should not persist Chat as the Codex wire_api"
+    );
+}
+
+#[test]
+fn provider_add_form_codex_local_routing_is_off_by_default_and_persisted() {
+    let mut form = ProviderAddFormState::new(AppType::Codex);
+    form.id.set("custom");
+    form.name.set("Custom");
+
+    let provider = form.to_provider_json_value();
+
+    assert!(!form.codex_local_routing_enabled());
+    assert_eq!(provider["meta"]["apiFormat"], "openai_responses");
+}
+
+#[test]
+fn provider_add_form_codex_local_routing_restores_meta_chat_format() {
+    let mut provider = Provider::with_id(
+        "custom".to_string(),
+        "Custom".to_string(),
+        json!({
+            "config": r#"
+model_provider = "custom"
+model = "deepseek-chat"
+
+[model_providers.custom]
+name = "custom"
+base_url = "https://api.example.com/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#,
+        }),
+        None,
+    );
+    provider.meta = Some(crate::provider::ProviderMeta {
+        api_format: Some("openai_chat".to_string()),
+        ..Default::default()
+    });
+
+    let form = ProviderAddFormState::from_provider(AppType::Codex, &provider);
+
+    assert!(form.codex_local_routing_enabled());
+}
+
+#[test]
+fn provider_add_form_codex_legacy_chat_wire_api_loads_as_local_route_mapping() {
+    let provider = Provider::with_id(
+        "custom".to_string(),
+        "Custom".to_string(),
+        json!({
+            "config": r#"
+model_provider = "custom"
+model = "deepseek-chat"
+
+[model_providers.custom]
+name = "custom"
+base_url = "https://api.example.com/v1"
+wire_api = "chat"
+requires_openai_auth = true
+"#,
+        }),
+        None,
+    );
+
+    let form = ProviderAddFormState::from_provider(AppType::Codex, &provider);
+    let saved = form.to_provider_json_value();
+    let config = saved["settingsConfig"]["config"]
+        .as_str()
+        .expect("Codex config should be serialized");
+
+    assert!(form.codex_local_routing_enabled());
+    assert_eq!(saved["meta"]["apiFormat"], "openai_chat");
+    assert!(config.contains("wire_api = \"responses\""));
+    assert!(!config.contains("wire_api = \"chat\""));
+}
+
+#[test]
+fn provider_add_form_codex_local_routing_saves_normalized_reasoning() {
+    let mut form = ProviderAddFormState::new(AppType::Codex);
+    form.id.set("custom");
+    form.name.set("Custom");
+    form.codex_base_url.set("https://api.example.com/v1");
+    form.claude_api_format = ClaudeApiFormat::OpenAiChat;
+
+    form.toggle_codex_reasoning_effort();
+
+    let provider = form.to_provider_json_value();
+    let reasoning = &provider["meta"]["codexChatReasoning"];
+
+    assert_eq!(reasoning["supportsThinking"], true);
+    assert_eq!(reasoning["supportsEffort"], true);
+    assert_eq!(reasoning["thinkingParam"], "thinking");
+    assert_eq!(reasoning["effortParam"], "reasoning_effort");
+    assert_eq!(reasoning["effortValueMode"], "passthrough");
+    assert_eq!(reasoning["outputFormat"], "auto");
+}
+
+#[test]
+fn provider_add_form_codex_responses_removes_reasoning_and_model_catalog() {
+    let mut provider = Provider::with_id(
+        "custom".to_string(),
+        "Custom".to_string(),
+        json!({
+            "config": r#"
+model_provider = "custom"
+model = "deepseek-chat"
+
+[model_providers.custom]
+name = "custom"
+base_url = "https://api.example.com/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#,
+            "modelCatalog": {
+                "models": [
+                    { "model": "deepseek-chat", "displayName": "DeepSeek Chat" }
+                ]
+            }
+        }),
+        None,
+    );
+    provider.meta = Some(crate::provider::ProviderMeta {
+        api_format: Some("openai_chat".to_string()),
+        codex_chat_reasoning: Some(crate::provider::CodexChatReasoningConfig {
+            supports_thinking: Some(true),
+            supports_effort: Some(true),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    let mut form = ProviderAddFormState::from_provider(AppType::Codex, &provider);
+    form.toggle_codex_local_routing_enabled();
+
+    let saved = form.to_provider_json_value();
+
+    assert_eq!(saved["meta"]["apiFormat"], "openai_responses");
+    assert!(saved["meta"].get("codexChatReasoning").is_none());
+    assert!(saved["settingsConfig"].get("modelCatalog").is_none());
+}
+
+#[test]
+fn provider_add_form_codex_model_catalog_saves_normalized_models_and_syncs_primary_model() {
+    let mut form = ProviderAddFormState::new(AppType::Codex);
+    form.id.set("custom");
+    form.name.set("Custom");
+    form.codex_base_url.set("https://api.example.com/v1");
+    form.codex_model.set("fallback-model");
+    form.claude_api_format = ClaudeApiFormat::OpenAiChat;
+    form.apply_codex_model_catalog_value(json!([
+        { "model": " deepseek-chat ", "displayName": " DeepSeek Chat ", "contextWindow": "128000 tokens" },
+        { "model": "deepseek-chat", "displayName": "Duplicate" },
+        { "model": "kimi-k2", "contextWindow": "256k" },
+        { "model": "qwen-coder", "contextWindow": "invalid" },
+        { "model": "" }
+    ]))
+    .expect("catalog should apply");
+
+    let saved = form.to_provider_json_value();
+    let config = saved["settingsConfig"]["config"]
+        .as_str()
+        .expect("Codex config should be serialized");
+    let models = saved["settingsConfig"]["modelCatalog"]["models"]
+        .as_array()
+        .expect("modelCatalog.models should be an array");
+
+    assert_eq!(models.len(), 3);
+    assert_eq!(models[0]["model"], "deepseek-chat");
+    assert_eq!(models[0]["displayName"], "DeepSeek Chat");
+    assert_eq!(models[0]["contextWindow"], 128000);
+    assert_eq!(models[1]["model"], "kimi-k2");
+    assert_eq!(models[1]["contextWindow"], 256000);
+    assert_eq!(models[2]["model"], "qwen-coder");
+    assert!(models[2].get("contextWindow").is_none());
+    assert!(
+        config.contains("model = \"deepseek-chat\""),
+        "first normalized catalog model should become the active Codex model"
+    );
+    assert!(config.contains("wire_api = \"responses\""));
 }
 
 #[test]

--- a/src-tauri/src/cli/tui/runtime_actions/editor.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/editor.rs
@@ -21,17 +21,6 @@ use super::helpers::{
 };
 use super::RuntimeActionContext;
 
-fn is_codex_official_provider(provider: &Provider) -> bool {
-    provider
-        .meta
-        .as_ref()
-        .and_then(|meta| meta.codex_official)
-        .unwrap_or(false)
-        || provider.category.as_deref() == Some("official")
-        || provider.website_url.as_deref() == Some("https://chatgpt.com/codex")
-        || provider.name.trim().eq_ignore_ascii_case("OpenAI Official")
-}
-
 fn validate_provider_submit(
     app_type: &AppType,
     provider: &Provider,
@@ -45,7 +34,7 @@ fn validate_provider_submit(
         });
     }
 
-    if matches!(app_type, AppType::Codex) && !is_codex_official_provider(provider) {
+    if matches!(app_type, AppType::Codex) && !provider.is_codex_official() {
         let parsed = crate::cli::tui::form::parse_codex_config_snippet(
             provider
                 .settings_config

--- a/src-tauri/src/cli/tui/ui/forms/provider.rs
+++ b/src-tauri/src/cli/tui/ui/forms/provider.rs
@@ -2,8 +2,13 @@ use super::*;
 use serde_json::json;
 use std::collections::BTreeSet;
 
-fn claude_api_format_label(api_format: crate::cli::tui::form::ClaudeApiFormat) -> String {
-    texts::tui_claude_api_format_value(api_format.as_str()).to_string()
+fn provider_api_format_label(provider: &super::form::ProviderAddFormState) -> String {
+    let api_format = provider.claude_api_format.as_str();
+    if matches!(provider.app_type, AppType::Codex) {
+        texts::tui_codex_api_format_value(api_format).to_string()
+    } else {
+        texts::tui_claude_api_format_value(api_format).to_string()
+    }
 }
 
 fn should_redact_provider_field(
@@ -154,6 +159,22 @@ pub(crate) fn render_provider_add_form(
     area: Rect,
     theme: &super::theme::Theme,
 ) {
+    if matches!(
+        provider.page,
+        super::form::ProviderFormPage::CodexLocalRouting
+    ) {
+        render_codex_local_routing_form(frame, app, provider, area, theme);
+        return;
+    }
+
+    if matches!(
+        provider.page,
+        super::form::ProviderFormPage::CodexModelCatalog
+    ) {
+        render_codex_model_catalog_form(frame, app, provider, area, theme);
+        return;
+    }
+
     if matches!(provider.page, super::form::ProviderFormPage::UsageQuery) {
         render_usage_query_form(frame, app, provider, area, theme);
         return;
@@ -434,6 +455,311 @@ pub(crate) fn render_provider_add_form(
             &highlighted_lines,
         );
     }
+}
+
+fn render_codex_local_routing_form(
+    frame: &mut Frame<'_>,
+    app: &App,
+    provider: &super::form::ProviderAddFormState,
+    area: Rect,
+    theme: &super::theme::Theme,
+) {
+    let title = texts::tui_codex_local_routing_title(provider.name.value.trim());
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(pane_border_style(app, Focus::Content, theme))
+        .title(title);
+    frame.render_widget(outer.clone(), area);
+    let inner = outer.inner(area);
+
+    let fields = provider.codex_local_routing_fields();
+    let selected_field = fields
+        .get(
+            provider
+                .codex_local_routing_field_idx
+                .min(fields.len().saturating_sub(1)),
+        )
+        .copied();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(0),
+            Constraint::Length(3),
+        ])
+        .split(inner);
+
+    render_key_bar(
+        frame,
+        chunks[0],
+        theme,
+        &codex_local_routing_form_key_items(selected_field),
+    );
+
+    let body = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .split(chunks[1]);
+
+    let fields_block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(focus_block_style(
+            matches!(provider.focus, FormFocus::Fields),
+            theme,
+        ))
+        .title(texts::tui_form_fields_title());
+    frame.render_widget(fields_block.clone(), body[0]);
+    let fields_inner = fields_block.inner(body[0]);
+
+    let rows_data = fields
+        .iter()
+        .map(|field| codex_local_routing_field_label_and_value(provider, *field))
+        .collect::<Vec<_>>();
+
+    let label_col_width = field_label_column_width(
+        rows_data
+            .iter()
+            .map(|(label, _value)| label.as_str())
+            .chain(std::iter::once(texts::tui_header_field())),
+        1,
+    );
+
+    let header = Row::new(vec![
+        Cell::from(cell_pad(texts::tui_header_field())),
+        Cell::from(texts::tui_header_value()),
+    ])
+    .style(Style::default().fg(theme.dim).add_modifier(Modifier::BOLD));
+
+    let rows = rows_data.iter().map(|(label, value)| {
+        Row::new(vec![Cell::from(cell_pad(label)), Cell::from(value.clone())])
+    });
+
+    let table = Table::new(
+        rows,
+        [Constraint::Length(label_col_width), Constraint::Min(10)],
+    )
+    .header(header)
+    .block(Block::default().borders(Borders::NONE))
+    .row_highlight_style(selection_style(theme))
+    .highlight_symbol(highlight_symbol(theme));
+
+    let mut state = TableState::default();
+    if !fields.is_empty() {
+        state.select(Some(
+            provider.codex_local_routing_field_idx.min(fields.len() - 1),
+        ));
+    }
+    frame.render_stateful_widget(table, fields_inner, &mut state);
+
+    render_codex_model_catalog_preview(frame, provider, body[1], theme);
+    render_codex_local_routing_input(frame, provider, selected_field, chunks[2], theme);
+}
+
+fn render_codex_model_catalog_preview(
+    frame: &mut Frame<'_>,
+    provider: &super::form::ProviderAddFormState,
+    area: Rect,
+    theme: &super::theme::Theme,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(Style::default().fg(theme.dim))
+        .title(texts::tui_codex_model_catalog_preview_title());
+    frame.render_widget(block.clone(), area);
+    let inner = block.inner(area);
+
+    if provider.codex_model_catalog.is_empty() {
+        frame.render_widget(
+            Paragraph::new(texts::tui_codex_model_catalog_empty())
+                .style(Style::default().fg(theme.dim))
+                .alignment(Alignment::Center),
+            inner,
+        );
+        return;
+    }
+
+    let rows = provider
+        .codex_model_catalog
+        .iter()
+        .enumerate()
+        .map(|(idx, row)| {
+            Row::new(vec![Cell::from(cell_pad(&format!(
+                "{}. {}",
+                idx + 1,
+                row.summary_label()
+            )))])
+        })
+        .collect::<Vec<_>>();
+
+    let table =
+        Table::new(rows, [Constraint::Min(10)]).block(Block::default().borders(Borders::NONE));
+    frame.render_widget(table, inner);
+}
+
+fn render_codex_model_catalog_form(
+    frame: &mut Frame<'_>,
+    app: &App,
+    provider: &super::form::ProviderAddFormState,
+    area: Rect,
+    theme: &super::theme::Theme,
+) {
+    let title = texts::tui_codex_model_catalog_title(provider.name.value.trim());
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(pane_border_style(app, Focus::Content, theme))
+        .title(title);
+    frame.render_widget(outer.clone(), area);
+    let inner = outer.inner(area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(0)])
+        .split(inner);
+
+    render_key_bar(
+        frame,
+        chunks[0],
+        theme,
+        &codex_model_catalog_form_key_items(!provider.codex_model_catalog.is_empty()),
+    );
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(focus_block_style(true, theme))
+        .title(texts::tui_codex_model_catalog());
+    frame.render_widget(block.clone(), chunks[1]);
+    let table_area = block.inner(chunks[1]);
+
+    if provider.codex_model_catalog.is_empty() {
+        frame.render_widget(
+            Paragraph::new(texts::tui_codex_model_catalog_empty())
+                .style(Style::default().fg(theme.dim))
+                .alignment(Alignment::Center),
+            table_area,
+        );
+        return;
+    }
+
+    let header = Row::new(vec![
+        Cell::from(cell_pad(texts::tui_codex_model_catalog_model_header())),
+        Cell::from(texts::tui_codex_model_catalog_display_header()),
+        Cell::from(texts::tui_codex_model_catalog_context_header()),
+    ])
+    .style(Style::default().fg(theme.dim).add_modifier(Modifier::BOLD));
+
+    let selected_idx = provider
+        .codex_model_catalog_idx
+        .min(provider.codex_model_catalog.len().saturating_sub(1));
+    let selected_field = provider.codex_model_catalog_field;
+    let rows = provider
+        .codex_model_catalog
+        .iter()
+        .enumerate()
+        .map(|(idx, row)| {
+            let context_window =
+                super::form::codex_model_catalog_context_window_label(&row.context_window);
+            Row::new(vec![
+                codex_model_catalog_cell(
+                    &row.model,
+                    idx,
+                    selected_idx,
+                    super::form::CodexModelCatalogField::Model,
+                    selected_field,
+                    theme,
+                ),
+                codex_model_catalog_cell(
+                    &row.display_name,
+                    idx,
+                    selected_idx,
+                    super::form::CodexModelCatalogField::DisplayName,
+                    selected_field,
+                    theme,
+                ),
+                codex_model_catalog_cell(
+                    &context_window,
+                    idx,
+                    selected_idx,
+                    super::form::CodexModelCatalogField::ContextWindow,
+                    selected_field,
+                    theme,
+                ),
+            ])
+        });
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Percentage(45),
+            Constraint::Percentage(35),
+            Constraint::Percentage(20),
+        ],
+    )
+    .header(header)
+    .block(Block::default().borders(Borders::NONE));
+
+    frame.render_widget(table, table_area);
+}
+
+fn codex_model_catalog_cell<'a>(
+    value: &str,
+    row_idx: usize,
+    selected_idx: usize,
+    field: super::form::CodexModelCatalogField,
+    selected_field: super::form::CodexModelCatalogField,
+    theme: &super::theme::Theme,
+) -> Cell<'a> {
+    Cell::from(cell_pad(value)).style(codex_model_catalog_cell_style(
+        row_idx,
+        selected_idx,
+        field,
+        selected_field,
+        theme,
+    ))
+}
+
+fn codex_model_catalog_cell_style(
+    row_idx: usize,
+    selected_idx: usize,
+    field: super::form::CodexModelCatalogField,
+    selected_field: super::form::CodexModelCatalogField,
+    theme: &super::theme::Theme,
+) -> Style {
+    if row_idx == selected_idx && field == selected_field {
+        selection_style(theme)
+    } else if row_idx == selected_idx {
+        if theme.no_color {
+            Style::default().add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.accent)
+        }
+    } else {
+        Style::default()
+    }
+}
+
+fn render_codex_local_routing_input(
+    frame: &mut Frame<'_>,
+    provider: &super::form::ProviderAddFormState,
+    selected: Option<super::form::CodexLocalRoutingField>,
+    area: Rect,
+    theme: &super::theme::Theme,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(Style::default().fg(theme.dim))
+        .title(texts::tui_form_input_title());
+    frame.render_widget(block.clone(), area);
+    let inner = block.inner(area);
+
+    let (line, _cursor_col) = codex_local_routing_field_editor_line(provider, selected);
+    frame.render_widget(Paragraph::new(line).wrap(Wrap { trim: false }), inner);
 }
 
 fn render_usage_query_form(
@@ -850,6 +1176,7 @@ pub(crate) fn provider_field_label_and_value(
         ProviderAddField::CodexFastMode => texts::tui_label_codex_fast_mode().to_string(),
         ProviderAddField::CodexBaseUrl => texts::tui_label_base_url().to_string(),
         ProviderAddField::CodexModel => texts::model_label().to_string(),
+        ProviderAddField::CodexLocalRouting => texts::tui_label_codex_local_routing().to_string(),
         ProviderAddField::CodexWireApi => {
             strip_trailing_colon(texts::codex_wire_api_label()).to_string()
         }
@@ -898,7 +1225,7 @@ pub(crate) fn provider_field_label_and_value(
     };
 
     let value = match field {
-        ProviderAddField::ClaudeApiFormat => claude_api_format_label(provider.claude_api_format),
+        ProviderAddField::ClaudeApiFormat => provider_api_format_label(provider),
         ProviderAddField::CodexWireApi => provider.codex_wire_api.as_str().to_string(),
         ProviderAddField::CodexRequiresOpenaiAuth => {
             if provider.codex_requires_openai_auth {
@@ -925,6 +1252,7 @@ pub(crate) fn provider_field_label_and_value(
                 "[ ]".to_string()
             }
         }
+        ProviderAddField::CodexLocalRouting => texts::tui_key_open().to_string(),
         ProviderAddField::IncludeCommonConfig => {
             if provider.include_common_config {
                 format!("[{}]", texts::tui_marker_active())
@@ -1005,10 +1333,12 @@ pub(crate) fn provider_field_editor_line(
     } else {
         let text = match field {
             ProviderAddField::ClaudeApiFormat => {
-                format!(
-                    "api_format = {}",
+                let value = if matches!(provider.app_type, AppType::Codex) {
+                    texts::tui_codex_api_format_value(provider.claude_api_format.as_str())
+                } else {
                     texts::tui_claude_api_format_value(provider.claude_api_format.as_str())
-                )
+                };
+                format!("api_format = {}", value)
             }
             ProviderAddField::CodexWireApi => {
                 format!("wire_api = {}", provider.codex_wire_api.as_str())
@@ -1034,6 +1364,9 @@ pub(crate) fn provider_field_editor_line(
             ProviderAddField::CodexFastMode => {
                 format!("codex_fast_mode = {}", provider.codex_fast_mode)
             }
+            ProviderAddField::CodexLocalRouting => {
+                format!("local_routing = {}", provider.codex_local_routing_enabled())
+            }
             ProviderAddField::CommonConfigDivider => String::new(),
             ProviderAddField::IncludeCommonConfig => {
                 format!("apply_common_config = {}", provider.include_common_config)
@@ -1057,6 +1390,81 @@ pub(crate) fn provider_field_editor_line(
         };
         (Line::raw(text), 0)
     }
+}
+
+pub(crate) fn codex_local_routing_field_label_and_value(
+    provider: &super::form::ProviderAddFormState,
+    field: super::form::CodexLocalRoutingField,
+) -> (String, String) {
+    let label = match field {
+        super::form::CodexLocalRoutingField::Enabled => {
+            texts::tui_codex_local_routing_enable().to_string()
+        }
+        super::form::CodexLocalRoutingField::SupportsThinking => {
+            texts::tui_codex_reasoning_supports_thinking().to_string()
+        }
+        super::form::CodexLocalRoutingField::SupportsEffort => {
+            texts::tui_codex_reasoning_supports_effort().to_string()
+        }
+        super::form::CodexLocalRoutingField::ModelCatalog => {
+            texts::tui_codex_model_catalog().to_string()
+        }
+    };
+
+    let value = match field {
+        super::form::CodexLocalRoutingField::Enabled => {
+            if provider.codex_local_routing_enabled() {
+                format!("[{}]", texts::tui_marker_active())
+            } else {
+                "[ ]".to_string()
+            }
+        }
+        super::form::CodexLocalRoutingField::SupportsThinking => {
+            if provider.codex_reasoning_supports_thinking() {
+                format!("[{}]", texts::tui_marker_active())
+            } else {
+                "[ ]".to_string()
+            }
+        }
+        super::form::CodexLocalRoutingField::SupportsEffort => {
+            if provider.codex_reasoning_supports_effort() {
+                format!("[{}]", texts::tui_marker_active())
+            } else {
+                "[ ]".to_string()
+            }
+        }
+        super::form::CodexLocalRoutingField::ModelCatalog => provider.codex_model_catalog_summary(),
+    };
+
+    (label, value)
+}
+
+pub(crate) fn codex_local_routing_field_editor_line(
+    provider: &super::form::ProviderAddFormState,
+    selected: Option<super::form::CodexLocalRoutingField>,
+) -> (Line<'static>, usize) {
+    let text = match selected {
+        Some(super::form::CodexLocalRoutingField::Enabled) => {
+            format!("local_routing = {}", provider.codex_local_routing_enabled())
+        }
+        Some(super::form::CodexLocalRoutingField::SupportsThinking) => {
+            format!(
+                "supportsThinking = {}",
+                provider.codex_reasoning_supports_thinking()
+            )
+        }
+        Some(super::form::CodexLocalRoutingField::SupportsEffort) => {
+            format!(
+                "supportsEffort = {}",
+                provider.codex_reasoning_supports_effort()
+            )
+        }
+        Some(super::form::CodexLocalRoutingField::ModelCatalog) => {
+            texts::tui_codex_model_catalog().to_string()
+        }
+        None => String::new(),
+    };
+    (Line::raw(text), 0)
 }
 
 fn provider_field_is_divider(field: ProviderAddField) -> bool {

--- a/src-tauri/src/cli/tui/ui/forms/shared.rs
+++ b/src-tauri/src/cli/tui/ui/forms/shared.rs
@@ -41,6 +41,7 @@ pub(crate) fn add_form_key_items(
                     Some(
                         ProviderAddField::ClaudeModelConfig
                         | ProviderAddField::CodexOAuthAccount
+                        | ProviderAddField::CodexLocalRouting
                         | ProviderAddField::CommonSnippet
                         | ProviderAddField::UsageQuery
                         | ProviderAddField::OpenClawModels
@@ -72,6 +73,48 @@ pub(crate) fn add_form_key_items(
         FormFocus::Content => {}
     }
 
+    keys
+}
+
+pub(crate) fn codex_local_routing_form_key_items(
+    selected_field: Option<super::form::CodexLocalRoutingField>,
+) -> Vec<(&'static str, &'static str)> {
+    let mut keys = vec![
+        ("Ctrl+S", texts::tui_key_save()),
+        ("Esc", texts::tui_key_no()),
+        ("↑↓", texts::tui_key_select()),
+    ];
+
+    let enter_action = match selected_field {
+        Some(super::form::CodexLocalRoutingField::ModelCatalog) => texts::tui_key_open(),
+        Some(
+            super::form::CodexLocalRoutingField::Enabled
+            | super::form::CodexLocalRoutingField::SupportsThinking
+            | super::form::CodexLocalRoutingField::SupportsEffort,
+        ) => texts::tui_key_toggle(),
+        None => texts::tui_key_toggle(),
+    };
+    keys.push(("Enter", enter_action));
+    keys
+}
+
+pub(crate) fn codex_model_catalog_form_key_items(
+    has_rows: bool,
+) -> Vec<(&'static str, &'static str)> {
+    let mut keys = vec![
+        ("Ctrl+S", texts::tui_key_save()),
+        ("Esc", texts::tui_key_no()),
+        ("f", texts::tui_key_fetch_model()),
+        ("+", texts::tui_key_add()),
+    ];
+    if has_rows {
+        keys.extend([
+            ("↑↓", texts::tui_key_select()),
+            ("←→", texts::tui_key_select()),
+            ("Enter", texts::tui_key_edit()),
+            ("Del", texts::tui_key_delete()),
+        ]);
+    }
     keys
 }
 

--- a/src-tauri/src/cli/tui/ui/overlay/pickers.rs
+++ b/src-tauri/src/cli/tui/ui/overlay/pickers.rs
@@ -195,41 +195,43 @@ pub(super) fn render_claude_api_format_picker_overlay(
         width: chunks[1].width.saturating_sub(4),
         height: chunks[1].height.saturating_sub(2),
     };
-    let current = app
+    let (app_type, current) = app
         .form
         .as_ref()
         .and_then(|form| match form {
-            FormState::ProviderAdd(provider) => Some(provider.claude_api_format),
+            FormState::ProviderAdd(provider) => {
+                Some((provider.app_type.clone(), provider.claude_api_format))
+            }
             _ => None,
         })
-        .unwrap_or(crate::cli::tui::form::ClaudeApiFormat::Anthropic);
-
-    let items = crate::cli::tui::form::ClaudeApiFormat::ALL
-        .into_iter()
-        .map(|api_format| {
-            let marker = if api_format == current {
-                texts::tui_marker_active()
-            } else {
-                texts::tui_marker_inactive()
-            };
-            ListItem::new(Line::from(Span::raw(format!(
-                "{marker}  {}",
-                texts::tui_claude_api_format_value(api_format.as_str())
-            ))))
+        .unwrap_or_else(|| {
+            (
+                app.app_type.clone(),
+                crate::cli::tui::form::ClaudeApiFormat::Anthropic,
+            )
         });
+
+    let choices = crate::cli::tui::form::ClaudeApiFormat::choices_for_app(&app_type);
+    let items = choices.into_iter().copied().map(|api_format| {
+        let marker = if api_format == current {
+            texts::tui_marker_active()
+        } else {
+            texts::tui_marker_inactive()
+        };
+        let label = if matches!(app_type, crate::app_config::AppType::Codex) {
+            texts::tui_codex_api_format_value(api_format.as_str())
+        } else {
+            texts::tui_claude_api_format_value(api_format.as_str())
+        };
+        ListItem::new(Line::from(Span::raw(format!("{marker}  {}", label))))
+    });
 
     let list = List::new(items)
         .highlight_style(selection_style(theme))
         .highlight_symbol(highlight_symbol(theme));
 
     let mut state = ListState::default();
-    state.select(Some(
-        selected.min(
-            crate::cli::tui::form::ClaudeApiFormat::ALL
-                .len()
-                .saturating_sub(1),
-        ),
-    ));
+    state.select(Some(selected.min(choices.len().saturating_sub(1))));
     frame.render_stateful_widget(list, body_area, &mut state);
 }
 

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1083,6 +1083,42 @@ pub fn update_codex_config_snippet(
     }
 }
 
+/// Normalize persisted Codex provider config to upstream semantics.
+///
+/// Codex providers should keep `wire_api = "responses"` in the Codex config
+/// TOML. Local Responses <-> Chat routing is controlled by provider
+/// `meta.apiFormat`, not by persisting `wire_api = "chat"`.
+pub fn normalize_codex_config_wire_api_to_responses(config_text: &str) -> String {
+    let mut doc = match config_text.trim().parse::<toml_edit::DocumentMut>() {
+        Ok(doc) => doc,
+        Err(_) => return config_text.to_string(),
+    };
+
+    let mut updated = false;
+    if let Some(provider_key) = active_codex_model_provider_id(&doc) {
+        if let Some(section) = doc
+            .get_mut("model_providers")
+            .and_then(|providers| providers.as_table_like_mut())
+            .and_then(|providers| providers.get_mut(&provider_key))
+            .and_then(|provider| provider.as_table_like_mut())
+        {
+            section.insert("wire_api", toml_edit::value("responses"));
+            updated = true;
+        }
+    }
+
+    if doc.get("wire_api").is_some() {
+        doc["wire_api"] = toml_edit::value("responses");
+        updated = true;
+    }
+
+    if updated {
+        doc.to_string().trim().to_string()
+    } else {
+        config_text.to_string()
+    }
+}
+
 fn non_empty(value: &str) -> Option<&str> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -1146,6 +1182,59 @@ mod tests {
         fn drop(&mut self) {
             let _ = crate::settings::update_settings(self.original.clone());
         }
+    }
+
+    #[test]
+    fn normalize_codex_config_wire_api_updates_active_provider_and_top_level() {
+        let normalized = normalize_codex_config_wire_api_to_responses(
+            r#"model_provider = "vendor"
+wire_api = "chat"
+
+[model_providers.vendor]
+base_url = "https://vendor.example/v1"
+wire_api = "chat"
+
+[model_providers.other]
+base_url = "https://other.example/v1"
+wire_api = "chat"
+"#,
+        );
+
+        let parsed = normalized
+            .parse::<toml_edit::DocumentMut>()
+            .expect("normalized config should stay valid TOML");
+        assert_eq!(parsed["wire_api"].as_str(), Some("responses"));
+        assert_eq!(
+            parsed["model_providers"]["vendor"]["wire_api"].as_str(),
+            Some("responses")
+        );
+        assert_eq!(
+            parsed["model_providers"]["other"]["wire_api"].as_str(),
+            Some("chat"),
+            "inactive providers should be left alone"
+        );
+    }
+
+    #[test]
+    fn normalize_codex_config_wire_api_updates_top_level_only_config() {
+        let normalized = normalize_codex_config_wire_api_to_responses(
+            r#"wire_api = "chat"
+model = "gpt-5.4"
+"#,
+        );
+
+        let parsed = normalized
+            .parse::<toml_edit::DocumentMut>()
+            .expect("normalized config should stay valid TOML");
+        assert_eq!(parsed["wire_api"].as_str(), Some("responses"));
+        assert_eq!(parsed["model"].as_str(), Some("gpt-5.4"));
+    }
+
+    #[test]
+    fn normalize_codex_config_wire_api_preserves_invalid_toml() {
+        let config = "model_provider = ";
+
+        assert_eq!(normalize_codex_config_wire_api_to_responses(config), config);
     }
 
     #[test]

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -122,6 +122,22 @@ impl Provider {
         self.provider_type() == Some("codex_oauth")
     }
 
+    pub fn is_codex_official(&self) -> bool {
+        self.meta
+            .as_ref()
+            .and_then(|meta| meta.codex_official)
+            .unwrap_or(false)
+            || self
+                .category
+                .as_deref()
+                .is_some_and(|value| value.eq_ignore_ascii_case("official"))
+            || self
+                .website_url
+                .as_deref()
+                .is_some_and(|value| value.eq_ignore_ascii_case("https://chatgpt.com/codex"))
+            || self.name.trim().eq_ignore_ascii_case("OpenAI Official")
+    }
+
     pub fn is_github_copilot(&self) -> bool {
         self.provider_type() == Some("github_copilot")
             || self.claude_base_url_contains("githubcopilot.com")
@@ -661,6 +677,35 @@ mod tests {
             ..Default::default()
         });
         assert!(copilot.is_github_copilot());
+    }
+
+    #[test]
+    fn provider_detects_codex_official_identity() {
+        let mut provider = Provider::with_id(
+            "openai".to_string(),
+            "Third Party".to_string(),
+            serde_json::json!({}),
+            None,
+        );
+        assert!(!provider.is_codex_official());
+
+        provider.meta = Some(ProviderMeta {
+            codex_official: Some(true),
+            ..Default::default()
+        });
+        assert!(provider.is_codex_official());
+
+        provider.meta = None;
+        provider.category = Some("Official".to_string());
+        assert!(provider.is_codex_official());
+
+        provider.category = None;
+        provider.website_url = Some("https://chatgpt.com/codex".to_string());
+        assert!(provider.is_codex_official());
+
+        provider.website_url = None;
+        provider.name = "OpenAI Official".to_string();
+        assert!(provider.is_codex_official());
     }
 }
 


### PR DESCRIPTION
## Summary
- expose Codex local routing configuration in the provider TUI instead of requiring raw JSON edits
- add a secondary model-mapping page with row/field editing, model fetching, add/delete support, and upstream-aligned persisted shape
- keep Codex config `wire_api = "responses"` while using provider `meta.apiFormat` for local Chat routing

Closes #168

## Verification
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml provider_codex_local_routing --lib -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml provider_add_form_codex_model_catalog --lib -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml provider_add_form_codex_local_routing --lib -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml codex_api_format --lib -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml normalize_codex_config_wire_api --lib -- --nocapture`
- `cargo check --manifest-path src-tauri/Cargo.toml --lib`
- `git diff --check`