### PR TITLE
fix(codex): add DeepSeek preset and chat bridge base handling

### DIFF
--- a/src-tauri/src/cli/commands/provider_input.rs
+++ b/src-tauri/src/cli/commands/provider_input.rs
@@ -5,7 +5,10 @@ use crate::app_config::AppType;
 use crate::cli::i18n::texts;
 use crate::cli::ui::info;
 use crate::error::AppError;
-use crate::provider::{AuthBinding, AuthBindingSource, ClaudeApiKeyField, Provider, ProviderMeta};
+use crate::provider::{
+    AuthBinding, AuthBindingSource, ClaudeApiKeyField, CodexChatReasoningConfig, Provider,
+    ProviderMeta,
+};
 use crate::services::ProviderService;
 use clap::ValueEnum;
 use colored::Colorize;
@@ -25,6 +28,7 @@ pub enum ProviderAddTemplate {
     Aicodemirror,
     Cubence,
     Dds,
+    Deepseek,
 }
 
 impl ProviderAddTemplate {
@@ -39,6 +43,7 @@ impl ProviderAddTemplate {
             Self::Aicodemirror => "aicodemirror",
             Self::Cubence => "cubence",
             Self::Dds => "dds",
+            Self::Deepseek => "deepseek",
         }
     }
 
@@ -49,10 +54,21 @@ impl ProviderAddTemplate {
     pub fn requires_settings_prompt(self) -> bool {
         matches!(
             self,
-            Self::Packycode | Self::Aicodemirror | Self::Cubence | Self::Dds
+            Self::Packycode | Self::Aicodemirror | Self::Cubence | Self::Dds | Self::Deepseek
         )
     }
 }
+
+const DEEPSEEK_CODEX_CONFIG: &str = r#"model_provider = "custom"
+model = "deepseek-v4-flash"
+model_reasoning_effort = "high"
+disable_response_storage = true
+
+[model_providers.custom]
+name = "deepseek"
+base_url = "https://api.deepseek.com"
+wire_api = "responses"
+requires_openai_auth = true"#;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProviderAddTemplateChoice {
@@ -238,7 +254,7 @@ const PROVIDER_TEMPLATE_CHOICES_CLAUDE: [ProviderAddTemplateChoice; 7] = [
     },
 ];
 
