### PR TITLE
fix(claude): avoid false live conflicts on provider switch

### DIFF
--- a/src-tauri/src/services/provider/claude.rs
+++ b/src-tauri/src/services/provider/claude.rs
@@ -241,6 +241,7 @@ impl ProviderService {
     ) -> Result<(), AppError> {
         let prepared = Self::prepare_claude_live_write(
             provider,
+            None,
             common_config_snippet,
             previous_common_config_snippet,
             apply_common_config,
@@ -257,6 +258,7 @@ impl ProviderService {
     ) -> Result<(), AppError> {
         let prepared = Self::prepare_claude_live_write(
             provider,
+            None,
             common_config_snippet,
             None,
             apply_common_config,
@@ -268,6 +270,7 @@ impl ProviderService {
 
     pub(super) fn prepare_claude_live_write(
         provider: &Provider,
+        previous_provider: Option<&Provider>,
         common_config_snippet: Option<&str>,
         previous_common_config_snippet: Option<&str>,
         apply_common_config: bool,
@@ -307,13 +310,23 @@ impl ProviderService {
         } else {
             json!({})
         };
-        let settings = live_merge::merge_json_live(
-            &AppType::Claude,
-            "settings.json",
-            local,
-            &content_to_write,
-            resolution,
-        )?;
+        let settings = match previous_provider {
+            Some(previous_provider) => live_merge::merge_json_with_base_live(
+                &AppType::Claude,
+                "settings.json",
+                local,
+                &previous_provider.settings_config,
+                &content_to_write,
+                resolution,
+            )?,
+            None => live_merge::merge_json_live(
+                &AppType::Claude,
+                "settings.json",
+                local,
+                &content_to_write,
+                resolution,
+            )?,
+        };
 
         Ok(PreparedLiveWrite::Claude { settings })
     }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2803,6 +2803,14 @@ impl ProviderService {
         }
 
         let backup = Self::capture_live_snapshot(app_type)?;
+        let previous_provider = effective_current_provider
+            .filter(|current_id| *current_id != provider_id)
+            .and_then(|current_id| {
+                config
+                    .get_manager(app_type)
+                    .and_then(|manager| manager.providers.get(current_id))
+                    .cloned()
+            });
         let provider = match app_type {
             AppType::Codex => {
                 Self::prepare_switch_codex(config, provider_id, effective_current_provider)?
@@ -2821,7 +2829,7 @@ impl ProviderService {
         Ok(PostCommitAction {
             app_type: app_type.clone(),
             provider,
-            previous_provider: None,
+            previous_provider,
             backup,
             sync_mcp: true,
             refresh_snapshot: true,
@@ -2982,6 +2990,7 @@ impl ProviderService {
             ),
             AppType::Claude => Self::prepare_claude_live_write(
                 provider,
+                previous_provider,
                 common_config_snippet,
                 previous_common_config_snippet,
                 apply_common_config,

--- a/src-tauri/src/services/provider/tests.rs
+++ b/src-tauri/src/services/provider/tests.rs
@@ -971,6 +971,98 @@ fn codex_switch_backfill_migrates_existing_common_meta_for_current_provider() {
     );
 }
 
+fn setup_claude_switch_preview_state(live_settings: Value) -> (TempDir, EnvGuard, AppState) {
+    let temp_home = TempDir::new().expect("create temp home");
+    let env = TestEnvGuard::isolated(temp_home.path());
+    std::fs::create_dir_all(crate::config::get_claude_config_dir()).expect("create ~/.claude");
+
+    let mut config = MultiAppConfig::default();
+    config.ensure_app(&AppType::Claude);
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "p1".to_string();
+        manager.providers.insert(
+            "p1".to_string(),
+            Provider::with_id(
+                "p1".to_string(),
+                "First".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_AUTH_TOKEN": "token1",
+                        "ANTHROPIC_BASE_URL": "https://claude.one"
+                    }
+                }),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "p2".to_string(),
+            Provider::with_id(
+                "p2".to_string(),
+                "Second".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_AUTH_TOKEN": "token2",
+                        "ANTHROPIC_BASE_URL": "https://claude.two"
+                    }
+                }),
+                None,
+            ),
+        );
+    }
+
+    write_json_file(&get_claude_settings_path(), &live_settings)
+        .expect("seed live settings with current provider");
+    let state = state_from_config(config);
+    state
+        .db
+        .set_current_provider(AppType::Claude.as_str(), "p1")
+        .expect("set db current provider");
+
+    (temp_home, env, state)
+}
+
+#[test]
+#[serial]
+fn preview_switch_live_conflicts_ignores_expected_current_provider_changes() {
+    let (_temp_home, _env, state) = setup_claude_switch_preview_state(json!({
+        "env": {
+            "ANTHROPIC_AUTH_TOKEN": "token1",
+            "ANTHROPIC_BASE_URL": "https://claude.one"
+        }
+    }));
+
+    let conflicts = ProviderService::preview_switch_live_conflicts(&state, AppType::Claude, "p2")
+        .expect("preview switch conflicts");
+
+    assert_eq!(
+        conflicts,
+        Vec::new(),
+        "switching from the current provider's live values to the target provider should not be treated as a local live conflict"
+    );
+}
+
+#[test]
+#[serial]
+fn preview_switch_live_conflicts_reports_real_local_provider_changes() {
+    let (_temp_home, _env, state) = setup_claude_switch_preview_state(json!({
+        "env": {
+            "ANTHROPIC_AUTH_TOKEN": "manual-token",
+            "ANTHROPIC_BASE_URL": "https://claude.one"
+        }
+    }));
+
+    let conflicts = ProviderService::preview_switch_live_conflicts(&state, AppType::Claude, "p2")
+        .expect("preview switch conflicts");
+
+    assert_eq!(conflicts.len(), 1);
+    assert_eq!(conflicts[0].path, "env.ANTHROPIC_AUTH_TOKEN");
+    assert_eq!(conflicts[0].local, "manual-token");
+    assert_eq!(conflicts[0].incoming, "token2");
+}
+
 #[tokio::test]
 #[serial]
 async fn switch_updates_running_proxy_takeover_target_without_restart() {


### PR DESCRIPTION
## Summary

- Avoid reporting normal Claude provider changes as live configuration conflicts during switch preview.
- Keep the previous provider snapshot as the merge base before backfilling live settings, then use that base when preparing Claude `settings.json`.
- Add regression coverage for both the expected switch case and a real local override that should still report a conflict.

Fixes #287

## Tests

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `git diff --check`
- `cargo test --manifest-path src-tauri/Cargo.toml preview_switch_live_conflicts -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml provider_switch -- --nocapture`