### PR TITLE
feat(tui): add Codex OAuth account manager

### DIFF
--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -3302,6 +3302,14 @@ pub mod texts {
         }
     }
 
+    pub fn tui_key_add_account() -> &'static str {
+        if is_chinese() {
+            "新增账号"
+        } else {
+            "add account"
+        }
+    }
+
     pub fn tui_key_copy() -> &'static str {
         if is_chinese() {
             "复制"
@@ -3579,6 +3587,22 @@ pub mod texts {
             "取消"
         } else {
             "cancel"
+        }
+    }
+
+    pub fn tui_key_cancel_login() -> &'static str {
+        if is_chinese() {
+            "取消登录"
+        } else {
+            "cancel login"
+        }
+    }
+
+    pub fn tui_key_keep_waiting() -> &'static str {
+        if is_chinese() {
+            "继续等待"
+        } else {
+            "keep waiting"
         }
     }
 
@@ -3914,6 +3938,44 @@ pub mod texts {
         }
     }
 
+    pub fn tui_managed_accounts_summary_loading() -> &'static str {
+        if is_chinese() {
+            "ChatGPT · 正在加载"
+        } else {
+            "ChatGPT · loading"
+        }
+    }
+
+    pub fn tui_managed_accounts_summary_not_loaded() -> &'static str {
+        if is_chinese() {
+            "ChatGPT · 未加载"
+        } else {
+            "ChatGPT · not loaded"
+        }
+    }
+
+    pub fn tui_managed_accounts_summary_empty() -> &'static str {
+        if is_chinese() {
+            "ChatGPT · 未认证 · 按 a 新增账号"
+        } else {
+            "ChatGPT · not authenticated · press a to add account"
+        }
+    }
+
+    pub fn tui_managed_accounts_summary_loaded(count: usize, default_account: &str) -> String {
+        if is_chinese() {
+            format!(
+                "ChatGPT · {} · 默认: {default_account}",
+                tui_managed_accounts_count(count)
+            )
+        } else {
+            format!(
+                "ChatGPT · {} · default: {default_account}",
+                tui_managed_accounts_count(count)
+            )
+        }
+    }
+
     pub fn tui_managed_accounts_chatgpt_provider() -> &'static str {
         if is_chinese() {
             "ChatGPT"
@@ -3927,6 +3989,14 @@ pub mod texts {
             "服务"
         } else {
             "Service"
+        }
+    }
+
+    pub fn tui_managed_accounts_list_title() -> &'static str {
+        if is_chinese() {
+            "账号列表"
+        } else {
+            "Accounts"
         }
     }
 
@@ -3986,6 +4056,14 @@ pub mod texts {
         }
     }
 
+    pub fn tui_managed_accounts_authenticated_at_label() -> &'static str {
+        if is_chinese() {
+            "认证时间"
+        } else {
+            "Authenticated At"
+        }
+    }
+
     pub fn tui_managed_accounts_login_with_chatgpt() -> &'static str {
         if is_chinese() {
             "登录 ChatGPT"
@@ -4031,6 +4109,22 @@ pub mod texts {
             "未进行登录。"
         } else {
             "No login in progress."
+        }
+    }
+
+    pub fn tui_confirm_managed_auth_cancel_title() -> &'static str {
+        if is_chinese() {
+            "取消登录？"
+        } else {
+            "Cancel Login?"
+        }
+    }
+
+    pub fn tui_confirm_managed_auth_cancel_message() -> &'static str {
+        if is_chinese() {
+            "当前 ChatGPT 登录流程仍在等待浏览器确认。按 Enter 确认取消，按 Esc 返回继续等待。"
+        } else {
+            "The ChatGPT login flow is still waiting for browser confirmation. Press Enter to cancel, or Esc to keep waiting."
         }
     }
 
@@ -6587,6 +6681,22 @@ pub mod texts {
             "ChatGPT 登录已开始。"
         } else {
             "ChatGPT login started."
+        }
+    }
+
+    pub fn tui_toast_managed_auth_login_in_progress(code: &str, url: &str) -> String {
+        if is_chinese() {
+            format!("ChatGPT 登录中\n代码: {code}\n验证地址: {url}\n按 Esc 取消")
+        } else {
+            format!("ChatGPT login in progress\nCode: {code}\nVerification URL: {url}\nPress Esc to cancel")
+        }
+    }
+
+    pub fn tui_toast_managed_auth_login_cancelled() -> &'static str {
+        if is_chinese() {
+            "ChatGPT 登录已取消。"
+        } else {
+            "ChatGPT login cancelled."
         }
     }
 

--- a/src-tauri/src/cli/tui/app/content_config.rs
+++ b/src-tauri/src/cli/tui/app/content_config.rs
@@ -918,17 +918,65 @@ impl App {
         key: KeyEvent,
         _data: &UiData,
     ) -> Action {
+        let account_count = self.managed_auth_account_count();
         match key.code {
             KeyCode::Up => {
-                self.settings_managed_accounts_idx = 0;
+                self.settings_managed_accounts_idx =
+                    self.settings_managed_accounts_idx.saturating_sub(1);
                 Action::None
             }
             KeyCode::Down => {
-                self.settings_managed_accounts_idx = 0;
+                self.settings_managed_accounts_idx =
+                    (self.settings_managed_accounts_idx + 1).min(account_count.saturating_sub(1));
                 Action::None
             }
+            KeyCode::Char('a') => self.start_managed_account_login(),
+            KeyCode::Char('r') => Action::ManagedAuthRefresh {
+                auth_provider: "codex_oauth".to_string(),
+            },
+            KeyCode::Char(' ') => self.switch_selected_managed_account(),
             KeyCode::Enter => self.activate_managed_account_row(),
             _ => Action::None,
+        }
+    }
+
+    fn managed_auth_account_count(&self) -> usize {
+        self.managed_auth_status
+            .as_ref()
+            .map(|status| status.accounts.len())
+            .unwrap_or(0)
+    }
+
+    fn selected_managed_account(&self) -> Option<&crate::services::ManagedAuthAccount> {
+        let status = self.managed_auth_status.as_ref()?;
+        status.accounts.get(
+            self.settings_managed_accounts_idx
+                .min(status.accounts.len().saturating_sub(1)),
+        )
+    }
+
+    fn start_managed_account_login(&mut self) -> Action {
+        if self.managed_auth_loading || self.managed_auth_login.is_some() {
+            return Action::None;
+        }
+
+        Action::ManagedAuthStartLogin {
+            auth_provider: "codex_oauth".to_string(),
+        }
+    }
+
+    fn switch_selected_managed_account(&mut self) -> Action {
+        if self.managed_auth_loading || self.managed_auth_login.is_some() {
+            return Action::None;
+        }
+
+        let Some(account) = self.selected_managed_account() else {
+            return Action::None;
+        };
+
+        Action::ManagedAuthSetDefault {
+            auth_provider: "codex_oauth".to_string(),
+            account_id: account.id.clone(),
         }
     }
 
