### PR TITLE
feat: preserve and edit OpenCode provider modalities field

### DIFF
--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -63,6 +63,14 @@ pub fn get_providers() -> Result<Map<String, Value>, AppError> {
 }
 
 pub fn set_provider(id: &str, provider: Value) -> Result<(), AppError> {
+    set_provider_value(id, provider, true)
+}
+
+fn set_provider_value(
+    id: &str,
+    mut provider: Value,
+    preserve_modalities: bool,
+) -> Result<(), AppError> {
     let mut full_config = read_opencode_config()?;
 
     if full_config.get("provider").is_none() {
@@ -73,6 +81,21 @@ pub fn set_provider(id: &str, provider: Value) -> Result<(), AppError> {
         .get_mut("provider")
         .and_then(Value::as_object_mut)
     {
+        if preserve_modalities {
+            if let Some(incoming) = provider.as_object_mut() {
+                if !incoming.contains_key("modalities") {
+                    if let Some(modalities) = providers
+                        .get(id)
+                        .and_then(Value::as_object)
+                        .and_then(|existing| existing.get("modalities"))
+                        .cloned()
+                    {
+                        incoming.insert("modalities".to_string(), modalities);
+                    }
+                }
+            }
+        }
+
         providers.insert(id.to_string(), provider);
     }
 
@@ -108,7 +131,7 @@ pub fn get_typed_providers() -> Result<IndexMap<String, OpenCodeProviderConfig>,
 pub fn set_typed_provider(id: &str, config: &OpenCodeProviderConfig) -> Result<(), AppError> {
     let value =
         serde_json::to_value(config).map_err(|source| AppError::JsonSerialize { source })?;
-    set_provider(id, value)
+    set_provider_value(id, value, false)
 }
 
 pub fn get_mcp_servers() -> Result<Map<String, Value>, AppError> {
@@ -142,4 +165,80 @@ pub fn remove_mcp_server(id: &str) -> Result<(), AppError> {
     }
 
     write_opencode_config(&config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestEnvGuard;
+    use serde_json::json;
+
+    fn provider_without_modalities(base_url: &str) -> Value {
+        json!({
+            "npm": OPENCODE_DEFAULT_NPM,
+            "options": {
+                "baseURL": base_url
+            }
+        })
+    }
+
+    fn seed_provider_with_modalities(modalities: &Value) {
+        write_opencode_config(&json!({
+            "$schema": "https://opencode.ai/config.json",
+            "provider": {
+                "vision": {
+                    "npm": OPENCODE_DEFAULT_NPM,
+                    "options": {
+                        "baseURL": "https://old.example.com/v1"
+                    },
+                    "modalities": modalities
+                }
+            }
+        }))
+        .expect("seed opencode config");
+    }
+
+    #[test]
+    fn opencode_provider_config_raw_set_provider_preserves_modalities_on_omit() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let _env = TestEnvGuard::isolated(temp.path());
+        let modalities = json!({ "input": ["text", "image"] });
+        seed_provider_with_modalities(&modalities);
+
+        set_provider(
+            "vision",
+            provider_without_modalities("https://new.example.com/v1"),
+        )
+        .expect("set raw provider");
+
+        let live = read_opencode_config().expect("read opencode config");
+        assert_eq!(
+            live["provider"]["vision"]["options"]["baseURL"],
+            json!("https://new.example.com/v1")
+        );
+        assert_eq!(live["provider"]["vision"]["modalities"], modalities);
+    }
+
+    #[test]
+    fn opencode_provider_config_typed_set_provider_can_clear_modalities() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let _env = TestEnvGuard::isolated(temp.path());
+        let modalities = json!({ "input": ["text", "image"] });
+        seed_provider_with_modalities(&modalities);
+        let config: OpenCodeProviderConfig =
+            serde_json::from_value(provider_without_modalities("https://new.example.com/v1"))
+                .expect("deserialize typed provider");
+
+        set_typed_provider("vision", &config).expect("set typed provider");
+
+        let live = read_opencode_config().expect("read opencode config");
+        let provider = live["provider"]["vision"]
+            .as_object()
+            .expect("serialized provider object");
+        assert_eq!(
+            provider["options"]["baseURL"],
+            json!("https://new.example.com/v1")
+        );
+        assert!(!provider.contains_key("modalities"));
+    }
 }

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -465,10 +465,14 @@ pub struct OpenCodeProviderConfig {
     pub npm: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modalities: Option<Value>,
     #[serde(default)]
     pub options: OpenCodeProviderOptions,
     #[serde(default)]
     pub models: HashMap<String, OpenCodeModel>,
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    pub extra: HashMap<String, Value>,
 }
 
 impl Default for OpenCodeProviderConfig {
@@ -476,8 +480,10 @@ impl Default for OpenCodeProviderConfig {
         Self {
             npm: "@ai-sdk/openai-compatible".to_string(),
             name: None,
+            modalities: None,
             options: OpenCodeProviderOptions::default(),
             models: HashMap::new(),
+            extra: HashMap::new(),
         }
     }
 }
@@ -556,7 +562,7 @@ pub struct OpenClawModelCost {
 
 #[cfg(test)]
 mod tests {
-    use super::{AuthBinding, AuthBindingSource, Provider, ProviderMeta};
+    use super::{AuthBinding, AuthBindingSource, OpenCodeProviderConfig, Provider, ProviderMeta};
 
     #[test]
     fn provider_meta_serializes_upstream_common_config_key_and_accepts_legacy_alias() {
@@ -589,6 +595,45 @@ mod tests {
         assert_eq!(meta.is_full_url, Some(true));
         let serialized = serde_json::to_value(&meta).expect("serialize provider meta");
         assert_eq!(serialized["isFullUrl"], true);
+    }
+
+    #[test]
+    fn opencode_provider_config_without_modalities_or_extra_serializes_as_existing_shape() {
+        let serialized =
+            serde_json::to_string(&OpenCodeProviderConfig::default()).expect("serialize config");
+
+        assert_eq!(
+            serialized,
+            r#"{"npm":"@ai-sdk/openai-compatible","options":{},"models":{}}"#
+        );
+    }
+
+    #[test]
+    fn opencode_provider_config_preserves_modalities_and_unknown_provider_keys() {
+        let input = serde_json::json!({
+            "npm": "@ai-sdk/openai-compatible",
+            "options": {
+                "baseURL": "https://vision.example.com/v1"
+            },
+            "models": {
+                "vision": { "name": "Vision" }
+            },
+            "modalities": {
+                "input": ["text", "image"],
+                "output": ["text"]
+            },
+            "customRouting": {
+                "tier": "vision"
+            }
+        });
+
+        let config: OpenCodeProviderConfig =
+            serde_json::from_value(input.clone()).expect("deserialize opencode config");
+        let serialized = serde_json::to_value(&config).expect("serialize opencode config");
+
+        assert_eq!(serialized["modalities"], input["modalities"]);
+        assert_eq!(serialized["customRouting"], input["customRouting"]);
+        assert!(serialized.get("extra").is_none());
     }
 
     #[test]

--- a/src-tauri/tests/opencode_provider.rs
+++ b/src-tauri/tests/opencode_provider.rs
@@ -35,6 +35,136 @@ fn read_opencode_live(path: &std::path::Path) -> serde_json::Value {
 }
 
 #[test]
+fn opencode_provider_modalities_round_trips_to_live_config() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let state = state_from_config(MultiAppConfig::default());
+    let modalities = json!({ "input": ["text", "image"] });
+    let provider_config = json!({
+        "npm": "@ai-sdk/openai-compatible",
+        "options": {
+            "baseURL": "https://vision.example.com/v1",
+            "apiKey": "sk-vision"
+        },
+        "models": {
+            "vision": { "name": "Vision" }
+        },
+        "modalities": modalities,
+        "customRouting": {
+            "tier": "vision"
+        }
+    });
+
+    ProviderService::add(
+        &state,
+        AppType::OpenCode,
+        Provider::with_id(
+            "vision".to_string(),
+            "Vision".to_string(),
+            provider_config.clone(),
+            None,
+        ),
+    )
+    .expect("add opencode provider with modalities");
+
+    let live = read_opencode_live(&opencode_config_path(home));
+    assert_eq!(live["provider"]["vision"], provider_config);
+    assert_eq!(live["provider"]["vision"]["modalities"], modalities);
+    assert_eq!(
+        live["provider"]["vision"]["customRouting"],
+        json!({ "tier": "vision" })
+    );
+    assert!(live["provider"]["vision"].get("extra").is_none());
+}
+
+#[test]
+fn opencode_provider_without_modalities_omits_modalities_and_extra_keys() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let state = state_from_config(MultiAppConfig::default());
+    let provider = opencode_provider("text-only", "Text Only", "https://text.example.com/v1");
+    let expected_config = provider.settings_config.clone();
+
+    ProviderService::add(&state, AppType::OpenCode, provider)
+        .expect("add opencode provider without modalities");
+
+    let live = read_opencode_live(&opencode_config_path(home));
+    let serialized_provider = live["provider"]["text-only"]
+        .as_object()
+        .expect("serialized provider object");
+
+    assert_eq!(live["provider"]["text-only"], expected_config);
+    assert!(!serialized_provider.contains_key("modalities"));
+    assert!(!serialized_provider.contains_key("extra"));
+}
+
+#[test]
+fn opencode_update_clears_existing_modalities_when_typed_provider_omits_them() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::OpenCode)
+            .expect("opencode manager");
+        manager.providers.insert(
+            "vision".to_string(),
+            opencode_provider("vision", "Vision", "https://old.example.com/v1"),
+        );
+    }
+
+    let opencode_path = opencode_config_path(home);
+    std::fs::create_dir_all(opencode_path.parent().expect("opencode config dir"))
+        .expect("create opencode dir");
+    let modalities = json!({ "input": ["text", "image"] });
+    std::fs::write(
+        &opencode_path,
+        serde_json::to_string_pretty(&json!({
+            "$schema": "https://opencode.ai/config.json",
+            "provider": {
+                "vision": {
+                    "npm": "@ai-sdk/openai-compatible",
+                    "options": {
+                        "baseURL": "https://old.example.com/v1",
+                        "apiKey": "sk-vision"
+                    },
+                    "models": {
+                        "vision": { "name": "Vision" }
+                    },
+                    "modalities": modalities
+                }
+            }
+        }))
+        .expect("serialize opencode live config"),
+    )
+    .expect("seed opencode live config");
+
+    let state = state_from_config(config);
+    ProviderService::update(
+        &state,
+        AppType::OpenCode,
+        opencode_provider("vision", "Vision Updated", "https://new.example.com/v1"),
+    )
+    .expect("update opencode provider without modalities");
+
+    let live = read_opencode_live(&opencode_path);
+    assert_eq!(
+        live["provider"]["vision"]["options"]["baseURL"],
+        json!("https://new.example.com/v1")
+    );
+    let provider = live["provider"]["vision"]
+        .as_object()
+        .expect("serialized provider object");
+    assert!(!provider.contains_key("modalities"));
+}
+
+#[test]
 fn opencode_add_syncs_all_providers_to_live_config() {
     let _guard = lock_test_mutex();
     reset_test_fs();


### PR DESCRIPTION
## Summary

This change models a `modalities` field on `OpenCodeProviderConfig` and preserves user-authored modalities across the live-config write paths, while staying additive and backward compatible.

## Why

OpenCode image-capable providers advertise their capabilities through a `modalities` block (e.g. `input = ["text", "image"]` and related output modalities). Today `OpenCodeProviderConfig` does not model `modalities` and has no provider-level catch-all, so when cc-switch deserializes an OpenCode provider into the typed config and re-serializes it back to `opencode.json`, a user-supplied provider-level `modalities` block is silently dropped. The result is that switching or editing an image-capable provider through cc-switch can strip the very field that makes it image-capable. This was confirmed by the maintainer on the issue, who kept #241 open for a follow-up release.

## Changes

- `src-tauri/src/provider.rs`: add an optional `modalities: Option<Value>` field and a flattened `extra` catch-all to `OpenCodeProviderConfig`, with `Default` updated accordingly. Both use `skip_serializing_if`, so providers without modalities serialize byte-identically to before (no spurious `"modalities": null` or empty `"extra": {}`).
- `src-tauri/src/opencode_config.rs`: split `set_provider` so raw `Value` callers preserve an existing on-disk `modalities` value when the incoming object omits the key (protecting JSON-editor / TUI edits), while the typed `set_typed_provider` path does not preserve — letting an explicit clear through `OpenCodeProviderConfig { modalities: None, .. }` actually remove the field instead of resurrecting a stale value.

## Tests

Added coverage in `src-tauri/tests/opencode_provider.rs` plus module unit tests:

- A provider with `modalities = { input: ["text","image"] }` round-trips through write -> read unchanged.
- A provider without modalities serializes with no `modalities`/`extra` key (backward-compat golden).
- The raw `set_provider` path preserves an existing on-disk modalities block when the incoming provider omits it.
- The typed `set_typed_provider` path clears modalities when the config explicitly omits them.

Verified locally from `src-tauri/`: `cargo fmt --check`, `cargo clippy --tests`, and the OpenCode/provider tests all pass.

Closes #241
