### PR TITLE
docs: highlight TUI and CLI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 
 <a href="https://trendshift.io/repositories/22544" target="_blank"><img src="https://trendshift.io/api/badge/repositories/22544" alt="SaladDay%2Fcc-switch-cli | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-**Command-Line Management Tool for Claude Code, Codex, Gemini, OpenCode, Hermes & OpenClaw**
+**TUI + CLI dual-mode manager for Claude Code, Codex, Gemini, OpenCode, Hermes & OpenClaw**
 
-Unified management for Claude Code, Codex, Gemini, OpenCode, Hermes, and OpenClaw provider configurations, plus app-specific support for MCP servers, skills, prompts, local proxy routes, and environment checks.
+Use the interactive TUI for daily switching, account, and session work, or the CLI for scripts and repeatable terminal workflows.
+
+Unified management for provider configurations, MCP servers, skills, prompts, local proxy routes, usage statistics, and environment checks across supported AI coding assistants.
 
 English | [中文](README_ZH.md)
 
@@ -103,11 +105,11 @@ This project is a **CLI fork** of [CC-Switch](https://github.com/farion1231/cc-s
 
 ## 🚀 Quick Start
 
-**Interactive Mode (Recommended)**
+**TUI Mode (Recommended)**
 ```bash
 cc-switch
 ```
-🤩 Follow on-screen menus to explore features.
+Use the full-screen interface to switch providers, manage accounts, review sessions, and inspect proxy status.
 
 **Command-Line Mode**
 ```bash
@@ -117,6 +119,9 @@ cc-switch use <id>                   # Switch provider (shortcut)
 cc-switch provider export <id>       # Export a Claude provider to a standalone settings file
 cc-switch provider stream-check <id> # Check provider stream health
 cc-switch start <claude|codex> <id> --dry-run # Preview launch
+cc-switch auth list                  # List managed ChatGPT/Codex OAuth accounts
+cc-switch sessions list --all        # Review saved assistant sessions
+cc-switch sessions sync-usage --all  # Import local session token/cost usage
 cc-switch config webdav show         # Inspect WebDAV sync settings
 cc-switch env tools                  # Check local CLI tools
 cc-switch mcp sync                   # Sync MCP servers
@@ -275,6 +280,20 @@ cc-switch provider fetch-models <id> # Fetch remote model list
 cc-switch provider export <id> --output ~/.claude/settings-demo.json # Custom settings file path
 ```
 
+### 🔐 Managed Accounts
+
+Manage ChatGPT/Codex OAuth accounts locally and reuse them across provider profiles, including using a Codex OAuth account as a Claude Code provider through the local proxy.
+
+**Features:** device-flow login, account listing, default account selection, account removal, and provider binding without copying long-lived tokens into each provider.
+
+```bash
+cc-switch auth status                # Show managed account status
+cc-switch auth login                 # Sign in with ChatGPT/Codex OAuth
+cc-switch auth list                  # List signed-in accounts
+cc-switch auth default <account-id>  # Set the default account
+cc-switch auth remove <account-id>   # Remove an account
+```
+
 ### 🛠️ MCP Server Management
 
 Manage Model Context Protocol servers across Claude, Codex, Gemini, OpenCode, and Hermes.
@@ -336,6 +355,20 @@ cc-switch skills repos enable <repo> # Enable repo without changing branch
 cc-switch skills repos disable <repo> # Disable repo without changing branch
 ```
 
+### 🕘 Session History & Usage Statistics
+
+Review saved assistant sessions, resume a session with one command, delete old records, and import local session logs into token/cost statistics.
+
+**Features:** cross-app session scanning, message preview, one-command resume, safe delete confirmation, JSON output, and usage sync for Claude, Codex, Gemini, and OpenCode.
+
+```bash
+cc-switch sessions list --all        # List saved sessions across supported apps
+cc-switch sessions show <id>         # Show session metadata and messages
+cc-switch sessions resume <id>       # Resume a saved session
+cc-switch sessions delete <id>       # Delete a saved session
+cc-switch sessions sync-usage --all  # Sync local logs into usage statistics
+```
+
 ### ⚙️ Configuration Management
 
 Manage configuration backups, imports, and exports.
@@ -378,11 +411,13 @@ cc-switch config webdav migrate-v1-to-v2
 cc-switch config reset               # Reset to default configuration
 ```
 
-### 🌉 Proxy Management
+### 🌉 Proxy Management & Model Relay
 
 Inspect and control daemon-managed per-app proxy routes for supported apps.
 
-**Features:** independent enable/disable per app, per-app listen ports, daemon-managed workers, current route inspection, dashboard telemetry, and foreground serve mode for debugging.
+**Features:** independent enable/disable per app, per-app listen ports, daemon-managed workers, current route inspection, dashboard telemetry, token accounting, and foreground serve mode for debugging.
+
+The local proxy can route Claude Code, Codex, and Gemini through CC-Switch, adapt OpenAI Responses API and Chat Completions providers, and connect mainstream OpenAI-compatible models such as DeepSeek, Kimi, Qwen, OpenRouter, xAI, Groq, and Mistral where the target app supports that route.
 
 ```bash
 cc-switch proxy show                              # Show proxy configuration, routes, and daemon worker status

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -7,9 +7,11 @@
 [![Built with Rust](https://img.shields.io/badge/built%20with-Rust-orange.svg)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-**Claude Code、Codex、Gemini、OpenCode、Hermes 与 OpenClaw 的命令行管理工具**
+**支持 TUI + CLI 双模式的 Claude Code、Codex、Gemini、OpenCode、Hermes 与 OpenClaw 管理工具**
 
-统一管理 Claude Code、Codex、Gemini、OpenCode、Hermes 与 OpenClaw 的供应商配置，并按应用提供 MCP 服务器、Skills 扩展、提示词、本地代理路由和环境检查等能力。
+日常切换、账号和会话管理可使用交互式 TUI；脚本化、自动化和终端工作流可使用 CLI。
+
+统一管理供应商配置、MCP 服务器、Skills 扩展、提示词、本地代理路由、用量统计和环境检查等能力。
 
 [English](README.md) | 中文
 
@@ -103,11 +105,11 @@
 
 ## 🚀 快速开始
 
-**交互模式（推荐）**
+**TUI 模式（推荐）**
 ```bash
 cc-switch
 ```
-🤩 按照屏幕菜单探索功能。
+使用全屏界面切换供应商、管理账号、查看会话并检查代理状态。
 
 **命令行模式**
 ```bash
@@ -117,6 +119,9 @@ cc-switch use <id>                   # 切换供应商（快捷命令）
 cc-switch provider export <id>       # 导出 Claude 供应商为独立 settings 文件
 cc-switch provider stream-check <id> # 检查供应商流式健康
 cc-switch start <claude|codex> <id> --dry-run # 预览启动配置
+cc-switch auth list                  # 查看托管的 ChatGPT/Codex OAuth 账号
+cc-switch sessions list --all        # 查看历史会话
+cc-switch sessions sync-usage --all  # 导入本地会话 token / cost 用量
 cc-switch config webdav show         # 查看 WebDAV 同步设置
 cc-switch env tools                  # 检查本地 CLI 工具
 cc-switch mcp sync                   # 同步 MCP 服务器
@@ -279,6 +284,20 @@ cc-switch provider fetch-models <id> # 拉取远端模型列表
 cc-switch provider export <id> --output ~/.claude/settings-demo.json # 自定义 settings 文件路径
 ```
 
+### 🔐 托管账号
+
+本地管理 ChatGPT/Codex OAuth 账号，并在供应商配置中复用；也可以通过本地代理将 Codex OAuth 账号作为 Claude Code 供应商使用。
+
+**功能：** 设备码登录、账号列表、默认账号选择、账号移除，以及无需在每个供应商里复制长期 token 的账号绑定。
+
+```bash
+cc-switch auth status                # 查看托管账号状态
+cc-switch auth login                 # 使用 ChatGPT/Codex OAuth 登录
+cc-switch auth list                  # 列出已登录账号
+cc-switch auth default <account-id>  # 设置默认账号
+cc-switch auth remove <account-id>   # 移除账号
+```
+
 ### 🛠️ MCP 服务器管理
 
 跨 Claude、Codex、Gemini、OpenCode 与 Hermes 管理模型上下文协议服务器。
@@ -340,6 +359,20 @@ cc-switch skills repos enable <repo> # 启用仓库但保留当前分支
 cc-switch skills repos disable <repo> # 禁用仓库但保留当前分支
 ```
 
+### 🕘 历史会话与用量统计
+
+查看历史会话，一键 resume，删除旧会话，并将本地会话日志导入 token / cost 统计，方便管理用量。
+
+**功能：** 跨应用扫描会话、消息预览、一键恢复、删除确认、JSON 输出，以及 Claude、Codex、Gemini、OpenCode 的用量同步。
+
+```bash
+cc-switch sessions list --all        # 列出支持应用的历史会话
+cc-switch sessions show <id>         # 查看会话信息和消息
+cc-switch sessions resume <id>       # 恢复会话
+cc-switch sessions delete <id>       # 删除会话
+cc-switch sessions sync-usage --all  # 同步本地日志到用量统计
+```
+
 ### ⚙️ 配置管理
 
 管理配置文件的备份、导入和导出。
@@ -382,11 +415,13 @@ cc-switch config webdav migrate-v1-to-v2
 cc-switch config reset               # 重置为默认配置
 ```
 
-### 🌉 代理管理
+### 🌉 代理管理与模型接入
 
 查看并控制由守护进程管理的按应用代理路由。
 
-**功能：** 每个应用可独立启用/禁用代理、每个应用可配置监听端口、由 daemon 管理 worker、当前路由检查、首页遥测，以及用于调试的前台运行模式。
+**功能：** 每个应用可独立启用/禁用代理、每个应用可配置监听端口、由 daemon 管理 worker、当前路由检查、首页遥测、token 统计，以及用于调试的前台运行模式。
+
+本地代理可将 Claude Code、Codex、Gemini 路由到 CC-Switch，适配 OpenAI Responses API 与 Chat Completions 供应商，并在目标应用支持的路径下接入 DeepSeek、Kimi、Qwen、OpenRouter、xAI、Groq、Mistral 等主流 OpenAI-compatible 模型。
 
 ```bash
 cc-switch proxy show                              # 显示代理配置、路由和 daemon worker 状态


### PR DESCRIPTION
## Summary
- Update the README positioning to call out TUI + CLI dual-mode workflows
- Document managed ChatGPT/Codex OAuth accounts
- Add session history and token/cost usage statistics commands
- Expand proxy/model relay notes for OpenAI-compatible providers

## Verification
- git diff --check