### PR TITLE
fix(usage): correct inflated input_tokens and Zhipu quota routing

### DIFF
--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -333,16 +333,42 @@ impl TokenUsage {
                             {
                                 usage.output_tokens = output as u32;
                             }
-                            // OpenRouter 转换后的流式响应：input_tokens 也在 message_delta 中
-                            // 如果 message_start 中没有 input_tokens，则从 message_delta 获取
-                            if usage.input_tokens == 0 {
-                                if let Some(input) =
-                                    delta_usage.get("input_tokens").and_then(|v| v.as_u64())
+                            // 部分 Anthropic 兼容上游（如 Qwen、MiniMax）在 message_start
+                            // 中将 fresh+cached 合并报告为 input_tokens，导致虚高。
+                            // 当 message_delta 提供了更小的正值 input_tokens 时，优先采用
+                            // delta 的值，并同步更新缓存计数以避免重复计算。
+                            if let Some(input) =
+                                delta_usage.get("input_tokens").and_then(|v| v.as_u64())
+                            {
+                                let delta_input = input as u32;
+                                if delta_input > 0
+                                    && (usage.input_tokens == 0
+                                        || delta_input < usage.input_tokens)
                                 {
-                                    usage.input_tokens = input as u32;
+                                    usage.input_tokens = delta_input;
+                                    // 同步采用 delta 中的缓存计数
+                                    if let Some(cache_read) = delta_usage
+                                        .get("cache_read_input_tokens")
+                                        .and_then(|v| v.as_u64())
+                                    {
+                                        usage.cache_read_tokens = cache_read as u32;
+                                    }
+                                    if let Some(cache_creation) = delta_usage
+                                        .get("cache_creation_input_tokens")
+                                        .and_then(|v| v.as_u64())
+                                    {
+                                        usage.cache_creation_tokens = cache_creation as u32;
+                                    }
+                                }
+                            } else {
+                                // OpenRouter 转换后的流式响应：input_tokens 仅在
+                                // message_delta 中且 message_start 未提供时的回退路径
+                                if usage.input_tokens == 0 {
+                                    // (no input_tokens in delta, keep start value)
                                 }
                             }
                             // 从 message_delta 中处理缓存命中(cache_read_input_tokens)
+                            // 仅当上面未从 delta 同步时才回退
                             if usage.cache_read_tokens == 0 {
                                 if let Some(cache_read) = delta_usage
                                     .get("cache_read_input_tokens")
@@ -352,7 +378,6 @@ impl TokenUsage {
                                 }
                             }
                             // 从 message_delta 中处理缓存创建(cache_creation_input_tokens)
-                            // 注: 现在 zhipu 没有返回 cache_creation_input_tokens 字段
                             if usage.cache_creation_tokens == 0 {
                                 if let Some(cache_creation) = delta_usage
                                     .get("cache_creation_input_tokens")

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -1161,4 +1161,102 @@ mod tests {
         assert_eq!(usage.output_tokens, 50);
         assert_eq!(usage.model, Some("gpt-4o".to_string()));
     }
+
+    #[test]
+    fn test_claude_stream_delta_input_override_inflated_start() {
+        // Some providers (Qwen, MiniMax) report fresh+cached as input_tokens in
+        // message_start, inflating the count. message_delta provides the correct
+        // (smaller) value that should override.
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {
+                        "input_tokens": 10000,
+                        "cache_read_input_tokens": 8000,
+                        "cache_creation_input_tokens": 0
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "output_tokens": 50,
+                    "input_tokens": 2000,
+                    "cache_read_input_tokens": 1500,
+                    "cache_creation_input_tokens": 0
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        // Delta input_tokens (2000) < start input_tokens (10000), so override
+        assert_eq!(usage.input_tokens, 2000);
+        assert_eq!(usage.output_tokens, 50);
+        // Cache counts synced from delta
+        assert_eq!(usage.cache_read_tokens, 1500);
+        assert_eq!(usage.cache_creation_tokens, 0);
+    }
+
+    #[test]
+    fn test_claude_stream_delta_input_not_overridden_when_larger() {
+        // If delta input_tokens is larger than start, keep the start value
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {
+                        "input_tokens": 1000,
+                        "cache_read_input_tokens": 200,
+                        "cache_creation_input_tokens": 0
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "output_tokens": 50,
+                    "input_tokens": 2000
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        // Delta (2000) > start (1000), so keep start value
+        assert_eq!(usage.input_tokens, 1000);
+        assert_eq!(usage.output_tokens, 50);
+    }
+
+    #[test]
+    fn test_claude_stream_delta_input_overrides_when_start_is_zero() {
+        // When start has zero input_tokens, delta should always be adopted
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {
+                        "input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "output_tokens": 50,
+                    "input_tokens": 500,
+                    "cache_read_input_tokens": 100
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 500);
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.cache_read_tokens, 100);
+    }
 }

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -342,8 +342,7 @@ impl TokenUsage {
                             {
                                 let delta_input = input as u32;
                                 if delta_input > 0
-                                    && (usage.input_tokens == 0
-                                        || delta_input < usage.input_tokens)
+                                    && (usage.input_tokens == 0 || delta_input < usage.input_tokens)
                                 {
                                     usage.input_tokens = delta_input;
                                     // 同步采用 delta 中的缓存计数

--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -464,7 +464,9 @@ pub async fn get_coding_plan_quota(
 
     let quota = match provider {
         CodingPlanProvider::Kimi => query_kimi(api_key).await,
-        CodingPlanProvider::ZhipuCn | CodingPlanProvider::ZhipuEn => query_zhipu(base_url, api_key).await,
+        CodingPlanProvider::ZhipuCn | CodingPlanProvider::ZhipuEn => {
+            query_zhipu(base_url, api_key).await
+        }
         CodingPlanProvider::MiniMaxCn => query_minimax(api_key, true).await,
         CodingPlanProvider::MiniMaxEn => query_minimax(api_key, false).await,
     };

--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -181,6 +181,28 @@ async fn query_kimi(api_key: &str) -> SubscriptionQuota {
 
 // ── 智谱 GLM ────────────────────────────────────────────────
 
+/// 智谱 TOKENS_LIMIT 条目按 `unit` 字段的显式窗口分类。
+enum ZhipuWindow {
+    FiveHour,
+    Weekly,
+}
+
+/// 按 `unit` 字段判定 TOKENS_LIMIT 条目所属窗口。
+///
+/// 实测形态（bigmodel.cn 与 z.ai 共用同一后端，字段一致）：
+/// - `unit: 3, number: 5` → 5 小时滚动窗口（老/新套餐均有）
+/// - `unit: 6, number: 7` 与 `unit: 6, number: 1` → 每周窗口（两种取值都被
+///   实测过，故只锚定 `unit`、不绑 `number`）
+///
+/// `unit` 缺失或值不认识时返回 None，由调用方走重置时间启发式兜底。
+fn classify_zhipu_window(item: &serde_json::Value) -> Option<ZhipuWindow> {
+    match item.get("unit").and_then(|v| v.as_i64()) {
+        Some(3) => Some(ZhipuWindow::FiveHour),
+        Some(6) => Some(ZhipuWindow::Weekly),
+        _ => None,
+    }
+}
+
 /// 根据用户配置的 base_url 确定智谱配额查询端点。
 /// 中国大陆用户使用 open.bigmodel.cn，国际用户使用 api.z.ai。
 fn zhipu_quota_base(base_url: &str) -> &'static str {
@@ -251,7 +273,14 @@ async fn query_zhipu(base_url: &str, api_key: &str) -> SubscriptionQuota {
         None => return make_error("Missing 'data' field in response".to_string()),
     };
 
-    let mut tiers = Vec::new();
+    // 按 `unit` 字段分类 TOKENS_LIMIT 条目：
+    // - unit: 3 → 5 小时滚动窗口
+    // - unit: 6 → 每周窗口
+    // unit 缺失或不识别时走重置时间启发式兜底。
+    type Entry = (Option<i64>, f64, Option<String>);
+    let mut five_hour: Option<Entry> = None;
+    let mut weekly: Option<Entry> = None;
+    let mut unclassified: Vec<Entry> = Vec::new();
 
     if let Some(limits) = data.get("limits").and_then(|v| v.as_array()) {
         for limit_item in limits {
@@ -259,35 +288,46 @@ async fn query_zhipu(base_url: &str, api_key: &str) -> SubscriptionQuota {
                 .get("type")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
+            if !limit_type.eq_ignore_ascii_case("TOKENS_LIMIT") {
+                continue;
+            }
             let percentage = limit_item
                 .get("percentage")
                 .and_then(|v| v.as_f64())
                 .unwrap_or(0.0);
-            let next_reset = limit_item
-                .get("nextResetTime")
-                .and_then(|v| v.as_i64())
-                .and_then(millis_to_iso8601);
-
-            if limit_type != "TOKENS_LIMIT" {
-                continue;
+            let reset_ms = limit_item.get("nextResetTime").and_then(|v| v.as_i64());
+            let reset_iso = reset_ms.and_then(millis_to_iso8601);
+            let entry = (reset_ms, percentage, reset_iso);
+            match classify_zhipu_window(limit_item) {
+                Some(ZhipuWindow::FiveHour) if five_hour.is_none() => five_hour = Some(entry),
+                Some(ZhipuWindow::Weekly) if weekly.is_none() => weekly = Some(entry),
+                _ => unclassified.push(entry),
             }
-
-            tiers.push(QuotaTier {
-                name: "five_hour".to_string(),
-                utilization: percentage,
-                resets_at: next_reset,
-            });
         }
     }
 
-    // 按 nextResetTime 排序：缺失的（刚重置的 5 小时桶）排在前面，
-    // 有值的按重置时间升序排列，确保显示顺序正确。
-    tiers.sort_by(|a, b| match (&a.resets_at, &b.resets_at) {
-        (None, None) => std::cmp::Ordering::Equal,
-        (None, Some(_)) => std::cmp::Ordering::Less,
-        (Some(_), None) => std::cmp::Ordering::Greater,
-        (Some(a_time), Some(b_time)) => a_time.cmp(b_time),
-    });
+    // 兜底启发式：无 nextResetTime 的条目优先归 five_hour（5 小时桶在 0% 等
+    // 状态下可能没有 reset），其余按 reset 升序依次填入仍空缺的槽位。
+    unclassified.sort_by_key(|(reset, _, _)| (reset.is_some(), reset.unwrap_or(i64::MIN)));
+    for entry in unclassified {
+        if five_hour.is_none() {
+            five_hour = Some(entry);
+        } else if weekly.is_none() {
+            weekly = Some(entry);
+        }
+        // 智谱当前最多两条 TOKENS_LIMIT，多余的忽略
+    }
+
+    let mut tiers = Vec::new();
+    for (name, slot) in [("five_hour", five_hour), ("weekly_limit", weekly)] {
+        if let Some((_, percentage, resets_at)) = slot {
+            tiers.push(QuotaTier {
+                name: name.to_string(),
+                utilization: percentage,
+                resets_at,
+            });
+        }
+    }
 
     // 套餐等级存入 credential_message
     let level = data
@@ -478,6 +518,7 @@ pub async fn get_coding_plan_quota(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn zhipu_quota_base_cn() {
@@ -591,5 +632,45 @@ mod tests {
         });
         assert_eq!(tiers[0].name, "five_hour");
         assert_eq!(tiers[1].name, "weekly");
+    }
+
+    #[test]
+    fn classify_zhipu_window_five_hour() {
+        let item = json!({"unit": 3, "number": 5});
+        assert!(matches!(
+            classify_zhipu_window(&item),
+            Some(ZhipuWindow::FiveHour)
+        ));
+    }
+
+    #[test]
+    fn classify_zhipu_window_weekly() {
+        let item = json!({"unit": 6, "number": 7});
+        assert!(matches!(
+            classify_zhipu_window(&item),
+            Some(ZhipuWindow::Weekly)
+        ));
+    }
+
+    #[test]
+    fn classify_zhipu_window_weekly_variant() {
+        // 实测 unit:6, number:1 也是每周窗口
+        let item = json!({"unit": 6, "number": 1});
+        assert!(matches!(
+            classify_zhipu_window(&item),
+            Some(ZhipuWindow::Weekly)
+        ));
+    }
+
+    #[test]
+    fn classify_zhipu_window_unknown_unit() {
+        let item = json!({"unit": 99, "number": 5});
+        assert!(classify_zhipu_window(&item).is_none());
+    }
+
+    #[test]
+    fn classify_zhipu_window_missing_unit() {
+        let item = json!({"number": 5});
+        assert!(classify_zhipu_window(&item).is_none());
     }
 }

--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -181,12 +181,25 @@ async fn query_kimi(api_key: &str) -> SubscriptionQuota {
 
 // ── 智谱 GLM ────────────────────────────────────────────────
 
-async fn query_zhipu(api_key: &str) -> SubscriptionQuota {
+/// 根据用户配置的 base_url 确定智谱配额查询端点。
+/// 中国大陆用户使用 open.bigmodel.cn，国际用户使用 api.z.ai。
+fn zhipu_quota_base(base_url: &str) -> &'static str {
+    if base_url.contains("bigmodel.cn") {
+        "https://open.bigmodel.cn"
+    } else {
+        "https://api.z.ai"
+    }
+}
+
+async fn query_zhipu(base_url: &str, api_key: &str) -> SubscriptionQuota {
     let client = crate::proxy::http_client::get();
 
-    // 统一走 api.z.ai 国际站（中国站 bigmodel.cn 有反爬机制）
+    let quota_url = format!(
+        "{}/api/monitor/usage/quota/limit",
+        zhipu_quota_base(base_url)
+    );
     let resp = client
-        .get("https://api.z.ai/api/monitor/usage/quota/limit")
+        .get(&quota_url)
         .header("Authorization", api_key) // 注意：智谱不加 Bearer 前缀
         .header("Content-Type", "application/json")
         .header("Accept-Language", "en-US,en")
@@ -265,6 +278,15 @@ async fn query_zhipu(api_key: &str) -> SubscriptionQuota {
             });
         }
     }
+
+    // 按 nextResetTime 排序：缺失的（刚重置的 5 小时桶）排在前面，
+    // 有值的按重置时间升序排列，确保显示顺序正确。
+    tiers.sort_by(|a, b| match (&a.resets_at, &b.resets_at) {
+        (None, None) => std::cmp::Ordering::Equal,
+        (None, Some(_)) => std::cmp::Ordering::Less,
+        (Some(_), None) => std::cmp::Ordering::Greater,
+        (Some(a_time), Some(b_time)) => a_time.cmp(b_time),
+    });
 
     // 套餐等级存入 credential_message
     let level = data
@@ -442,7 +464,7 @@ pub async fn get_coding_plan_quota(
 
     let quota = match provider {
         CodingPlanProvider::Kimi => query_kimi(api_key).await,
-        CodingPlanProvider::ZhipuCn | CodingPlanProvider::ZhipuEn => query_zhipu(api_key).await,
+        CodingPlanProvider::ZhipuCn | CodingPlanProvider::ZhipuEn => query_zhipu(base_url, api_key).await,
         CodingPlanProvider::MiniMaxCn => query_minimax(api_key, true).await,
         CodingPlanProvider::MiniMaxEn => query_minimax(api_key, false).await,
     };

--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -184,7 +184,8 @@ async fn query_kimi(api_key: &str) -> SubscriptionQuota {
 /// 根据用户配置的 base_url 确定智谱配额查询端点。
 /// 中国大陆用户使用 open.bigmodel.cn，国际用户使用 api.z.ai。
 fn zhipu_quota_base(base_url: &str) -> &'static str {
-    if base_url.contains("bigmodel.cn") {
+    let url = base_url.to_lowercase();
+    if url.contains("bigmodel.cn") {
         "https://open.bigmodel.cn"
     } else {
         "https://api.z.ai"
@@ -472,4 +473,123 @@ pub async fn get_coding_plan_quota(
     };
 
     Ok(quota)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zhipu_quota_base_cn() {
+        assert_eq!(
+            zhipu_quota_base("https://open.bigmodel.cn/api/paas/v4"),
+            "https://open.bigmodel.cn"
+        );
+    }
+
+    #[test]
+    fn zhipu_quota_base_en() {
+        assert_eq!(
+            zhipu_quota_base("https://api.z.ai/api/paas/v4"),
+            "https://api.z.ai"
+        );
+    }
+
+    #[test]
+    fn zhipu_quota_base_case_insensitive() {
+        assert_eq!(
+            zhipu_quota_base("https://OPEN.BIGMODEL.CN/api/paas/v4"),
+            "https://open.bigmodel.cn"
+        );
+        assert_eq!(
+            zhipu_quota_base("https://Api.Z.AI/api/paas/v4"),
+            "https://api.z.ai"
+        );
+    }
+
+    #[test]
+    fn detect_provider_case_insensitive() {
+        assert!(matches!(
+            detect_provider("https://OPEN.BIGMODEL.CN/api/paas/v4"),
+            Some(CodingPlanProvider::ZhipuCn)
+        ));
+        assert!(matches!(
+            detect_provider("https://Api.Z.AI/api/paas/v4"),
+            Some(CodingPlanProvider::ZhipuEn)
+        ));
+    }
+
+    #[test]
+    fn zhipu_quota_base_matches_detect_provider_for_cn() {
+        // Ensure zhipu_quota_base and detect_provider agree on CN vs EN
+        let urls = [
+            "https://open.bigmodel.cn/api/paas/v4",
+            "https://OPEN.BIGMODEL.CN/api/paas/v4",
+            "https://api.z.ai/api/paas/v4",
+            "https://Api.Z.AI/api/paas/v4",
+        ];
+        for url in &urls {
+            let provider = detect_provider(url);
+            let base = zhipu_quota_base(url);
+            match provider {
+                Some(CodingPlanProvider::ZhipuCn) => {
+                    assert_eq!(base, "https://open.bigmodel.cn", "CN mismatch for {url}")
+                }
+                Some(CodingPlanProvider::ZhipuEn) => {
+                    assert_eq!(base, "https://api.z.ai", "EN mismatch for {url}")
+                }
+                _ => panic!("unexpected provider for {url}"),
+            }
+        }
+    }
+
+    #[test]
+    fn zhipu_tier_sorting_none_resets_at_first() {
+        // When the 5-hour bucket has 0% utilization, nextResetTime is absent.
+        // Tiers with None resets_at should sort before those with Some.
+        let mut tiers = vec![
+            QuotaTier {
+                name: "weekly".to_string(),
+                utilization: 50.0,
+                resets_at: Some("2026-06-15T00:00:00Z".to_string()),
+            },
+            QuotaTier {
+                name: "five_hour".to_string(),
+                utilization: 0.0,
+                resets_at: None,
+            },
+        ];
+        tiers.sort_by(|a, b| match (&a.resets_at, &b.resets_at) {
+            (None, None) => std::cmp::Ordering::Equal,
+            (None, Some(_)) => std::cmp::Ordering::Less,
+            (Some(_), None) => std::cmp::Ordering::Greater,
+            (Some(a_time), Some(b_time)) => a_time.cmp(b_time),
+        });
+        assert_eq!(tiers[0].name, "five_hour");
+        assert_eq!(tiers[1].name, "weekly");
+    }
+
+    #[test]
+    fn zhipu_tier_sorting_by_reset_time_ascending() {
+        let mut tiers = vec![
+            QuotaTier {
+                name: "weekly".to_string(),
+                utilization: 50.0,
+                resets_at: Some("2026-06-15T00:00:00Z".to_string()),
+            },
+            QuotaTier {
+                name: "five_hour".to_string(),
+                utilization: 30.0,
+                resets_at: Some("2026-06-10T12:00:00Z".to_string()),
+            },
+        ];
+        tiers.sort_by(|a, b| match (&a.resets_at, &b.resets_at) {
+            (None, None) => std::cmp::Ordering::Equal,
+            (None, Some(_)) => std::cmp::Ordering::Less,
+            (Some(_), None) => std::cmp::Ordering::Greater,
+            (Some(a_time), Some(b_time)) => a_time.cmp(b_time),
+        });
+        assert_eq!(tiers[0].name, "five_hour");
+        assert_eq!(tiers[1].name, "weekly");
+    }
 }


### PR DESCRIPTION
## Summary

### 1. Inflated input_tokens in Claude stream parsing

Some Anthropic-compatible SSE providers (e.g. Qwen, MiniMax) report the full context (fresh + cached) as `input_tokens` in `message_start`, double-counting the cached portion. The `message_delta` handler only adopted `input_tokens` when the start value was exactly zero, so the correct (smaller) delta value was silently discarded.

**Fix:** When `message_delta` provides a positive `input_tokens` smaller than the current value, prefer it and sync cache counts from the same delta block.

### 2. Zhipu quota query hardcoded to international endpoint

`query_zhipu()` always hit `https://api.z.ai`, making quota queries fail for users on the mainland China preset (`open.bigmodel.cn`).

**Fix:** Route by the configured `base_url` — `open.bigmodel.cn` users query `open.bigmodel.cn`, others query `api.z.ai`.

### 3. Zhipu tier sorting

When the 5-hour bucket is at 0% utilization, the API omits `nextResetTime`. Without sorting, the weekly bucket could incorrectly claim the five-hour slot.

**Fix:** Sort tiers with missing `nextResetTime` first (just-reset 5-hour bucket), then by reset time ascending.

## Changes

- `src-tauri/src/proxy/usage/parser.rs` — update `from_claude_stream_events` delta handling
- `src-tauri/src/services/coding_plan.rs` — add `zhipu_quota_base` helper, update `query_zhipu` signature, add tier sorting

Closes #259