-const PROVIDER_TEMPLATE_CHOICES_CODEX: [ProviderAddTemplateChoice; 6] = [
+const PROVIDER_TEMPLATE_CHOICES_CODEX: [ProviderAddTemplateChoice; 7] = [
     ProviderAddTemplateChoice {
         template: ProviderAddTemplate::Custom,
         label: "Custom",
@@ -262,6 +278,10 @@ const PROVIDER_TEMPLATE_CHOICES_CODEX: [ProviderAddTemplateChoice; 6] = [
     ProviderAddTemplateChoice {
         template: ProviderAddTemplate::Dds,
         label: SPONSOR_PROVIDER_PRESETS[3].chip_label,
+    },
+    ProviderAddTemplateChoice {
+        template: ProviderAddTemplate::Deepseek,
+        label: "DeepSeek",
     },
 ];
 
@@ -408,6 +428,8 @@ pub fn build_provider_template_seed(
     let category = template_default_category(template).map(str::to_string);
     let meta = template_default_meta(app_type, template);
     let settings_config = build_provider_template_settings_config(app_type, template, &id)?;
+    let icon = template_default_icon(template).map(str::to_string);
+    let icon_color = template_default_icon_color(template).map(str::to_string);
 
     Ok(Provider {
         id,
@@ -418,8 +440,8 @@ pub fn build_provider_template_seed(
         created_at: None,
         sort_index: None,
         notes: None,
-        icon: None,
-        icon_color: None,
+        icon,
+        icon_color,
         meta,
         in_failover_queue: false,
     })
@@ -431,6 +453,7 @@ fn template_default_name(template: ProviderAddTemplate) -> Result<&'static str, 
         ProviderAddTemplate::CodexOauth => "Codex",
         ProviderAddTemplate::OpenaiOfficial => "OpenAI Official",
         ProviderAddTemplate::GoogleOauth => "Google OAuth",
+        ProviderAddTemplate::Deepseek => "DeepSeek",
         ProviderAddTemplate::Packycode
         | ProviderAddTemplate::Aicodemirror
         | ProviderAddTemplate::Cubence
@@ -447,6 +470,7 @@ fn template_default_website_url(template: ProviderAddTemplate) -> Option<&'stati
         ProviderAddTemplate::CodexOauth => Some("https://openai.com/chatgpt/pricing"),
         ProviderAddTemplate::OpenaiOfficial => Some("https://chatgpt.com/codex"),
         ProviderAddTemplate::GoogleOauth => Some("https://ai.google.dev"),
+        ProviderAddTemplate::Deepseek => Some("https://platform.deepseek.com"),
         ProviderAddTemplate::Packycode
         | ProviderAddTemplate::Aicodemirror
         | ProviderAddTemplate::Cubence
@@ -460,6 +484,7 @@ fn template_default_category(template: ProviderAddTemplate) -> Option<&'static s
         ProviderAddTemplate::ClaudeOfficial
         | ProviderAddTemplate::OpenaiOfficial
         | ProviderAddTemplate::GoogleOauth => Some("official"),
+        ProviderAddTemplate::Deepseek => Some("cn_official"),
         ProviderAddTemplate::Custom
         | ProviderAddTemplate::CodexOauth
         | ProviderAddTemplate::Packycode
@@ -489,6 +514,18 @@ fn template_default_meta(
             codex_official: Some(true),
             ..Default::default()
         }),
+        ProviderAddTemplate::Deepseek => Some(ProviderMeta {
+            api_format: Some("openai_chat".to_string()),
+            codex_chat_reasoning: Some(CodexChatReasoningConfig {
+                supports_thinking: Some(true),
+                supports_effort: Some(true),
+                thinking_param: Some("thinking".to_string()),
+                effort_param: Some("reasoning_effort".to_string()),
+                effort_value_mode: Some("deepseek".to_string()),
+                output_format: Some("reasoning_content".to_string()),
+            }),
+            ..Default::default()
+        }),
         ProviderAddTemplate::GoogleOauth => Some(ProviderMeta {
             partner_promotion_key: Some("google-official".to_string()),
             ..Default::default()
@@ -508,6 +545,36 @@ fn template_default_meta(
             meta
         }),
         ProviderAddTemplate::Custom | ProviderAddTemplate::ClaudeOfficial => None,
+    }
+}
+
+fn template_default_icon(template: ProviderAddTemplate) -> Option<&'static str> {
+    match template {
+        ProviderAddTemplate::Deepseek => Some("deepseek"),
+        ProviderAddTemplate::Custom
+        | ProviderAddTemplate::ClaudeOfficial
+        | ProviderAddTemplate::CodexOauth
+        | ProviderAddTemplate::OpenaiOfficial
+        | ProviderAddTemplate::GoogleOauth
+        | ProviderAddTemplate::Packycode
+        | ProviderAddTemplate::Aicodemirror
+        | ProviderAddTemplate::Cubence
+        | ProviderAddTemplate::Dds => None,
+    }
+}
+
+fn template_default_icon_color(template: ProviderAddTemplate) -> Option<&'static str> {
+    match template {
+        ProviderAddTemplate::Deepseek => Some("#1E88E5"),
+        ProviderAddTemplate::Custom
+        | ProviderAddTemplate::ClaudeOfficial
+        | ProviderAddTemplate::CodexOauth
+        | ProviderAddTemplate::OpenaiOfficial
+        | ProviderAddTemplate::GoogleOauth
+        | ProviderAddTemplate::Packycode
+        | ProviderAddTemplate::Aicodemirror
+        | ProviderAddTemplate::Cubence
+        | ProviderAddTemplate::Dds => None,
     }
 }
 
@@ -533,6 +600,7 @@ fn build_provider_template_settings_config(
             }
         })),
         ProviderAddTemplate::OpenaiOfficial => build_codex_official_settings_config(None),
+        ProviderAddTemplate::Deepseek => Ok(build_codex_deepseek_settings_config()),
         ProviderAddTemplate::GoogleOauth => Ok(json!({ "env": {} })),
         ProviderAddTemplate::Packycode
         | ProviderAddTemplate::Aicodemirror
@@ -544,6 +612,26 @@ fn build_provider_template_settings_config(
         ),
         ProviderAddTemplate::Custom => Err(unsupported_template_error(template)),
     }