@@ -937,18 +985,13 @@ impl App {
             return Action::None;
         }
 
-        let Some(status) = self.managed_auth_status.as_ref() else {
+        if self.managed_auth_status.is_none() {
             return Action::ManagedAuthRefresh {
                 auth_provider: "codex_oauth".to_string(),
             };
-        };
+        }
 
-        if let Some(account) = status
-            .accounts
-            .iter()
-            .find(|account| account.is_default)
-            .or_else(|| status.accounts.first())
-        {
+        if let Some(account) = self.selected_managed_account() {
             self.overlay = Overlay::ManagedAccountActionPicker {
                 auth_provider: "codex_oauth".to_string(),
                 account_id: account.id.clone(),

--- a/src-tauri/src/cli/tui/app/menu.rs
+++ b/src-tauri/src/cli/tui/app/menu.rs
@@ -254,10 +254,10 @@ impl App {
         self.tick = self.tick.wrapping_add(1);
         self.expire_managed_auth_login_if_needed();
         if let Some(toast) = &mut self.toast {
-            if toast.remaining_ticks > 0 {
+            if !toast.persistent && toast.remaining_ticks > 0 {
                 toast.remaining_ticks -= 1;
             }
-            if toast.remaining_ticks == 0 {
+            if !toast.persistent && toast.remaining_ticks == 0 {
                 self.toast = None;
             }
         }
@@ -279,6 +279,7 @@ impl App {
 
         self.managed_auth_login = None;
         self.managed_auth_loading = false;
+        self.clear_managed_auth_cancel_confirm();
         self.push_toast(
             texts::tui_toast_managed_auth_login_expired(),
             ToastKind::Warning,
@@ -366,6 +367,47 @@ impl App {
 
     pub fn push_toast(&mut self, message: impl Into<String>, kind: ToastKind) {
         self.toast = Some(Toast::new(message, kind));
+    }
+
+    pub fn push_persistent_toast(&mut self, message: impl Into<String>, kind: ToastKind) {
+        self.toast = Some(Toast::persistent(message, kind));
+    }
+
+    pub(crate) fn clear_managed_auth_login_toast(&mut self) {
+        if self.toast.as_ref().is_some_and(|toast| toast.persistent) {
+            self.toast = None;
+        }
+    }
+
+    pub(crate) fn clear_managed_auth_cancel_confirm(&mut self) {
+        if matches!(
+            &self.overlay,
+            Overlay::Confirm(ConfirmOverlay {
+                action: ConfirmAction::ManagedAuthCancelLogin,
+                ..
+            })
+        ) {
+            self.close_overlay();
+        }
+    }
+
+    pub(crate) fn cancel_managed_auth_login(&mut self) {
+        if self.managed_auth_login.take().is_some() {
+            self.managed_auth_loading = false;
+            self.clear_managed_auth_login_toast();
+            self.push_toast(
+                texts::tui_toast_managed_auth_login_cancelled(),
+                ToastKind::Info,
+            );
+        }
+    }
+
+    fn confirm_managed_auth_login_cancel(&mut self) {
+        self.overlay = Overlay::Confirm(ConfirmOverlay {
+            title: texts::tui_confirm_managed_auth_cancel_title().to_string(),
+            message: texts::tui_confirm_managed_auth_cancel_message().to_string(),
+            action: ConfirmAction::ManagedAuthCancelLogin,
+        });
     }
 
     pub(crate) fn prompt_visible_apps_auto_detection(&mut self) {
@@ -482,6 +524,15 @@ impl App {
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
             self.should_quit = true;
             return Action::Quit;
+        }
+
+        if self.managed_auth_login.is_some()
+            && !self.overlay.is_active()
+            && !self.text_input_is_active()
+            && matches!(key.code, KeyCode::Esc)
+        {
+            self.confirm_managed_auth_login_cancel();
+            return Action::None;
         }
 
         if key.modifiers.contains(KeyModifiers::CONTROL)

--- a/src-tauri/src/cli/tui/app/overlay_handlers/dialogs.rs
+++ b/src-tauri/src/cli/tui/app/overlay_handlers/dialogs.rs
@@ -88,6 +88,10 @@ impl App {
                     ConfirmAction::ProviderApiFormatProxyNotice => Action::None,
                     ConfirmAction::CommonConfigNotice => Action::ConfirmCommonConfigNotice,
                     ConfirmAction::UsageQueryNotice => Action::ConfirmUsageQueryNotice,
+                    ConfirmAction::ManagedAuthCancelLogin => {
+                        self.cancel_managed_auth_login();
+                        Action::None
+                    }
                     ConfirmAction::ProxyEnableAndAutoFailover { app_type } => {
                         Action::EnableProxyAndAutoFailover {
                             app_type: app_type.clone(),

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -19,7 +19,9 @@ mod tests {
     use crate::cli::tui::runtime_actions::{
         handle_action, run_external_editor_for_prompt_form_content,
     };
-    use crate::cli::tui::runtime_systems::RequestTracker;
+    use crate::cli::tui::runtime_systems::{
+        handle_managed_auth_msg, ManagedAuthMsg, RequestTracker,
+    };
     use crate::cli::tui::terminal::TuiTerminal;
     use crate::commands::workspace::{DailyMemoryFileInfo, DailyMemorySearchResult, ALLOWED_FILES};
     use crate::error::AppError;
@@ -99,6 +101,17 @@ mod tests {
                     is_default: false,
                 },
             ],
+        }
+    }
+
+    fn managed_auth_device() -> crate::services::ManagedAuthDeviceCodeResponse {
+        crate::services::ManagedAuthDeviceCodeResponse {
+            provider: "codex_oauth".to_string(),
+            device_code: "device-1".to_string(),
+            user_code: "USER-1".to_string(),
+            verification_uri: "https://auth.example.test/device".to_string(),
+            expires_in: 900,
+            interval: 5,
         }
     }
 
@@ -9350,7 +9363,7 @@ mod tests {
     }
 
     #[test]
-    fn settings_managed_accounts_page_uses_single_chatgpt_entry() {
+    fn settings_managed_accounts_page_supports_multi_account_actions() {
         let mut app = App::new(Some(AppType::Claude));
         app.route = Route::SettingsManagedAccounts;
         app.focus = Focus::Content;
@@ -9372,11 +9385,26 @@ mod tests {
             Action::ManagedAuthStartLogin { auth_provider } if auth_provider == "codex_oauth"
         ));
 
+        let action = app.on_key(key(KeyCode::Char('a')), &UiData::default());
+        assert!(matches!(
+            action,
+            Action::ManagedAuthStartLogin { auth_provider } if auth_provider == "codex_oauth"
+        ));
+
         app.managed_auth_status = Some(managed_auth_status());
         app.settings_managed_accounts_idx = 0;
         let action = app.on_key(key(KeyCode::Down), &UiData::default());
         assert!(matches!(action, Action::None));
-        assert_eq!(app.settings_managed_accounts_idx, 0);
+        assert_eq!(app.settings_managed_accounts_idx, 1);
+
+        let action = app.on_key(key(KeyCode::Char(' ')), &UiData::default());
+        assert!(matches!(
+            action,
+            Action::ManagedAuthSetDefault {
+                auth_provider,
+                account_id,
+            } if auth_provider == "codex_oauth" && account_id == "acc-alt"
+        ));
 
         let action = app.on_key(key(KeyCode::Enter), &UiData::default());
         assert!(matches!(action, Action::None));
@@ -9386,8 +9414,84 @@ mod tests {
                 auth_provider,
                 account_id,
                 selected: 0,
-            } if auth_provider == "codex_oauth" && account_id == "acc-default"
+            } if auth_provider == "codex_oauth" && account_id == "acc-alt"
         ));
+    }
+
+    #[test]
+    fn managed_auth_login_uses_toast_and_esc_confirmation() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::SettingsManagedAccounts;
+        app.focus = Focus::Content;
+
+        handle_managed_auth_msg(
+            &mut app,
+            ManagedAuthMsg::LoginStarted {
+                auth_provider: "codex_oauth".to_string(),
+                result: Ok(managed_auth_device()),
+            },
+        );
+
+        let toast = app.toast.as_ref().expect("login toast");
+        assert!(toast.persistent);
+        assert!(toast.message.contains("USER-1"), "{}", toast.message);
+        assert!(
+            toast.message.contains("Press Esc to cancel"),
+            "{}",
+            toast.message
+        );
+        assert!(!toast.message.contains("Esc/c"), "{}", toast.message);
+
+        let action = app.on_key(key(KeyCode::Char('c')), &UiData::default());
+        assert!(matches!(action, Action::None));
+        assert!(app.managed_auth_login.is_some());
+        assert!(matches!(app.overlay, Overlay::None));
+
+        let action = app.on_key(key(KeyCode::Esc), &UiData::default());
+        assert!(matches!(action, Action::None));
+        assert!(app.managed_auth_login.is_some());
+        assert!(matches!(
+            app.overlay,
+            Overlay::Confirm(ConfirmOverlay {
+                action: ConfirmAction::ManagedAuthCancelLogin,
+                ..
+            })
+        ));
+
+        let action = app.on_key(key(KeyCode::Esc), &UiData::default());
+        assert!(matches!(action, Action::None));
+        assert!(app.managed_auth_login.is_some());
+        assert!(matches!(app.overlay, Overlay::None));
+
+        let action = app.on_key(key(KeyCode::Esc), &UiData::default());
+        assert!(matches!(action, Action::None));
+        let action = app.on_key(key(KeyCode::Enter), &UiData::default());
+        assert!(matches!(action, Action::None));
+        assert!(app.managed_auth_login.is_none());
+        assert!(matches!(app.overlay, Overlay::None));
+        assert!(matches!(
+            app.toast.as_ref(),
+            Some(toast)
+                if !toast.persistent
+                    && toast.message == texts::tui_toast_managed_auth_login_cancelled()
+        ));
+
+        handle_managed_auth_msg(
+            &mut app,
+            ManagedAuthMsg::LoginPolled {
+                auth_provider: "codex_oauth".to_string(),
+                device_code: "device-1".to_string(),
+                result: Ok(Some(crate::services::ManagedAuthAccount {
+                    id: "acc-new".to_string(),
+                    provider: "codex_oauth".to_string(),
+                    login: "new@example.com".to_string(),
+                    avatar_url: None,
+                    authenticated_at: 3,
+                    is_default: true,
+                })),
+            },
+        );
+        assert!(app.managed_auth_status.is_none());
     }
 
     #[test]

--- a/src-tauri/src/cli/tui/app/types.rs
+++ b/src-tauri/src/cli/tui/app/types.rs
@@ -376,6 +376,7 @@ pub struct Toast {
     pub message: String,
     pub kind: ToastKind,
     pub remaining_ticks: u16,
+    pub persistent: bool,
 }
 
 impl Toast {
@@ -384,6 +385,16 @@ impl Toast {
             message: message.into(),
             kind,
             remaining_ticks: 12,
+            persistent: false,
+        }
+    }
+
+    pub fn persistent(message: impl Into<String>, kind: ToastKind) -> Self {
+        Self {
+            message: message.into(),
+            kind,
+            remaining_ticks: 0,
+            persistent: true,
         }
     }
 }
@@ -443,6 +454,7 @@ pub enum ConfirmAction {
     ProviderApiFormatProxyNotice,
     CommonConfigNotice,
     UsageQueryNotice,
+    ManagedAuthCancelLogin,
     ProxyEnableAndAutoFailover {
         app_type: AppType,
     },
@@ -537,8 +549,6 @@ pub enum CommonSnippetViewSource {
 pub struct ManagedAuthLoginState {
     pub auth_provider: String,
     pub device_code: String,
-    pub user_code: String,
-    pub verification_uri: String,
     pub expires_at_tick: u64,
     pub poll_interval_ticks: u64,
     pub next_poll_tick: u64,

--- a/src-tauri/src/cli/tui/runtime_systems/handlers.rs
+++ b/src-tauri/src/cli/tui/runtime_systems/handlers.rs
@@ -301,22 +301,27 @@ pub(crate) fn handle_managed_auth_msg(app: &mut App, msg: ManagedAuthMsg) {
                     let now = app.tick;
                     let expires_ticks = seconds_to_tui_ticks(device.expires_in).max(1);
                     let interval_ticks = seconds_to_tui_ticks(device.interval).max(1);
+                    let user_code = device.user_code.clone();
+                    let verification_uri = device.verification_uri.clone();
                     app.managed_auth_login = Some(crate::cli::tui::app::ManagedAuthLoginState {
                         auth_provider,
                         device_code: device.device_code,
-                        user_code: device.user_code,
-                        verification_uri: device.verification_uri,
                         expires_at_tick: now.saturating_add(expires_ticks),
                         poll_interval_ticks: interval_ticks,
                         next_poll_tick: now,
                     });
-                    app.push_toast(
-                        texts::tui_toast_managed_auth_login_started(),
+                    app.push_persistent_toast(
+                        texts::tui_toast_managed_auth_login_in_progress(
+                            &user_code,
+                            &verification_uri,
+                        ),
                         ToastKind::Info,
                     );
                 }
                 Err(err) => {
                     app.managed_auth_login = None;
+                    app.clear_managed_auth_login_toast();
+                    app.clear_managed_auth_cancel_confirm();
                     app.push_toast(
                         texts::tui_toast_managed_auth_login_failed(&err),
                         ToastKind::Error,
@@ -330,14 +335,17 @@ pub(crate) fn handle_managed_auth_msg(app: &mut App, msg: ManagedAuthMsg) {
             result,
         } => match result {
             Ok(Some(account)) => {
-                if app
+                if !app
                     .managed_auth_login
                     .as_ref()
                     .is_some_and(|login| login.device_code == device_code)
                 {
-                    app.managed_auth_login = None;
+                    return;
                 }
+                app.managed_auth_login = None;
                 app.managed_auth_loading = false;
+                app.clear_managed_auth_login_toast();
+                app.clear_managed_auth_cancel_confirm();
                 if let Some(status) = app.managed_auth_status.as_mut() {
                     if status.provider == auth_provider {
                         status.authenticated = true;
@@ -356,6 +364,7 @@ pub(crate) fn handle_managed_auth_msg(app: &mut App, msg: ManagedAuthMsg) {
                         accounts: vec![account.clone()],
                     });
                 }
+                app.settings_managed_accounts_idx = 0;
                 app.push_toast(
                     texts::tui_toast_managed_auth_login_finished(&account.login),
                     ToastKind::Success,
@@ -363,14 +372,17 @@ pub(crate) fn handle_managed_auth_msg(app: &mut App, msg: ManagedAuthMsg) {
             }
             Ok(None) => {}
             Err(err) => {
-                if app
+                if !app
                     .managed_auth_login
                     .as_ref()
                     .is_some_and(|login| login.device_code == device_code)
                 {
-                    app.managed_auth_login = None;
+                    return;
                 }
+                app.managed_auth_login = None;
                 app.managed_auth_loading = false;
+                app.clear_managed_auth_login_toast();
+                app.clear_managed_auth_cancel_confirm();
                 app.push_toast(
                     texts::tui_toast_managed_auth_login_failed(&err),
                     ToastKind::Error,

--- a/src-tauri/src/cli/tui/runtime_systems/mod.rs
+++ b/src-tauri/src/cli/tui/runtime_systems/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use handlers::{
 #[cfg(test)]
 pub(crate) use types::{
     build_model_fetch_candidate_urls, model_fetch_strategy_for_field,
-    parse_model_ids_from_response, UpdateMsg,
+    parse_model_ids_from_response, ManagedAuthMsg, UpdateMsg,
 };
 pub(crate) use types::{
     build_stream_check_result_lines, fetch_provider_models_for_tui, ModelFetchStrategy,

--- a/src-tauri/src/cli/tui/ui.rs
+++ b/src-tauri/src/cli/tui/ui.rs
@@ -102,8 +102,13 @@ pub fn render(frame: &mut Frame<'_>, app: &App, data: &UiData) {
     render_content(frame, app, data, body[1], &theme);
     render_footer(frame, app, data, root[2], &theme);
 
-    render_overlay(frame, app, data, &theme);
-    render_toast(frame, app, &theme);
+    if should_render_toast_below_overlay(app) {
+        render_toast(frame, app, &theme);
+        render_overlay(frame, app, data, &theme);
+    } else {
+        render_overlay(frame, app, data, &theme);
+        render_toast(frame, app, &theme);
+    }
 }
 
 pub(super) fn proxy_open_flash_effect(area: Rect) -> tachyonfx::Effect {
@@ -115,6 +120,15 @@ pub(super) fn proxy_open_flash_effect(area: Rect) -> tachyonfx::Effect {
         .with_area(area);
 
     fx::ping_pong(radial_hsl_xform)
+}
+
+fn should_render_toast_below_overlay(app: &App) -> bool {
+    app.toast.as_ref().is_some_and(|toast| toast.persistent)
+        && matches!(
+            &app.overlay,
+            Overlay::Confirm(confirm)
+                if matches!(confirm.action, ConfirmAction::ManagedAuthCancelLogin)
+        )
 }
 
 fn render_content(

--- a/src-tauri/src/cli/tui/ui/chrome.rs
+++ b/src-tauri/src/cli/tui/ui/chrome.rs
@@ -489,9 +489,12 @@ pub(super) fn toast_rect(content_area: Rect, message: &str) -> Rect {
         .max(1)
         .min(TOAST_MAX_WIDTH);
     let min_width = TOAST_MIN_WIDTH.min(max_width);
-    let width = (UnicodeWidthStr::width(message) as u16)
-        .saturating_add(8)
-        .clamp(min_width, max_width);
+    let content_width = message
+        .lines()
+        .map(UnicodeWidthStr::width)
+        .max()
+        .unwrap_or(0) as u16;
+    let width = content_width.saturating_add(8).clamp(min_width, max_width);
 
     let inner_width = width.saturating_sub(2).max(1);
     let wrapped_lines = wrap_message_lines(message, inner_width).len() as u16;

--- a/src-tauri/src/cli/tui/ui/config.rs
+++ b/src-tauri/src/cli/tui/ui/config.rs
@@ -2657,58 +2657,232 @@ pub(super) fn render_settings_managed_accounts(
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Min(0)])
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Min(0),
+        ])
         .split(inner);
 
     if app.focus == Focus::Content {
-        let key_label = managed_account_enter_label(app);
-        render_key_bar_center(frame, chunks[0], theme, &[("Enter", key_label)]);
+        let keys = managed_account_key_items(app);
+        render_key_bar_center(frame, chunks[0], theme, &keys);
     }
+
+    render_summary_bar(frame, chunks[1], theme, managed_accounts_page_summary(app));
 
     let columns = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(28), Constraint::Min(0)])
-        .split(chunks[1]);
+        .constraints([Constraint::Percentage(44), Constraint::Percentage(56)])
+        .split(chunks[2]);
 
-    render_managed_account_services(frame, inset_left(columns[0], CONTENT_INSET_LEFT), theme);
+    render_managed_account_list(frame, app, columns[0], theme);
     render_managed_account_details(frame, app, columns[1], theme);
 }
 
-fn managed_account_enter_label(app: &App) -> &'static str {
-    if app.managed_auth_loading || app.managed_auth_login.is_some() {
-        return texts::tui_loading();
+fn managed_accounts_page_summary(app: &App) -> String {
+    if app.managed_auth_loading {
+        return texts::tui_managed_accounts_summary_loading().to_string();
     }
 
     let Some(status) = app.managed_auth_status.as_ref() else {
-        return texts::tui_key_refresh();
+        return texts::tui_managed_accounts_summary_not_loaded().to_string();
     };
 
-    if primary_managed_account(status).is_some() {
-        texts::tui_key_open()
-    } else {
-        texts::tui_key_login()
+    if status.accounts.is_empty() {
+        return texts::tui_managed_accounts_summary_empty().to_string();
     }
+
+    let default_account = status
+        .default_account_id
+        .as_ref()
+        .and_then(|default_id| {
+            status
+                .accounts
+                .iter()
+                .find(|account| &account.id == default_id)
+                .map(|account| account.login.as_str())
+        })
+        .or_else(|| {
+            status
+                .accounts
+                .iter()
+                .find(|account| account.is_default)
+                .map(|account| account.login.as_str())
+        })
+        .unwrap_or_else(|| texts::none());
+
+    texts::tui_managed_accounts_summary_loaded(status.accounts.len(), default_account)
 }
 
-fn render_managed_account_services(frame: &mut Frame<'_>, area: Rect, theme: &super::theme::Theme) {
-    let header = Row::new(vec![Cell::from(
-        texts::tui_managed_accounts_provider_column(),
-    )])
-    .style(Style::default().fg(theme.dim).add_modifier(Modifier::BOLD));
+fn managed_account_key_items(app: &App) -> Vec<(&'static str, &'static str)> {
+    if app.managed_auth_login.is_some() {
+        return vec![("Esc", texts::tui_key_cancel())];
+    }
 
-    let rows = [Row::new(vec![Cell::from(
-        texts::tui_managed_accounts_chatgpt_provider(),
-    )])];
+    let mut items = vec![
+        ("a", texts::tui_key_add_account()),
+        ("r", texts::tui_key_refresh()),
+    ];
 
-    let table = Table::new(rows, [Constraint::Min(10)])
-        .header(header)
-        .block(Block::default().borders(Borders::NONE))
-        .row_highlight_style(selection_style(theme))
+    if app.managed_auth_loading {
+        return items;
+    }
+
+    match app.managed_auth_status.as_ref() {
+        None => items.push(("Enter", texts::tui_key_refresh())),
+        Some(status) if status.accounts.is_empty() => {
+            items.push(("Enter", texts::tui_key_add_account()));
+        }
+        Some(_) => {
+            items.push(("Space", texts::tui_key_switch()));
+            items.push(("Enter", texts::tui_key_open()));
+        }
+    }
+
+    items
+}
+
+fn render_managed_account_list(
+    frame: &mut Frame<'_>,
+    app: &App,
+    area: Rect,
+    theme: &super::theme::Theme,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(if app.focus == Focus::Content {
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.dim)
+        })
+        .title(texts::tui_managed_accounts_list_title());
+    frame.render_widget(block.clone(), area);
+    let inner = inset_left(block.inner(area), CONTENT_INSET_LEFT);
+
+    let status = app.managed_auth_status.as_ref();
+    if app.managed_auth_loading && status.is_none() {
+        render_managed_account_list_state(frame, inner, texts::tui_loading(), theme);
+        return;
+    }
+
+    let Some(status) = status else {
+        render_managed_account_list_state(
+            frame,
+            inner,
+            texts::tui_managed_accounts_not_loaded(),
+            theme,
+        );
+        return;
+    };
+
+    if status.accounts.is_empty() {
+        render_managed_account_list_state(
+            frame,
+            inner,
+            texts::tui_managed_accounts_not_authenticated(),
+            theme,
+        );
+        return;
+    }
+
+    let width = inner.width.saturating_sub(1);
+    let items = status
+        .accounts
+        .iter()
+        .map(|account| managed_account_list_item(account, width, theme));
+
+    let list = List::new(items)
+        .highlight_style(selection_style(theme))
         .highlight_symbol(highlight_symbol(theme));
 
-    let mut state = TableState::default();
-    state.select(Some(0));
-    frame.render_stateful_widget(table, area, &mut state);
+    let mut state = ListState::default();
+    state.select(Some(app.settings_managed_accounts_idx));
+    frame.render_stateful_widget(list, inner, &mut state);
+}
+
+fn render_managed_account_list_state(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    text: &'static str,
+    theme: &super::theme::Theme,
+) {
+    frame.render_widget(
+        Paragraph::new(Line::styled(text, Style::default().fg(theme.comment)))
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn managed_account_list_item(
+    account: &crate::services::ManagedAuthAccount,
+    width: u16,
+    theme: &super::theme::Theme,
+) -> ListItem<'static> {
+    let marker_style = if account.is_default {
+        Style::default()
+            .fg(theme.accent)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.dim)
+    };
+    let login_style = Style::default().add_modifier(Modifier::BOLD);
+    let default_label = texts::tui_managed_accounts_default();
+    let default_chip_width = UnicodeWidthStr::width(default_label) as u16 + 2;
+    let login_width = if account.is_default {
+        width
+            .saturating_sub(default_chip_width)
+            .saturating_sub(5)
+            .max(4)
+    } else {
+        width.saturating_sub(3).max(4)
+    };
+    let meta_width = width.saturating_sub(3).max(4);
+    let account_id = truncate_to_display_width(&account.id, meta_width.saturating_sub(12));
+    let meta = truncate_to_display_width(
+        &format!(
+            "{} · {} · {} {account_id}",
+            texts::tui_managed_accounts_chatgpt_provider(),
+            texts::tui_managed_accounts_authenticated(),
+            texts::tui_label_id()
+        ),
+        meta_width,
+    );
+
+    let mut title_spans = vec![
+        Span::styled(
+            if account.is_default {
+                texts::tui_marker_active()
+            } else {
+                texts::tui_marker_inactive()
+            },
+            marker_style,
+        ),
+        Span::raw("  "),
+        Span::styled(
+            truncate_to_display_width(&account.login, login_width),
+            login_style,
+        ),
+    ];
+    if account.is_default {
+        title_spans.push(Span::raw("  "));
+        title_spans.push(Span::styled(
+            format!(" {default_label} "),
+            active_chip_style(theme),
+        ));
+    }
+
+    ListItem::new(vec![
+        Line::from(title_spans),
+        Line::from(vec![
+            Span::raw("   "),
+            Span::styled(meta, Style::default().fg(theme.comment)),
+        ]),
+    ])
 }
 
 fn render_managed_account_details(
@@ -2717,13 +2891,7 @@ fn render_managed_account_details(
     area: Rect,
     theme: &super::theme::Theme,
 ) {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(area);
-
-    render_managed_account_detail_panel(frame, app, chunks[0], theme);
-    render_managed_auth_login_panel(frame, app, chunks[1], theme);
+    render_managed_account_detail_panel(frame, app, area, theme);
 }
 
 fn render_managed_account_detail_panel(
@@ -2740,72 +2908,182 @@ fn render_managed_account_detail_panel(
     frame.render_widget(block.clone(), area);
     let inner = inset_left(block.inner(area), CONTENT_INSET_LEFT);
 
-    let rows_data = managed_account_detail_rows(app);
-    let label_col_width =
-        field_label_column_width(rows_data.iter().map(|(label, _value)| label.as_str()), 0);
-    let rows = rows_data
-        .iter()
-        .map(|(label, value)| Row::new(vec![Cell::from(label.clone()), Cell::from(value.clone())]));
-
-    let table = Table::new(
-        rows,
-        [Constraint::Length(label_col_width), Constraint::Min(10)],
-    )
-    .block(Block::default().borders(Borders::NONE));
-    frame.render_widget(table, inner);
+    frame.render_widget(
+        Paragraph::new(managed_account_detail_lines(app, theme)).wrap(Wrap { trim: false }),
+        inner,
+    );
 }
 
-fn managed_account_detail_rows(app: &App) -> Vec<(String, String)> {
-    let mut rows = vec![(
-        texts::tui_managed_accounts_provider_column().to_string(),
-        texts::tui_managed_accounts_chatgpt_provider().to_string(),
-    )];
+fn managed_account_detail_lines(app: &App, theme: &super::theme::Theme) -> Vec<Line<'static>> {
+    let label_width = managed_account_detail_label_width();
+    let mut lines = Vec::new();
 
     if app.managed_auth_loading {
-        rows.push((
-            texts::tui_managed_accounts_auth_status_label().to_string(),
+        lines.push(managed_account_detail_field(
+            texts::tui_managed_accounts_auth_status_label(),
             texts::tui_loading().to_string(),
+            Style::default().fg(theme.comment),
+            label_width,
+            theme,
         ));
-        return rows;
+        return lines;
     }
 
     let Some(status) = app.managed_auth_status.as_ref() else {
-        rows.push((
-            texts::tui_managed_accounts_auth_status_label().to_string(),
+        lines.push(managed_account_detail_field(
+            texts::tui_managed_accounts_auth_status_label(),
             texts::tui_managed_accounts_not_loaded().to_string(),
+            Style::default().fg(theme.comment),
+            label_width,
+            theme,
         ));
-        return rows;
+        return lines;
     };
 
-    let Some(account) = primary_managed_account(status) else {
-        rows.push((
-            texts::tui_managed_accounts_auth_status_label().to_string(),
+    let default_account = status
+        .default_account_id
+        .as_ref()
+        .and_then(|default_id| {
+            status
+                .accounts
+                .iter()
+                .find(|account| &account.id == default_id)
+                .map(|account| account.login.clone())
+        })
+        .unwrap_or_else(|| texts::none().to_string());
+
+    let Some(account) = selected_managed_account(app, status) else {
+        lines.push(managed_account_detail_field(
+            texts::tui_managed_accounts_default_account_label(),
+            default_account,
+            Style::default(),
+            label_width,
+            theme,
+        ));
+        lines.push(managed_account_detail_field(
+            texts::tui_managed_accounts_account_label(),
+            texts::tui_managed_accounts_count(status.accounts.len()),
+            Style::default(),
+            label_width,
+            theme,
+        ));
+        lines.push(managed_account_detail_field(
+            texts::tui_managed_accounts_auth_status_label(),
             texts::tui_managed_accounts_not_authenticated().to_string(),
+            Style::default().fg(theme.comment),
+            label_width,
+            theme,
         ));
-        return rows;
+        return lines;
     };
 
-    rows.push((
-        texts::tui_managed_accounts_auth_status_label().to_string(),
-        texts::tui_managed_accounts_authenticated().to_string(),
+    lines.push(Line::from(vec![
+        Span::styled(
+            account.login.clone(),
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            if account.is_default {
+                format!(" {} ", texts::tui_managed_accounts_default())
+            } else {
+                format!(" {} ", texts::tui_managed_accounts_authenticated())
+            },
+            if account.is_default {
+                active_chip_style(theme)
+            } else {
+                inactive_chip_style(theme)
+            },
+        ),
+    ]));
+    lines.push(Line::raw(""));
+    lines.push(managed_account_detail_field(
+        texts::tui_managed_accounts_provider_column(),
+        texts::tui_managed_accounts_chatgpt_provider().to_string(),
+        Style::default(),
+        label_width,
+        theme,
     ));
-    rows.push((
-        texts::tui_managed_accounts_account_label().to_string(),
-        account.login.clone(),
+    lines.push(managed_account_detail_field(
+        texts::tui_managed_accounts_default_account_label(),
+        default_account,
+        Style::default(),
+        label_width,
+        theme,
     ));
-    rows.push((
-        texts::tui_managed_accounts_account_id_label().to_string(),
+    lines.push(managed_account_detail_field(
+        texts::tui_managed_accounts_account_label(),
+        texts::tui_managed_accounts_count(status.accounts.len()),
+        Style::default(),
+        label_width,
+        theme,
+    ));
+    lines.push(Line::raw(""));
+    lines.push(managed_account_detail_field(
+        texts::tui_managed_accounts_account_id_label(),
         account.id.clone(),
+        Style::default().fg(theme.comment),
+        label_width,
+        theme,
     ));
-    rows.push((
-        texts::tui_managed_accounts_default_account_label().to_string(),
-        if account.is_default {
-            texts::tui_managed_accounts_default().to_string()
-        } else {
-            texts::none().to_string()
-        },
+    lines.push(managed_account_detail_field(
+        texts::tui_managed_accounts_authenticated_at_label(),
+        format_managed_account_authenticated_at(account.authenticated_at),
+        Style::default().fg(theme.comment),
+        label_width,
+        theme,
     ));
-    rows
+    lines
+}
+
+fn managed_account_detail_label_width() -> usize {
+    [
+        texts::tui_managed_accounts_provider_column(),
+        texts::tui_managed_accounts_default_account_label(),
+        texts::tui_managed_accounts_account_label(),
+        texts::tui_managed_accounts_auth_status_label(),
+        texts::tui_managed_accounts_account_id_label(),
+        texts::tui_managed_accounts_authenticated_at_label(),
+    ]
+    .into_iter()
+    .map(UnicodeWidthStr::width)
+    .max()
+    .unwrap_or(0)
+}
+
+fn managed_account_detail_field(
+    label: &'static str,
+    value: String,
+    value_style: Style,
+    label_width: usize,
+    theme: &super::theme::Theme,
+) -> Line<'static> {
+    kv_line(
+        theme,
+        label,
+        label_width,
+        vec![Span::styled(value, value_style)],
+    )
+}
+
+fn format_managed_account_authenticated_at(timestamp: i64) -> String {
+    if timestamp <= 0 {
+        return texts::tui_na().to_string();
+    }
+
+    format_sync_time_local_to_minute(timestamp).unwrap_or_else(|| texts::tui_na().to_string())
+}
+
+fn selected_managed_account<'a>(
+    app: &App,
+    status: &'a crate::services::ManagedAuthStatus,
+) -> Option<&'a crate::services::ManagedAuthAccount> {
+    status.accounts.get(
+        app.settings_managed_accounts_idx
+            .min(status.accounts.len().saturating_sub(1)),
+    )
 }
 
 fn primary_managed_account(
@@ -2816,40 +3094,6 @@ fn primary_managed_account(
         .iter()
         .find(|account| account.is_default)
         .or_else(|| status.accounts.first())
-}
-
-fn render_managed_auth_login_panel(
-    frame: &mut Frame<'_>,
-    app: &App,
-    area: Rect,
-    theme: &super::theme::Theme,
-) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_type(BorderType::Plain)
-        .border_style(Style::default().fg(theme.dim))
-        .title(texts::tui_managed_accounts_login_status());
-    frame.render_widget(block.clone(), area);
-    let inner = block.inner(area);
-
-    let lines = if let Some(login) = app.managed_auth_login.as_ref() {
-        vec![
-            Line::raw(texts::tui_managed_accounts_login_waiting()),
-            Line::raw(texts::tui_managed_accounts_user_code(&login.user_code)),
-            Line::raw(texts::tui_managed_accounts_verification_url(
-                &login.verification_uri,
-            )),
-        ]
-    } else if app.managed_auth_loading {
-        vec![Line::raw(texts::tui_loading())]
-    } else {
-        vec![Line::styled(
-            texts::tui_managed_accounts_login_idle(),
-            Style::default().fg(theme.dim),
-        )]
-    };
-
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
 }
 
 pub(super) fn render_settings_proxy(

--- a/src-tauri/src/cli/tui/ui/overlay/basic.rs
+++ b/src-tauri/src/cli/tui/ui/overlay/basic.rs
@@ -130,6 +130,16 @@ pub(super) fn render_confirm_overlay(
             theme,
             &[("Enter", texts::tui_key_close())],
         );
+    } else if matches!(confirm.action, ConfirmAction::ManagedAuthCancelLogin) {
+        render_key_bar_center(
+            frame,
+            chunks[0],
+            theme,
+            &[
+                ("Enter", texts::tui_key_cancel_login()),
+                ("Esc", texts::tui_key_keep_waiting()),
+            ],
+        );
     } else {
         render_key_bar_center(
             frame,

--- a/src-tauri/src/cli/tui/ui/tests.rs
+++ b/src-tauri/src/cli/tui/ui/tests.rs
@@ -2080,7 +2080,7 @@ fn settings_page_shows_managed_accounts_summary() {
 }
 
 #[test]
-fn settings_managed_accounts_page_renders_chatgpt_left_and_details_right() {
+fn settings_managed_accounts_page_renders_multi_account_manager() {
     let _lock = lock_env();
     let _lang = use_test_language(Language::English);
     let _no_color = EnvGuard::remove("NO_COLOR");
@@ -2113,13 +2113,135 @@ fn settings_managed_accounts_page_renders_chatgpt_left_and_details_right() {
         "{all}"
     );
     assert!(all.contains("default@example.com"), "{all}");
-    assert!(!all.contains("alt@example.com"), "{all}");
+    assert!(all.contains("alt@example.com"), "{all}");
     assert!(all.contains("acc-default"), "{all}");
     assert!(all.contains(texts::tui_managed_accounts_default()), "{all}");
+    assert!(all.contains(texts::tui_key_add_account()), "{all}");
+    assert!(all.contains(texts::tui_key_switch()), "{all}");
     assert!(
-        all.contains(texts::tui_managed_accounts_login_idle()),
+        !all.contains(texts::tui_managed_accounts_login_status()),
         "{all}"
     );
+    assert!(
+        !all.contains(texts::tui_managed_accounts_login_waiting()),
+        "{all}"
+    );
+    assert!(
+        !all.contains(texts::tui_managed_accounts_login_idle()),
+        "{all}"
+    );
+}
+
+#[test]
+fn settings_managed_accounts_login_renders_only_toast() {
+    let _lock = lock_env();
+    let _lang = use_test_language(Language::English);
+    let _no_color = EnvGuard::remove("NO_COLOR");
+
+    let mut app = App::new(Some(AppType::Claude));
+    app.route = Route::SettingsManagedAccounts;
+    app.focus = Focus::Content;
+    app.managed_auth_login = Some(crate::cli::tui::app::ManagedAuthLoginState {
+        auth_provider: "codex_oauth".to_string(),
+        device_code: "device-1".to_string(),
+        expires_at_tick: 900,
+        poll_interval_ticks: 5,
+        next_poll_tick: 0,
+    });
+    app.push_persistent_toast(
+        texts::tui_toast_managed_auth_login_in_progress(
+            "USER-1",
+            "https://auth.example.test/device",
+        ),
+        crate::cli::tui::app::ToastKind::Info,
+    );
+
+    let buf = render(&app, &minimal_data(&app.app_type));
+    let all = all_text(&buf);
+
+    let rows = (0..buf.area.height)
+        .map(|y| line_at(&buf, y))
+        .collect::<Vec<_>>();
+    let title_row = rows
+        .iter()
+        .position(|row| row.contains("ChatGPT login in progress"))
+        .expect("login toast should render title line");
+    let code_row = rows
+        .iter()
+        .position(|row| row.contains("Code: USER-1"))
+        .expect("login toast should render code line");
+    let url_row = rows
+        .iter()
+        .position(|row| row.contains("Verification URL: https://auth.example.test/device"))
+        .expect("login toast should render URL line");
+    let cancel_row = rows
+        .iter()
+        .position(|row| row.contains("Press Esc to cancel"))
+        .expect("login toast should render cancel hint line");
+    assert!(title_row < code_row && code_row < url_row && url_row < cancel_row);
+    assert!(!rows[title_row].contains("USER-1"), "{}", rows[title_row]);
+    assert!(all.contains("USER-1"), "{all}");
+    assert!(all.contains("Press Esc to cancel"), "{all}");
+    assert!(!all.contains("Esc/c"), "{all}");
+    assert!(
+        !all.contains(texts::tui_managed_accounts_login_status()),
+        "{all}"
+    );
+    assert!(
+        !all.contains(texts::tui_managed_accounts_login_waiting()),
+        "{all}"
+    );
+    assert!(
+        !all.contains(texts::tui_managed_accounts_login_idle()),
+        "{all}"
+    );
+}
+
+#[test]
+fn managed_auth_cancel_confirm_renders_above_login_toast() {
+    let _lock = lock_env();
+    let _lang = use_test_language(Language::English);
+    let _no_color = EnvGuard::remove("NO_COLOR");
+
+    let mut app = App::new(Some(AppType::Claude));
+    app.route = Route::SettingsManagedAccounts;
+    app.focus = Focus::Content;
+    app.managed_auth_login = Some(crate::cli::tui::app::ManagedAuthLoginState {
+        auth_provider: "codex_oauth".to_string(),
+        device_code: "device-1".to_string(),
+        expires_at_tick: 900,
+        poll_interval_ticks: 5,
+        next_poll_tick: 0,
+    });
+    app.push_persistent_toast(
+        texts::tui_toast_managed_auth_login_in_progress(
+            "USER-1",
+            "https://auth.example.test/device",
+        ),
+        crate::cli::tui::app::ToastKind::Info,
+    );
+    app.overlay = Overlay::Confirm(ConfirmOverlay {
+        title: texts::tui_confirm_managed_auth_cancel_title().to_string(),
+        message: texts::tui_confirm_managed_auth_cancel_message().to_string(),
+        action: ConfirmAction::ManagedAuthCancelLogin,
+    });
+
+    let all = all_text(&render(&app, &minimal_data(&app.app_type)));
+
+    assert!(
+        all.contains(texts::tui_confirm_managed_auth_cancel_title()),
+        "{all}"
+    );
+    assert!(all.contains("Press Enter to cancel"), "{all}");
+    assert!(all.contains("Esc to keep waiting"), "{all}");
+
+    let key_bar_row = all
+        .lines()
+        .find(|line| line.contains("Enter cancel login"))
+        .expect("managed auth cancel confirm should render a specific key bar");
+    assert!(key_bar_row.contains("Esc keep waiting"), "{key_bar_row}");
+    assert!(!key_bar_row.contains("Enter confirm"), "{key_bar_row}");
+    assert!(!key_bar_row.contains("Esc cancel"), "{key_bar_row}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a managed Codex OAuth accounts view in settings with account list, details, and account actions
- move device login progress into a persistent toast and require Esc confirmation to cancel
- keep overlay/toast layering scoped so ordinary warning toasts still render above pickers

## Tests
- cargo test -q --manifest-path src-tauri/Cargo.toml managed_auth_cancel_confirm_renders_above_login_toast --lib
- cargo test -q --manifest-path src-tauri/Cargo.toml settings_managed_accounts_login_renders_only_toast --lib
- cargo test -q --manifest-path src-tauri/Cargo.toml zero_selection_warning_toast_renders_after_picker_rejection --lib
- cargo test -q --manifest-path src-tauri/Cargo.toml managed_auth_login_uses_toast_and_esc_confirmation --lib
- cargo test -q --manifest-path src-tauri/Cargo.toml settings_managed_accounts --lib
- cargo check -q --manifest-path src-tauri/Cargo.toml
- git diff --check

Related to #168