### PR TITLE
fix(tui): use readonly snapshots for hot refresh

### DIFF
--- a/src-tauri/src/cli/provider_quota.rs
+++ b/src-tauri/src/cli/provider_quota.rs
@@ -119,7 +119,7 @@ pub(crate) async fn query_quota(target: &QuotaTarget) -> Result<ProviderUsageQuo
             crate::services::CodexOAuthService::get_quota(account_id.as_deref()).await,
         )),
         QuotaTargetKind::UsageScript => {
-            let state = AppState::try_new().map_err(|error| error.to_string())?;
+            let state = AppState::try_open_snapshot().map_err(|error| error.to_string())?;
             ProviderService::query_provider_usage(
                 &state,
                 target.app_type.clone(),

--- a/src-tauri/src/cli/tui/data.rs
+++ b/src-tauri/src/cli/tui/data.rs
@@ -852,6 +852,10 @@ pub(crate) fn load_state() -> Result<AppState, AppError> {
     AppState::try_new()
 }
 
+pub(crate) fn load_snapshot_state() -> Result<AppState, AppError> {
+    AppState::try_open_snapshot()
+}
+
 impl UiData {
     pub fn load(app_type: &AppType) -> Result<Self, AppError> {
         let state = load_state()?;
@@ -866,19 +870,30 @@ impl UiData {
         Ok(data)
     }
 
-    pub(crate) fn load_fast_from_state(
+    pub(crate) fn load_fast_snapshot_from_state(
         state: &AppState,
         app_type: &AppType,
     ) -> Result<Self, AppError> {
-        Self::load_base_from_state(state, app_type)
+        Self::load_base_from_state_with_mode(state, app_type, ProviderLoadMode::SnapshotOnly)
     }
 
     fn load_base_from_state(state: &AppState, app_type: &AppType) -> Result<Self, AppError> {
-        let providers = load_providers(state, app_type)?;
+        Self::load_base_from_state_with_mode(state, app_type, ProviderLoadMode::SyncLive)
+    }
+
+    fn load_base_from_state_with_mode(
+        state: &AppState,
+        app_type: &AppType,
+        provider_load_mode: ProviderLoadMode,
+    ) -> Result<Self, AppError> {
+        let providers = load_providers_with_mode(state, app_type, provider_load_mode)?;
         let mcp = load_mcp(state)?;
         let prompts = load_prompts(state, app_type)?;
         let config = load_config_snapshot(state, app_type)?;
-        let skills = load_skills_snapshot()?;
+        let skills = match provider_load_mode {
+            ProviderLoadMode::SyncLive => load_skills_snapshot()?,
+            ProviderLoadMode::SnapshotOnly => load_skills_snapshot_from_state(state)?,
+        };
         let proxy = load_proxy_snapshot_from_state(state, app_type)?;
 
         Ok(Self {
@@ -935,6 +950,12 @@ impl UiData {
         ids.extend(self.providers.live_ids.iter().cloned());
         ids.into_iter().collect()
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderLoadMode {
+    SyncLive,
+    SnapshotOnly,
 }
 
 pub(crate) fn load_usage_pricing_data_from_state(
@@ -1003,13 +1024,22 @@ pub(crate) fn quota_target_for_provider(
     crate::cli::provider_quota::quota_target_for_provider(app_type, &row.id, &row.provider)
 }
 
+#[cfg(test)]
 fn load_providers(state: &AppState, app_type: &AppType) -> Result<ProvidersSnapshot, AppError> {
-    if matches!(app_type, AppType::OpenClaw) {
+    load_providers_with_mode(state, app_type, ProviderLoadMode::SyncLive)
+}
+
+fn load_providers_with_mode(
+    state: &AppState,
+    app_type: &AppType,
+    mode: ProviderLoadMode,
+) -> Result<ProvidersSnapshot, AppError> {
+    if mode == ProviderLoadMode::SyncLive && matches!(app_type, AppType::OpenClaw) {
         ProviderService::sync_openclaw_providers_from_live(state)?;
     }
 
-    let current_id = ProviderService::current(state, app_type.clone())?;
     let providers = ProviderService::list(state, app_type.clone())?;
+    let current_id = current_provider_for_mode(state, app_type, mode, &providers)?;
     let sorted = sort_providers(&providers);
 
     let openclaw_live_providers = if matches!(app_type, AppType::OpenClaw) {
@@ -1055,7 +1085,7 @@ fn load_providers(state: &AppState, app_type: &AppType) -> Result<ProvidersSnaps
         .and_then(|model| openclaw_default_model_ref_parts(&model.primary))
         .map(|(provider_id, _)| provider_id.to_string());
 
-    let rows = sorted
+    let mut rows = sorted
         .into_iter()
         .map(|(id, provider)| {
             let openclaw_live_provider = openclaw_live_providers
@@ -1092,6 +1122,43 @@ fn load_providers(state: &AppState, app_type: &AppType) -> Result<ProvidersSnaps
         })
         .collect::<Vec<_>>();
 
+    if matches!(app_type, AppType::OpenClaw) && mode == ProviderLoadMode::SnapshotOnly {
+        let saved_ids = rows
+            .iter()
+            .map(|row| row.id.clone())
+            .collect::<HashSet<_>>();
+        let mut live_only_ids = openclaw_live_ids
+            .iter()
+            .filter(|id| !saved_ids.contains(*id))
+            .cloned()
+            .collect::<Vec<_>>();
+        live_only_ids.sort();
+
+        for id in live_only_ids {
+            let Some(live_provider) = openclaw_live_providers.get(&id) else {
+                continue;
+            };
+            let provider = Provider::with_id(id.clone(), id.clone(), live_provider.clone(), None);
+
+            rows.push(ProviderRow {
+                api_url: extract_api_url(&provider.settings_config, app_type),
+                is_current: false,
+                is_in_config: true,
+                is_saved: false,
+                is_default_model: openclaw_primary_default_provider_id.as_deref()
+                    == Some(id.as_str()),
+                primary_model_id: extract_primary_model_id(
+                    &provider.settings_config,
+                    app_type,
+                    Some(live_provider),
+                ),
+                default_model_id: openclaw_default_model_ids.get(&id).cloned(),
+                id,
+                provider,
+            });
+        }
+    }
+
     let rows = if matches!(app_type, AppType::OpenClaw) {
         rows.into_iter()
             .filter(|row| !openclaw_live_providers.contains_key(&row.id) || row.is_in_config)
@@ -1112,6 +1179,34 @@ fn load_providers(state: &AppState, app_type: &AppType) -> Result<ProvidersSnaps
         rows,
         live_ids,
     })
+}
+
+fn current_provider_for_mode(
+    state: &AppState,
+    app_type: &AppType,
+    mode: ProviderLoadMode,
+    providers: &IndexMap<String, Provider>,
+) -> Result<String, AppError> {
+    if mode == ProviderLoadMode::SyncLive {
+        return ProviderService::current(state, app_type.clone());
+    }
+
+    if matches!(app_type, AppType::Hermes) {
+        return crate::hermes_config::get_current_provider_id().map(|opt| opt.unwrap_or_default());
+    }
+    if app_type.is_additive_mode() {
+        return Ok(String::new());
+    }
+    if let Some(local_id) = crate::settings::get_current_provider(app_type) {
+        if providers.contains_key(&local_id) {
+            return Ok(local_id);
+        }
+    }
+
+    state
+        .db
+        .get_current_provider(app_type.as_str())
+        .map(|opt| opt.unwrap_or_default())
 }
 
 fn sort_providers(providers: &IndexMap<String, Provider>) -> Vec<(String, Provider)> {
@@ -2374,15 +2469,28 @@ fn load_proxy_snapshot_from_state(
         .map_err(|e| AppError::Message(format!("failed to create async runtime: {e}")))?;
 
     runtime.block_on(async {
-        let config = state.proxy_service.get_global_config().await?;
-        let app_proxy_config = state.db.get_proxy_config_for_app(app_type.as_str()).await?;
+        let config = state.db.get_global_proxy_config_or_default().await?;
+        let app_proxy_config = state
+            .db
+            .get_proxy_config_for_app_or_default(app_type.as_str())
+            .await?;
         let configured_listen_port = state.db.get_app_proxy_preferred_port(app_type.as_str())?;
-        let runtime_status = state.proxy_service.get_status().await;
-        let takeover = state
-            .proxy_service
-            .get_takeover_status()
-            .await
-            .map_err(AppError::Message)?;
+        let runtime_status = state.proxy_service.get_status_snapshot().await;
+        let claude_takeover = state
+            .db
+            .get_proxy_config_for_app_or_default("claude")
+            .await?
+            .enabled;
+        let codex_takeover = state
+            .db
+            .get_proxy_config_for_app_or_default("codex")
+            .await?
+            .enabled;
+        let gemini_takeover = state
+            .db
+            .get_proxy_config_for_app_or_default("gemini")
+            .await?
+            .enabled;
 
         let current_app_target = runtime_status
             .active_targets
@@ -2411,7 +2519,7 @@ fn load_proxy_snapshot_from_state(
             .unwrap_or(configured_listen_port);
         let default_cost_multiplier = state
             .db
-            .get_default_cost_multiplier(app_type.as_str())
+            .get_default_cost_multiplier_or_default(app_type.as_str())
             .await
             .ok()
             .map(|value| value.trim().to_string())
@@ -2424,9 +2532,9 @@ fn load_proxy_snapshot_from_state(
                 || !runtime_status.active_workers.is_empty(),
             active_worker_apps,
             auto_failover_enabled: app_proxy_config.auto_failover_enabled,
-            claude_takeover: takeover.claude,
-            codex_takeover: takeover.codex,
-            gemini_takeover: takeover.gemini,
+            claude_takeover,
+            codex_takeover,
+            gemini_takeover,
             default_cost_multiplier,
             configured_listen_address: config.listen_address.clone(),
             configured_listen_port,
@@ -2459,6 +2567,21 @@ fn load_skills_snapshot() -> Result<SkillsSnapshot, AppError> {
     Ok(SkillsSnapshot {
         installed: SkillService::list_installed()?,
         repos: SkillService::list_repos()?,
+        sync_method: SkillService::get_sync_method()?,
+    })
+}
+
+fn load_skills_snapshot_from_state(state: &AppState) -> Result<SkillsSnapshot, AppError> {
+    let mut installed = state
+        .db
+        .get_all_installed_skills()?
+        .into_values()
+        .collect::<Vec<_>>();
+    installed.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+
+    Ok(SkillsSnapshot {
+        installed,
+        repos: state.db.get_skill_repos()?,
         sync_method: SkillService::get_sync_method()?,
     })
 }
@@ -3665,6 +3788,84 @@ mod tests {
         assert!(
             providers.contains_key("live-only"),
             "loading OpenClaw rows should mirror live providers into the local manager"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn load_fast_snapshot_openclaw_projects_live_only_provider_without_persisting() {
+        let _guard = lock_test_home_and_settings();
+        let temp = tempdir().expect("create tempdir");
+        let openclaw_dir = temp.path().join(".openclaw");
+        std::fs::create_dir_all(&openclaw_dir).expect("create openclaw dir");
+        let _home = HomeGuard::set(temp.path());
+        let _settings = SettingsGuard::with_openclaw_dir(&openclaw_dir);
+
+        crate::openclaw_config::set_provider(
+            "live-only",
+            json!({
+                "baseUrl": "https://api.example.com/v1",
+                "models": [
+                    {"id": "openclaw-live-model", "name": "Live Only Model"}
+                ]
+            }),
+        )
+        .expect("seed live openclaw provider");
+
+        let state = load_state().expect("initialize database");
+        assert!(
+            ProviderService::list(&state, AppType::OpenClaw)
+                .expect("list providers before snapshot")
+                .is_empty(),
+            "precondition: live-only provider should not be persisted before snapshot load"
+        );
+        drop(state);
+
+        let snapshot_state = load_snapshot_state().expect("load readonly snapshot state");
+        let snapshot = UiData::load_fast_snapshot_from_state(&snapshot_state, &AppType::OpenClaw)
+            .expect("load OpenClaw snapshot rows");
+        let row = snapshot
+            .providers
+            .rows
+            .iter()
+            .find(|row| row.id == "live-only")
+            .expect("live-only provider should appear in snapshot rows");
+        assert!(row.is_in_config);
+        assert!(!row.is_saved);
+        assert_eq!(provider_display_name(&AppType::OpenClaw, row), "live-only");
+        assert_eq!(row.primary_model_id.as_deref(), Some("openclaw-live-model"));
+
+        drop(snapshot_state);
+        let reloaded_state = load_state().expect("reload state after snapshot load");
+        assert!(
+            ProviderService::list(&reloaded_state, AppType::OpenClaw)
+                .expect("list providers after snapshot")
+                .is_empty(),
+            "snapshot-only OpenClaw load must not persist live-only providers"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn load_fast_snapshot_does_not_clear_invalid_settings_current_provider() {
+        let _guard = lock_test_home_and_settings();
+        let temp = tempdir().expect("create tempdir");
+        let _home = HomeGuard::set(temp.path());
+        crate::settings::set_current_provider(&AppType::Claude, Some("missing-local-current"))
+            .expect("seed invalid local current provider");
+
+        let state = load_state().expect("initialize database");
+        drop(state);
+
+        let snapshot_state = load_snapshot_state().expect("load readonly snapshot state");
+        let snapshot = UiData::load_fast_snapshot_from_state(&snapshot_state, &AppType::Claude)
+            .expect("load Claude snapshot rows");
+
+        assert_eq!(snapshot.providers.current_id, "");
+        assert_eq!(
+            crate::settings::get_current_provider(&AppType::Claude).as_deref(),
+            Some("missing-local-current"),
+            "snapshot provider load must not repair or clear local settings"
         );
     }
 

--- a/src-tauri/src/cli/tui/runtime_systems/workers.rs
+++ b/src-tauri/src/cli/tui/runtime_systems/workers.rs
@@ -12,7 +12,8 @@ use crate::services::{SkillService, StreamCheckService, WebDavSyncService};
 use crate::settings::{set_webdav_sync_settings, webdav_jianguoyun_preset};
 
 use super::super::data::{
-    load_state, load_usage_pricing_data_from_state_for_range, UiData, UsageRangePreset,
+    load_snapshot_state, load_state, load_usage_pricing_data_from_state_for_range, UiData,
+    UsageRangePreset,
 };
 use super::types::{
     fetch_provider_models_for_tui, model_fetch_strategy_for_field, AppDataMsg, AppDataReq,
@@ -1215,7 +1216,7 @@ fn state_for_epoch(
         .as_ref()
         .is_none_or(|(cached_epoch, _)| *cached_epoch != epoch);
     if needs_reload {
-        *state_cache = Some((epoch, load_state()?));
+        *state_cache = Some((epoch, load_snapshot_state()?));
     }
     Ok(&state_cache.as_ref().expect("state cache initialized").1)
 }
@@ -1237,8 +1238,8 @@ fn handle_app_data_req(
     let result = state_for_epoch(state_cache, app_state_epoch)
         .and_then(|state| {
             state
-                .refresh_config_from_db()
-                .and_then(|()| UiData::load_fast_from_state(state, &app_type))
+                .reload_config_snapshot_from_db()
+                .and_then(|()| UiData::load_fast_snapshot_from_state(state, &app_type))
         })
         .map_err(|err| err.to_string());
 
@@ -1329,7 +1330,7 @@ fn handle_usage_pricing_uncached_req_with_cancel<F>(
     else {
         return;
     };
-    let result = load_state()
+    let result = load_snapshot_state()
         .and_then(|state| {
             let handle = {
                 let conn = state.db.conn.lock().map_err(AppError::from)?;

--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -20,6 +20,32 @@ fn default_app_preferred_port(app_type: &str) -> u16 {
     }
 }
 
+fn default_global_proxy_config() -> GlobalProxyConfig {
+    GlobalProxyConfig {
+        proxy_enabled: false,
+        listen_address: "127.0.0.1".to_string(),
+        listen_port: 15721,
+        enable_logging: true,
+    }
+}
+
+fn default_app_proxy_config(app_type: impl Into<String>) -> AppProxyConfig {
+    AppProxyConfig {
+        app_type: app_type.into(),
+        enabled: false,
+        auto_failover_enabled: false,
+        max_retries: 3,
+        streaming_first_byte_timeout: 60,
+        streaming_idle_timeout: 120,
+        non_streaming_timeout: 600,
+        circuit_failure_threshold: 4,
+        circuit_success_threshold: 2,
+        circuit_timeout_seconds: 60,
+        circuit_error_rate_threshold: 0.6,
+        circuit_min_requests: 10,
+    }
+}
+
 impl Database {
     // ==================== Global Proxy Config ====================
 
@@ -74,13 +100,34 @@ impl Database {
             Err(rusqlite::Error::QueryReturnedNoRows) => {
                 // 如果不存在，创建默认配置
                 self.init_proxy_config_rows().await?;
-                Ok(GlobalProxyConfig {
-                    proxy_enabled: false,
-                    listen_address: "127.0.0.1".to_string(),
-                    listen_port: 15721,
-                    enable_logging: true,
-                })
+                Ok(default_global_proxy_config())
             }
+            Err(e) => Err(AppError::Database(e.to_string())),
+        }
+    }
+
+    /// 获取全局代理配置，不存在时返回默认值但不写入数据库。
+    pub async fn get_global_proxy_config_or_default(&self) -> Result<GlobalProxyConfig, AppError> {
+        let result = {
+            let conn = lock_conn!(self.conn);
+            conn.query_row(
+                "SELECT proxy_enabled, listen_address, listen_port, enable_logging
+                 FROM proxy_config WHERE app_type = 'claude'",
+                [],
+                |row| {
+                    Ok(GlobalProxyConfig {
+                        proxy_enabled: row.get::<_, i32>(0)? != 0,
+                        listen_address: row.get(1)?,
+                        listen_port: row.get::<_, i32>(2)? as u16,
+                        enable_logging: row.get::<_, i32>(3)? != 0,
+                    })
+                },
+            )
+        };
+
+        match result {
+            Ok(config) => Ok(config),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(default_global_proxy_config()),
             Err(e) => Err(AppError::Database(e.to_string())),
         }
     }
@@ -159,6 +206,27 @@ impl Database {
                 self.init_proxy_config_rows().await?;
                 Ok("1".to_string())
             }
+            Err(e) => Err(AppError::Database(e.to_string())),
+        }
+    }
+
+    /// 获取默认成本倍率，不存在时返回默认值但不写入数据库。
+    pub async fn get_default_cost_multiplier_or_default(
+        &self,
+        app_type: &str,
+    ) -> Result<String, AppError> {
+        let result = {
+            let conn = lock_conn!(self.conn);
+            conn.query_row(
+                "SELECT default_cost_multiplier FROM proxy_config WHERE app_type = ?1",
+                [app_type],
+                |row| row.get(0),
+            )
+        };
+
+        match result {
+            Ok(value) => Ok(value),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok("1".to_string()),
             Err(e) => Err(AppError::Database(e.to_string())),
         }
     }
@@ -294,20 +362,50 @@ impl Database {
             Err(rusqlite::Error::QueryReturnedNoRows) => {
                 // 如果不存在，创建默认配置
                 self.init_proxy_config_rows().await?;
-                Ok(AppProxyConfig {
-                    app_type: app_type_owned,
-                    enabled: false,
-                    auto_failover_enabled: false,
-                    max_retries: 3,
-                    streaming_first_byte_timeout: 60,
-                    streaming_idle_timeout: 120,
-                    non_streaming_timeout: 600,
-                    circuit_failure_threshold: 4,
-                    circuit_success_threshold: 2,
-                    circuit_timeout_seconds: 60,
-                    circuit_error_rate_threshold: 0.6,
-                    circuit_min_requests: 10,
-                })
+                Ok(default_app_proxy_config(app_type_owned))
+            }
+            Err(e) => Err(AppError::Database(e.to_string())),
+        }
+    }
+
+    /// 获取应用级代理配置，不存在时返回默认值但不写入数据库。
+    pub async fn get_proxy_config_for_app_or_default(
+        &self,
+        app_type: &str,
+    ) -> Result<AppProxyConfig, AppError> {
+        let app_type_owned = app_type.to_string();
+        let result = {
+            let conn = lock_conn!(self.conn);
+            conn.query_row(
+                "SELECT app_type, enabled, auto_failover_enabled,
+                        max_retries, streaming_first_byte_timeout, streaming_idle_timeout, non_streaming_timeout,
+                        circuit_failure_threshold, circuit_success_threshold, circuit_timeout_seconds,
+                        circuit_error_rate_threshold, circuit_min_requests
+                 FROM proxy_config WHERE app_type = ?1",
+                [app_type],
+                |row| {
+                    Ok(AppProxyConfig {
+                        app_type: row.get(0)?,
+                        enabled: row.get::<_, i32>(1)? != 0,
+                        auto_failover_enabled: row.get::<_, i32>(2)? != 0,
+                        max_retries: row.get::<_, i32>(3)? as u32,
+                        streaming_first_byte_timeout: row.get::<_, i32>(4)? as u32,
+                        streaming_idle_timeout: row.get::<_, i32>(5)? as u32,
+                        non_streaming_timeout: row.get::<_, i32>(6)? as u32,
+                        circuit_failure_threshold: row.get::<_, i32>(7)? as u32,
+                        circuit_success_threshold: row.get::<_, i32>(8)? as u32,
+                        circuit_timeout_seconds: row.get::<_, i32>(9)? as u32,
+                        circuit_error_rate_threshold: row.get(10)?,
+                        circuit_min_requests: row.get::<_, i32>(11)? as u32,
+                    })
+                },
+            )
+        };
+
+        match result {
+            Ok(config) => Ok(config),
+            Err(rusqlite::Error::QueryReturnedNoRows) => {
+                Ok(default_app_proxy_config(app_type_owned))
             }
             Err(e) => Err(AppError::Database(e.to_string())),
         }

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -38,7 +38,7 @@ pub use dao::FailoverQueueItem;
 
 use crate::config::get_app_config_dir;
 use crate::error::AppError;
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 use serde::Serialize;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -83,6 +83,14 @@ pub struct Database {
 }
 
 impl Database {
+    fn configure_connection(conn: &Connection) -> Result<(), AppError> {
+        conn.execute("PRAGMA foreign_keys = ON;", [])
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        conn.busy_timeout(Duration::from_secs(5))
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(())
+    }
+
     /// 初始化数据库连接并创建表
     ///
     /// 数据库文件位于 `~/.cc-switch/cc-switch.db`
@@ -96,14 +104,10 @@ impl Database {
 
         let conn = Connection::open(&db_path).map_err(|e| AppError::Database(e.to_string()))?;
 
-        // 启用外键约束
-        conn.execute("PRAGMA foreign_keys = ON;", [])
-            .map_err(|e| AppError::Database(e.to_string()))?;
+        Self::configure_connection(&conn)?;
         // 多进程并发：daemon 与 worker 都会打开这个文件，WAL + busy_timeout 让
         // 短暂的 SQLITE_BUSY 自动重试而不是直接失败。
         conn.pragma_update(None, "journal_mode", "WAL")
-            .map_err(|e| AppError::Database(e.to_string()))?;
-        conn.busy_timeout(std::time::Duration::from_secs(5))
             .map_err(|e| AppError::Database(e.to_string()))?;
 
         let db = Self {
@@ -138,15 +142,45 @@ impl Database {
         Ok(db)
     }
 
+    /// 打开当前 schema 的只读快照连接。
+    ///
+    /// 用于 TUI 后台热刷新等只读路径；不会创建目录、建表、迁移、seed 或执行启动维护。
+    pub fn open_readonly_current_schema() -> Result<Self, AppError> {
+        let db_path = get_app_config_dir().join("cc-switch.db");
+        if !db_path.exists() {
+            return Err(AppError::Database(format!(
+                "database is not initialized: {}",
+                db_path.display()
+            )));
+        }
+
+        let conn = Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        Self::configure_connection(&conn)?;
+
+        let version = Self::get_user_version(&conn)?;
+        if version > SCHEMA_VERSION {
+            return Err(Self::future_schema_error(version));
+        }
+        if version != SCHEMA_VERSION {
+            return Err(AppError::Database(format!(
+                "database schema version {version} requires initialization before snapshot reads; current schema version is {SCHEMA_VERSION}"
+            )));
+        }
+
+        Ok(Self {
+            conn: Mutex::new(conn),
+            runtime_key: format!("file:{}", db_path.display()),
+        })
+    }
+
     /// 创建内存数据库（用于测试）
     pub fn memory() -> Result<Self, AppError> {
         static NEXT_MEMORY_DB_ID: AtomicU64 = AtomicU64::new(1);
 
         let conn = Connection::open_in_memory().map_err(|e| AppError::Database(e.to_string()))?;
 
-        // 启用外键约束
-        conn.execute("PRAGMA foreign_keys = ON;", [])
-            .map_err(|e| AppError::Database(e.to_string()))?;
+        Self::configure_connection(&conn)?;
 
         let db = Self {
             conn: Mutex::new(conn),

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -247,6 +247,85 @@ fn init_rejects_future_schema_before_creating_tables() {
 }
 
 #[test]
+#[serial_test::serial]
+fn readonly_snapshot_rejects_missing_database_without_creating_file() {
+    let _lock = crate::test_support::lock_test_home_and_settings();
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let _guard = ConfigDirEnvGuard::set(temp.path());
+    let db_path = temp.path().join("cc-switch.db");
+
+    let err = match Database::open_readonly_current_schema() {
+        Ok(_) => panic!("missing database should not open as a snapshot"),
+        Err(err) => err,
+    };
+
+    assert!(
+        err.to_string().contains("database is not initialized"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        !db_path.exists(),
+        "readonly snapshot open should not create the database file"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn readonly_snapshot_rejects_old_schema_without_migrating() {
+    let _lock = crate::test_support::lock_test_home_and_settings();
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let _guard = ConfigDirEnvGuard::set(temp.path());
+    let db_path = temp.path().join("cc-switch.db");
+    let conn = Connection::open(&db_path).expect("open db");
+    Database::set_user_version(&conn, SCHEMA_VERSION - 1).expect("set old version");
+    drop(conn);
+
+    let err = match Database::open_readonly_current_schema() {
+        Ok(_) => panic!("old schema should require initialization first"),
+        Err(err) => err,
+    };
+
+    assert!(
+        err.to_string().contains("requires initialization"),
+        "unexpected error: {err}"
+    );
+    let conn = Connection::open(&db_path).expect("reopen db");
+    assert!(
+        !Database::table_exists(&conn, "providers").expect("check providers table"),
+        "readonly snapshot open should not create or migrate tables"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn readonly_snapshot_opens_current_schema_without_allowing_writes() {
+    let _lock = crate::test_support::lock_test_home_and_settings();
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let _guard = ConfigDirEnvGuard::set(temp.path());
+
+    let db = Database::init().expect("initialize database");
+    assert_eq!(
+        Database::get_user_version(&db.conn.lock().expect("lock db conn")).expect("read version"),
+        SCHEMA_VERSION
+    );
+    drop(db);
+
+    let snapshot =
+        Database::open_readonly_current_schema().expect("open readonly current schema snapshot");
+    assert!(
+        snapshot.get_all_providers("claude").is_ok(),
+        "readonly snapshot should support normal reads"
+    );
+    let err = snapshot
+        .set_setting("snapshot_write_probe", "1")
+        .expect_err("readonly snapshot should reject writes");
+    assert!(
+        err.to_string().contains("readonly") || err.to_string().contains("read-only"),
+        "unexpected write error: {err}"
+    );
+}
+
+#[test]
 fn schema_migration_adds_missing_columns_for_providers() {
     let conn = Connection::open_in_memory().expect("open memory db");
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1020,11 +1020,19 @@ impl ProxyService {
     }
 
     pub async fn get_status(&self) -> ProxyStatus {
+        self.get_status_with_cleanup(true).await
+    }
+
+    pub async fn get_status_snapshot(&self) -> ProxyStatus {
+        self.get_status_with_cleanup(false).await
+    }
+
+    async fn get_status_with_cleanup(&self, cleanup_stale_sessions: bool) -> ProxyStatus {
         if let Some(server) = self.runtime.server.read().await.as_ref() {
             return server.get_status().await;
         }
 
-        let sessions = self.load_persisted_runtime_sessions();
+        let sessions = self.load_persisted_runtime_sessions_with_cleanup(cleanup_stale_sessions);
         if !sessions.is_empty()
             && sessions
                 .iter()
@@ -1068,7 +1076,7 @@ impl ProxyService {
                 }
             }
 
-            if !stale_app_keys.is_empty() {
+            if cleanup_stale_sessions && !stale_app_keys.is_empty() {
                 let _ = self.clear_persisted_runtime_sessions_for_app_keys(&stale_app_keys);
             }
 
@@ -1095,10 +1103,14 @@ impl ProxyService {
                 };
             }
 
-            let _ = self.clear_persisted_runtime_session();
+            if cleanup_stale_sessions {
+                let _ = self.clear_persisted_runtime_session();
+            }
         }
 
-        if let Some(status) = Self::daemon_status_snapshot().await {
+        if let Some(status) =
+            Self::daemon_status_snapshot_with_cleanup(cleanup_stale_sessions).await
+        {
             return status;
         }
 
@@ -1107,6 +1119,13 @@ impl ProxyService {
 
     #[cfg(unix)]
     async fn daemon_status_snapshot() -> Option<ProxyStatus> {
+        Self::daemon_status_snapshot_with_cleanup(true).await
+    }
+
+    #[cfg(unix)]
+    async fn daemon_status_snapshot_with_cleanup(
+        cleanup_stale_socket: bool,
+    ) -> Option<ProxyStatus> {
         use crate::daemon::ipc::{
             client,
             protocol::{Request, Response},
@@ -1142,7 +1161,9 @@ impl ProxyService {
                     ErrorKind::ConnectionRefused | ErrorKind::NotFound
                 ) =>
             {
-                let _ = std::fs::remove_file(socket_path);
+                if cleanup_stale_socket {
+                    let _ = std::fs::remove_file(socket_path);
+                }
                 None
             }
             Err(error) => {
@@ -1154,6 +1175,13 @@ impl ProxyService {
 
     #[cfg(not(unix))]
     async fn daemon_status_snapshot() -> Option<ProxyStatus> {
+        Self::daemon_status_snapshot_with_cleanup(true).await
+    }
+
+    #[cfg(not(unix))]
+    async fn daemon_status_snapshot_with_cleanup(
+        _cleanup_stale_socket: bool,
+    ) -> Option<ProxyStatus> {
         None
     }
 
@@ -2878,6 +2906,13 @@ impl ProxyService {
     }
 
     fn load_persisted_runtime_sessions(&self) -> Vec<PersistedProxyRuntimeSession> {
+        self.load_persisted_runtime_sessions_with_cleanup(true)
+    }
+
+    fn load_persisted_runtime_sessions_with_cleanup(
+        &self,
+        cleanup_invalid_session: bool,
+    ) -> Vec<PersistedProxyRuntimeSession> {
         let Some(raw) = self.load_raw_persisted_runtime_session() else {
             return Vec::new();
         };
@@ -2898,7 +2933,9 @@ impl ProxyService {
         match serde_json::from_str::<PersistedProxyRuntimeSession>(&raw) {
             Ok(session) => vec![session],
             Err(_) => {
-                let _ = self.clear_persisted_runtime_session();
+                if cleanup_invalid_session {
+                    let _ = self.clear_persisted_runtime_session();
+                }
                 Vec::new()
             }
         }
@@ -4845,6 +4882,33 @@ base_url = "https://api.openai.com/v1"
         assert!(
             service.load_legacy_persisted_runtime_session().is_none(),
             "daemon workers map must not be treated as legacy upgrade residue"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_status_snapshot_does_not_clear_invalid_runtime_session() {
+        let db = Arc::new(Database::memory().expect("create database"));
+        let service = ProxyService::new(db.clone());
+
+        db.set_setting(PROXY_RUNTIME_SESSION_KEY, "not-json")
+            .expect("write invalid runtime session");
+
+        let status = service.get_status_snapshot().await;
+        assert!(!status.running);
+        assert_eq!(
+            db.get_setting(PROXY_RUNTIME_SESSION_KEY)
+                .expect("read runtime session after snapshot status")
+                .as_deref(),
+            Some("not-json"),
+            "snapshot status reads must not repair or clear persisted runtime state"
+        );
+
+        let _ = service.get_status().await;
+        assert!(
+            db.get_setting(PROXY_RUNTIME_SESSION_KEY)
+                .expect("read runtime session after normal status")
+                .is_none(),
+            "normal status keeps the existing cleanup behavior"
         );
     }
 

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -89,6 +89,13 @@ impl AppState {
         Self::from_parts(db, config)
     }
 
+    /// 打开只读数据库快照，用于 TUI 后台热刷新等非初始化路径。
+    pub fn try_open_snapshot() -> Result<Self, AppError> {
+        let db = Arc::new(Database::open_readonly_current_schema()?);
+        let config = export_db_to_multi_app_config(&db)?;
+        Self::from_parts(db, config)
+    }
+
     /// 创建新的应用状态，并在真实进程启动路径上执行一次启动恢复。
     pub fn try_new_with_startup_recovery() -> Result<Self, AppError> {
         let state = Self::try_new()?;
@@ -264,6 +271,14 @@ impl AppState {
             &mut config,
         )?;
 
+        let mut guard = self.config.write().map_err(AppError::from)?;
+        *guard = config;
+        Ok(())
+    }
+
+    /// 从数据库重建内存配置快照，但不执行任何 legacy/common-config 写入迁移。
+    pub fn reload_config_snapshot_from_db(&self) -> Result<(), AppError> {
+        let config = export_db_to_multi_app_config(&self.db)?;
         let mut guard = self.config.write().map_err(AppError::from)?;
         *guard = config;
         Ok(())


### PR DESCRIPTION
## Summary
- add a readonly DB snapshot opener and AppState snapshot path for TUI hot refreshes
- route TUI app-data, usage/pricing, and UsageScript quota reads through snapshot state
- avoid hidden writes in snapshot proxy, skills, OpenClaw live provider, and settings current-provider reads

## Verification
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- git diff --check
- cargo test --manifest-path src-tauri/Cargo.toml readonly_snapshot -- --nocapture
- cargo test --manifest-path src-tauri/Cargo.toml load_fast_snapshot_openclaw_projects_live_only_provider_without_persisting -- --nocapture
- cargo test --manifest-path src-tauri/Cargo.toml load_fast_snapshot_does_not_clear_invalid_settings_current_provider -- --nocapture
- cargo test --manifest-path src-tauri/Cargo.toml get_status_snapshot_does_not_clear_invalid_runtime_session -- --nocapture