+}
+
+fn build_codex_deepseek_settings_config() -> Value {
+    json!({
+        "config": DEEPSEEK_CODEX_CONFIG,
+        "modelCatalog": {
+            "models": [
+                {
+                    "model": "deepseek-v4-flash",
+                    "displayName": "DeepSeek V4 Flash",
+                    "contextWindow": 1000000,
+                },
+                {
+                    "model": "deepseek-v4-pro",
+                    "displayName": "DeepSeek V4 Pro",
+                    "contextWindow": 1000000,
+                },
+            ],
+        },
+    })
 }
 
 fn build_sponsor_template_settings_config(
@@ -974,6 +1062,7 @@ requires_openai_auth = true
                 "* AICodeMirror",
                 "* Cubence",
                 "* DDS",
+                "DeepSeek",
             ]
         );
         assert_eq!(
@@ -1008,6 +1097,10 @@ requires_openai_auth = true
         );
         assert!(
             validate_provider_add_template(&AppType::Claude, ProviderAddTemplate::GoogleOauth)
+                .is_err()
+        );
+        assert!(
+            validate_provider_add_template(&AppType::Claude, ProviderAddTemplate::Deepseek)
                 .is_err()
         );
     }
@@ -1371,6 +1464,78 @@ requires_openai_auth = true
                 .as_ref()
                 .and_then(|meta| meta.partner_promotion_key.as_deref()),
             Some("google-official")
+        );
+    }
+
+    #[test]
+    fn cli_codex_deepseek_template_matches_upstream_preset_values() {
+        let provider =
+            build_provider_template_seed(&AppType::Codex, ProviderAddTemplate::Deepseek, &[])
+                .expect("build DeepSeek Codex provider");
+
+        assert_eq!(provider.id, "deepseek");
+        assert_eq!(provider.name, "DeepSeek");
+        assert_eq!(
+            provider.website_url.as_deref(),
+            Some("https://platform.deepseek.com")
+        );
+        assert_eq!(provider.category.as_deref(), Some("cn_official"));
+        assert_eq!(provider.icon.as_deref(), Some("deepseek"));
+        assert_eq!(provider.icon_color.as_deref(), Some("#1E88E5"));
+        assert!(
+            provider.settings_config.get("auth").is_none(),
+            "DeepSeek preset should not persist an empty API key snapshot"
+        );
+
+        let config = provider
+            .settings_config
+            .get("config")
+            .and_then(Value::as_str)
+            .expect("DeepSeek Codex config should be TOML string");
+        assert!(config.contains("model_provider = \"custom\""));
+        assert!(config.contains("model = \"deepseek-v4-flash\""));
+        assert!(config.contains("disable_response_storage = true"));
+        assert!(config.contains("[model_providers.custom]"));
+        assert!(config.contains("name = \"deepseek\""));
+        assert!(config.contains("base_url = \"https://api.deepseek.com\""));
+        assert!(config.contains("wire_api = \"responses\""));
+        assert!(config.contains("requires_openai_auth = true"));
+        assert!(
+            !config.contains("https://api.deepseek.com/v1"),
+            "DeepSeek Codex preset should match upstream base URL without /v1"
+        );
+
+        assert_eq!(
+            provider.settings_config["modelCatalog"],
+            json!({
+                "models": [
+                    {
+                        "model": "deepseek-v4-flash",
+                        "displayName": "DeepSeek V4 Flash",
+                        "contextWindow": 1000000,
+                    },
+                    {
+                        "model": "deepseek-v4-pro",
+                        "displayName": "DeepSeek V4 Pro",
+                        "contextWindow": 1000000,
+                    },
+                ],
+            })
+        );
+
+        let meta = provider.meta.expect("DeepSeek metadata should be present");
+        assert_eq!(meta.api_format.as_deref(), Some("openai_chat"));
+        let reasoning = meta
+            .codex_chat_reasoning
+            .expect("DeepSeek reasoning metadata should be present");
+        assert_eq!(reasoning.supports_thinking, Some(true));
+        assert_eq!(reasoning.supports_effort, Some(true));
+        assert_eq!(reasoning.thinking_param.as_deref(), Some("thinking"));
+        assert_eq!(reasoning.effort_param.as_deref(), Some("reasoning_effort"));
+        assert_eq!(reasoning.effort_value_mode.as_deref(), Some("deepseek"));
+        assert_eq!(
+            reasoning.output_format.as_deref(),
+            Some("reasoning_content")
         );
     }
 

