### PR TITLE
fix(codex): use relative filename for catalog path and include archived sessions

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -530,8 +530,7 @@ fn set_codex_model_catalog_json_field(
     match catalog_path {
         Some(_path) => {
             // 使用相对文件名而非绝对路径，保持与 Codex 自身引用方式一致
-            doc["model_catalog_json"] =
-                toml_edit::value(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME);
+            doc["model_catalog_json"] = toml_edit::value(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME);
         }
         None => {
             let should_remove = doc
@@ -1522,7 +1521,7 @@ name = "any"
             parsed
                 .get("model_catalog_json")
                 .and_then(toml::Value::as_str),
-            Some("/tmp/cc-switch-model-catalog.json")
+            Some("cc-switch-model-catalog.json")
         );
         assert!(
             parsed
@@ -1691,7 +1690,7 @@ wire_api = "responses"
             parsed
                 .get("model_catalog_json")
                 .and_then(toml::Value::as_str),
-            Some(get_codex_model_catalog_path().to_string_lossy().as_ref())
+            Some(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME)
         );
         let generated_catalog: Value = serde_json::from_str(
             &fs::read_to_string(get_codex_model_catalog_path()).expect("read catalog"),

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -528,8 +528,10 @@ fn set_codex_model_catalog_json_field(
     let generated_path = get_codex_model_catalog_path();
 
     match catalog_path {
-        Some(path) => {
-            doc["model_catalog_json"] = toml_edit::value(path.to_string_lossy().as_ref());
+        Some(_path) => {
+            // 使用相对文件名而非绝对路径，保持与 Codex 自身引用方式一致
+            doc["model_catalog_json"] =
+                toml_edit::value(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME);
         }
         None => {
             let should_remove = doc

--- a/src-tauri/src/session_manager/providers/codex.rs
+++ b/src-tauri/src/session_manager/providers/codex.rs
@@ -22,9 +22,16 @@ static UUID_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 pub fn scan_sessions() -> Vec<SessionMeta> {
-    let root = get_codex_config_dir().join("sessions");
+    let config_dir = get_codex_config_dir();
     let mut files = Vec::new();
-    collect_jsonl_files(&root, &mut files);
+
+    // 扫描活跃会话目录（按日期分区）
+    let sessions_root = config_dir.join("sessions");
+    collect_jsonl_files(&sessions_root, &mut files);
+
+    // 扫描归档会话目录（扁平结构）
+    let archived_root = config_dir.join("archived_sessions");
+    collect_jsonl_files(&archived_root, &mut files);
 
     let mut sessions = Vec::new();
     for path in files {


### PR DESCRIPTION
## Summary

### 1. model_catalog_json uses absolute path

`set_codex_model_catalog_json_field` wrote the full absolute path (e.g. `/home/user/.codex/cc-switch-model-catalog.json`) into `config.toml`. This breaks portability and is inconsistent with how Codex itself references catalog files.

**Fix:** Write the relative filename `cc-switch-model-catalog.json` instead. The guard logic already handles both formats defensively.

### 2. Archived sessions not discoverable

The Session Manager only scanned `sessions/` but not `archived_sessions/`, making archived Codex sessions invisible in TUI/CLI.

**Fix:** Scan `archived_sessions/` alongside `sessions/` in `scan_sessions()`. Note: the session usage sync code already scanned both directories — this gap was only in the session manager.

## Changes

- `src-tauri/src/codex_config.rs` — write relative filename in `set_codex_model_catalog_json_field`
- `src-tauri/src/session_manager/providers/codex.rs` — add `archived_sessions/` scanning in `scan_sessions()`

Closes #260