--- a/src-tauri/src/cli/tui/form/provider_templates.rs
+++ b/src-tauri/src/cli/tui/form/provider_templates.rs
@@ -3,9 +3,20 @@ use crate::provider::{ClaudeApiKeyField, CodexChatReasoningConfig};
 use serde_json::json;
 
 use super::{
-    ClaudeApiFormat, CodexModelCatalogField, CodexWireApi, FormMode, GeminiAuthType,
-    ProviderAddFormState, HERMES_DEFAULT_API_MODE, OPENCLAW_DEFAULT_API_PROTOCOL,
+    ClaudeApiFormat, CodexModelCatalogField, CodexModelCatalogRow, CodexWireApi, FormMode,
+    GeminiAuthType, ProviderAddFormState, HERMES_DEFAULT_API_MODE, OPENCLAW_DEFAULT_API_PROTOCOL,
 };
+
+const DEEPSEEK_CODEX_CONFIG: &str = r#"model_provider = "custom"
+model = "deepseek-v4-flash"
+model_reasoning_effort = "high"
+disable_response_storage = true
+
+[model_providers.custom]
+name = "deepseek"
+base_url = "https://api.deepseek.com"
+wire_api = "responses"
+requires_openai_auth = true"#;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ProviderTemplateId {
@@ -13,6 +24,7 @@ enum ProviderTemplateId {
     ClaudeOfficial,
     CodexOAuth,
     OpenAiOfficial,
+    DeepSeek,
     GoogleOAuth,
 }
 
@@ -167,6 +179,12 @@ static PROVIDER_TEMPLATE_DEFS_CODEX: [ProviderTemplateDef; 2] = [
     },
 ];
 
+static PROVIDER_TEMPLATE_DEFS_CODEX_AFTER_SPONSORS: [ProviderTemplateDef; 1] =
+    [ProviderTemplateDef {
+        id: ProviderTemplateId::DeepSeek,
+        label: "DeepSeek",
+    }];
+
 static PROVIDER_TEMPLATE_DEFS_GEMINI: [ProviderTemplateDef; 2] = [
     ProviderTemplateDef {
         id: ProviderTemplateId::Custom,
@@ -215,10 +233,24 @@ pub(super) fn provider_sponsor_presets(app_type: &AppType) -> &'static [SponsorP
     }
 }
 
+pub(super) fn provider_after_sponsor_template_defs(
+    app_type: &AppType,
+) -> &'static [ProviderTemplateDef] {
+    match app_type {
+        AppType::Codex => &PROVIDER_TEMPLATE_DEFS_CODEX_AFTER_SPONSORS,
+        AppType::Claude
+        | AppType::Gemini
+        | AppType::OpenCode
+        | AppType::Hermes
+        | AppType::OpenClaw => &[],
+    }
+}
+
 impl ProviderAddFormState {
     pub fn template_count(&self) -> usize {
         provider_builtin_template_defs(&self.app_type).len()
             + provider_sponsor_presets(&self.app_type).len()
+            + provider_after_sponsor_template_defs(&self.app_type).len()
     }
 
     pub fn template_labels(&self) -> Vec<&'static str> {
@@ -231,27 +263,42 @@ impl ProviderAddFormState {
                 .iter()
                 .map(|preset| preset.chip_label),
         );
+        labels.extend(
+            provider_after_sponsor_template_defs(&self.app_type)
+                .iter()
+                .map(|def| def.label),
+        );
         labels
     }
 
     pub fn apply_template(&mut self, idx: usize, existing_ids: &[String]) {
         let builtin_defs = provider_builtin_template_defs(&self.app_type);
         let sponsor_presets = provider_sponsor_presets(&self.app_type);
-        let total_templates = builtin_defs.len() + sponsor_presets.len();
+        let after_sponsor_defs = provider_after_sponsor_template_defs(&self.app_type);
+        let total_templates = builtin_defs.len() + sponsor_presets.len() + after_sponsor_defs.len();
         let idx = idx.min(total_templates.saturating_sub(1));
         self.template_idx = idx;
         self.id_is_manual = false;
 
-        if idx >= builtin_defs.len() {
+        if idx >= builtin_defs.len() && idx < builtin_defs.len() + sponsor_presets.len() {
             let sponsor_idx = idx.saturating_sub(builtin_defs.len());
             if let Some(preset) = sponsor_presets.get(sponsor_idx) {
                 self.apply_sponsor_preset(preset);
             }
         } else {
-            let template_id = builtin_defs
-                .get(idx)
-                .map(|def| def.id)
-                .unwrap_or(ProviderTemplateId::Custom);
+            let template_id = if idx < builtin_defs.len() {
+                builtin_defs
+                    .get(idx)
+                    .map(|def| def.id)
+                    .unwrap_or(ProviderTemplateId::Custom)
+            } else {
+                let after_sponsor_idx =
+                    idx.saturating_sub(builtin_defs.len() + sponsor_presets.len());
+                after_sponsor_defs
+                    .get(after_sponsor_idx)
+                    .map(|def| def.id)
+                    .unwrap_or(ProviderTemplateId::Custom)
+            };
 
             if template_id == ProviderTemplateId::Custom {
                 if matches!(self.mode, FormMode::Add) {
@@ -387,6 +434,73 @@ impl ProviderAddFormState {
                     self.codex_requires_openai_auth = true;
                     self.codex_env_key.set("");
                     self.reset_codex_local_routing_state();
+                }
+                ProviderTemplateId::DeepSeek => {
+                    self.extra = json!({
+                        "category": "cn_official",
+                        "icon": "deepseek",
+                        "iconColor": "#1E88E5",
+                        "meta": {
+                            "apiFormat": "openai_chat",
+                            "codexChatReasoning": {
+                                "supportsThinking": true,
+                                "supportsEffort": true,
+                                "thinkingParam": "thinking",
+                                "effortParam": "reasoning_effort",
+                                "effortValueMode": "deepseek",
+                                "outputFormat": "reasoning_content",
+                            },
+                        },
+                        "settingsConfig": {
+                            "config": DEEPSEEK_CODEX_CONFIG,
+                            "modelCatalog": {
+                                "models": [
+                                    {
+                                        "model": "deepseek-v4-flash",
+                                        "displayName": "DeepSeek V4 Flash",
+                                        "contextWindow": 1000000,
+                                    },
+                                    {
+                                        "model": "deepseek-v4-pro",
+                                        "displayName": "DeepSeek V4 Pro",
+                                        "contextWindow": 1000000,
+                                    },
+                                ],
+                            },
+                        },
+                    });
+                    self.name.set("DeepSeek");
+                    self.website_url.set("https://platform.deepseek.com");
+                    self.codex_api_key.set("");
+                    self.codex_base_url.set("https://api.deepseek.com");
+                    self.codex_model.set("deepseek-v4-flash");
+                    self.codex_wire_api = CodexWireApi::Responses;
+                    self.codex_requires_openai_auth = true;
+                    self.codex_env_key.set("");
+                    self.claude_api_format = ClaudeApiFormat::OpenAiChat;
+                    self.codex_chat_reasoning = CodexChatReasoningConfig {
+                        supports_thinking: Some(true),
+                        supports_effort: Some(true),
+                        thinking_param: Some("thinking".to_string()),
+                        effort_param: Some("reasoning_effort".to_string()),
+                        effort_value_mode: Some("deepseek".to_string()),
+                        output_format: Some("reasoning_content".to_string()),
+                    };
+                    self.codex_model_catalog = vec![
+                        CodexModelCatalogRow {
+                            model: "deepseek-v4-flash".to_string(),
+                            display_name: "DeepSeek V4 Flash".to_string(),
+                            context_window: "1000000".to_string(),
+                        },
+                        CodexModelCatalogRow {
+                            model: "deepseek-v4-pro".to_string(),
+                            display_name: "DeepSeek V4 Pro".to_string(),
+                            context_window: "1000000".to_string(),
+                        },
+                    ];
+                    self.codex_local_routing_field_idx = 0;
+                    self.codex_model_catalog_idx = 0;
+                    self.codex_model_catalog_field = CodexModelCatalogField::Model;
                 }
                 ProviderTemplateId::GoogleOAuth => {
                     self.extra = json!({

--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -27,6 +27,10 @@ fn dds_template_index(app_type: AppType) -> usize {
     template_index_by_label(app_type, "* DDS")
 }
 
+fn deepseek_template_index(app_type: AppType) -> usize {
+    template_index_by_label(app_type, "DeepSeek")
+}
+
 fn normalize_template_provider_json(mut value: serde_json::Value) -> serde_json::Value {
     if let Some(obj) = value.as_object_mut() {
         obj.remove("inFailoverQueue");
@@ -104,6 +108,7 @@ fn provider_add_form_template_labels_follow_explicit_support_matrix() {
             "* AICodeMirror",
             "* Cubence",
             "* DDS",
+            "DeepSeek",
         ]
     );
 
@@ -172,6 +177,7 @@ fn cli_provider_templates_match_tui_serializer_output() {
             ProviderAddTemplate::Aicodemirror,
             "* AICodeMirror",
         ),
+        (AppType::Codex, ProviderAddTemplate::Deepseek, "DeepSeek"),
         (AppType::Gemini, ProviderAddTemplate::Cubence, "* Cubence"),
         (AppType::Claude, ProviderAddTemplate::Dds, "* DDS"),
         (
@@ -190,6 +196,84 @@ fn cli_provider_templates_match_tui_serializer_output() {
     ] {
         assert_cli_template_matches_tui_serializer(app_type, template, label);
     }
+}
+
+#[test]
+fn provider_add_form_codex_deepseek_template_matches_upstream_preset_values() {
+    let mut form = ProviderAddFormState::new(AppType::Codex);
+    let existing_ids = Vec::<String>::new();
+
+    form.apply_template(deepseek_template_index(AppType::Codex), &existing_ids);
+
+    assert_eq!(form.id.value, "deepseek");
+    assert_eq!(form.name.value, "DeepSeek");
+    assert_eq!(form.website_url.value, "https://platform.deepseek.com");
+    assert_eq!(form.codex_base_url.value, "https://api.deepseek.com");
+    assert_eq!(form.codex_model.value, "deepseek-v4-flash");
+    assert_eq!(form.codex_wire_api, CodexWireApi::Responses);
+    assert!(form.codex_requires_openai_auth);
+
+    let labels = ProviderAddFormState::new(AppType::Codex).template_labels();
+    assert_eq!(
+        labels.last().copied(),
+        Some("DeepSeek"),
+        "DeepSeek should stay after all partner presets"
+    );
+
+    let fields = form.fields();
+    assert!(fields.contains(&ProviderAddField::CodexBaseUrl));
+    assert!(fields.contains(&ProviderAddField::CodexModel));
+    assert!(fields.contains(&ProviderAddField::CodexApiKey));
+
+    let provider = form.to_provider_json_value();
+    assert_eq!(provider["category"], "cn_official");
+    assert_eq!(provider["icon"], "deepseek");
+    assert_eq!(provider["iconColor"], "#1E88E5");
+    assert_eq!(provider["meta"]["apiFormat"], "openai_chat");
+    assert_eq!(
+        provider["meta"]["codexChatReasoning"],
+        json!({
+            "supportsThinking": true,
+            "supportsEffort": true,
+            "thinkingParam": "thinking",
+            "effortParam": "reasoning_effort",
+            "effortValueMode": "deepseek",
+            "outputFormat": "reasoning_content",
+        })
+    );
+
+    let cfg = provider["settingsConfig"]["config"]
+        .as_str()
+        .expect("settingsConfig.config should be TOML string");
+    assert!(cfg.contains("model_provider = \"custom\""));
+    assert!(cfg.contains("model = \"deepseek-v4-flash\""));
+    assert!(cfg.contains("disable_response_storage = true"));
+    assert!(cfg.contains("[model_providers.custom]"));
+    assert!(cfg.contains("name = \"deepseek\""));
+    assert!(cfg.contains("base_url = \"https://api.deepseek.com\""));
+    assert!(cfg.contains("wire_api = \"responses\""));
+    assert!(cfg.contains("requires_openai_auth = true"));
+    assert!(
+        !cfg.contains("https://api.deepseek.com/v1"),
+        "DeepSeek Codex preset should match upstream base URL without /v1"
+    );
+    assert_eq!(
+        provider["settingsConfig"]["modelCatalog"],
+        json!({
+            "models": [
+                {
+                    "model": "deepseek-v4-flash",
+                    "displayName": "DeepSeek V4 Flash",
+                    "contextWindow": 1000000,
+                },
+                {
+                    "model": "deepseek-v4-pro",
+                    "displayName": "DeepSeek V4 Pro",
+                    "contextWindow": 1000000,
+                },
+            ],
+        })
+    );
 }
 
 #[test]

--- a/src-tauri/src/proxy/forwarder/request_builder.rs
+++ b/src-tauri/src/proxy/forwarder/request_builder.rs
@@ -275,6 +275,7 @@ impl RequestForwarder {
                 .then_some(self.session_id.as_str()),
             force_identity_encoding,
             claude_api_format.as_deref(),
+            codex_responses_to_chat,
             copilot_optimization.as_ref(),
         )
         .await
@@ -400,6 +401,7 @@ async fn build_request(
     client_session_id: Option<&str>,
     force_identity_encoding: bool,
     claude_api_format: Option<&str>,
+    codex_responses_to_chat: bool,
     copilot_optimization: Option<&CopilotOptimization>,
 ) -> Result<reqwest::RequestBuilder, ProxyError> {
     let (endpoint_path, endpoint_query) = split_endpoint_and_query(endpoint);
@@ -424,6 +426,8 @@ async fn build_request(
         && endpoint_path.trim_matches('/') == "chat/completions"
     {
         append_query_to_url(base_url.trim_end_matches('/'), endpoint_query)
+    } else if codex_responses_to_chat {
+        append_endpoint_to_base_url(base_url, endpoint)
     } else {
         adapter.build_url(base_url, endpoint)
     };
@@ -713,6 +717,14 @@ fn append_query_to_url(url: &str, query: Option<&str>) -> String {
     } else {
         format!("{url}?{query}")
     }
+}
+
+fn append_endpoint_to_base_url(base_url: &str, endpoint: &str) -> String {
+    format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        endpoint.trim_start_matches('/')
+    )
 }
 
 fn reject_proxy_placeholder_for_managed_account_upstream(

--- a/src-tauri/src/proxy/forwarder/tests/request_building.rs
+++ b/src-tauri/src/proxy/forwarder/tests/request_building.rs
@@ -1534,6 +1534,40 @@ async fn codex_chat_prepare_request_preserves_responses_compact_query() {
 }
 
 #[tokio::test]
+async fn codex_chat_prepare_request_uses_provider_chat_base_without_forcing_v1() {
+    let provider = codex_chat_provider("https://api.deepseek.com", "deepseek-v4-pro");
+    let (_db, router) = test_router().await;
+    let forwarder = RequestForwarder::new(router).expect("create forwarder");
+    let request_body = json!({
+        "model": "gpt-5.4",
+        "input": "hello"
+    });
+
+    let request = forwarder
+        .prepare_request(
+            &AppType::Codex,
+            &provider,
+            "/v1/responses?foo=bar",
+            &request_body,
+            &HeaderMap::new(),
+            ForwardOptions {
+                max_retries: 0,
+                request_timeout: Some(Duration::from_secs(2)),
+                bypass_circuit_breaker: true,
+            },
+        )
+        .await
+        .expect("prepare Codex Chat bridge request")
+        .build()
+        .expect("build Codex Chat bridge request");
+
+    assert_eq!(
+        request.url().as_str(),
+        "https://api.deepseek.com/chat/completions?foo=bar"
+    );
+}
+
+#[tokio::test]
 async fn codex_chat_prepare_request_preserves_full_chat_endpoint_base_url() {
     let provider = codex_chat_provider(
         "https://example.com/openai/v1/chat/completions",


### PR DESCRIPTION
## Summary
- add an upstream-aligned DeepSeek Codex preset after partner presets in TUI and CLI
- keep DeepSeek Codex Chat routing metadata, reasoning defaults, and model catalog aligned with upstream
- build Codex Responses -> Chat bridge URLs from the configured provider base without forcing `/v1`

Fixes #242

## Tests
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml provider_add_form_template_labels_follow_explicit_support_matrix`
- `cargo test --manifest-path src-tauri/Cargo.toml cli_provider_template_labels_follow_tui_support_matrix`
- `cargo test --manifest-path src-tauri/Cargo.toml --quiet provider_add_form_codex_deepseek_template_matches_upstream_preset_values`
- `cargo test --manifest-path src-tauri/Cargo.toml --quiet cli_codex_deepseek_template_matches_upstream_preset_values`
- `cargo test --manifest-path src-tauri/Cargo.toml --quiet cli_provider_templates_match_tui_serializer_output`
- `cargo test --manifest-path src-tauri/Cargo.toml --quiet codex_chat_prepare_request_uses_provider_chat_base_without_forcing_v1`
- `git diff --check`