### PR TITLE
fix(claude): scope switch live merge base

### DIFF
--- a/src-tauri/src/services/provider/claude.rs
+++ b/src-tauri/src/services/provider/claude.rs
@@ -270,7 +270,7 @@ impl ProviderService {
 
     pub(super) fn prepare_claude_live_write(
         provider: &Provider,
-        previous_provider: Option<&Provider>,
+        live_merge_base: Option<&Value>,
         common_config_snippet: Option<&str>,
         previous_common_config_snippet: Option<&str>,
         apply_common_config: bool,
@@ -310,12 +310,12 @@ impl ProviderService {
         } else {
             json!({})
         };
-        let settings = match previous_provider {
-            Some(previous_provider) => live_merge::merge_json_with_base_live(
+        let settings = match live_merge_base {
+            Some(base) => live_merge::merge_json_with_base_live(
                 &AppType::Claude,
                 "settings.json",
                 local,
-                &previous_provider.settings_config,
+                base,
                 &content_to_write,
                 resolution,
             )?,

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -142,6 +142,7 @@ struct PostCommitAction {
     app_type: AppType,
     provider: Provider,
     previous_provider: Option<Provider>,
+    claude_live_merge_base: Option<Value>,
     backup: LiveSnapshot,
     sync_mcp: bool,
     refresh_snapshot: bool,
@@ -827,6 +828,7 @@ impl ProviderService {
                 &action.app_type,
                 &action.provider,
                 action.previous_provider.as_ref(),
+                action.claude_live_merge_base.as_ref(),
                 action.common_config_snippet.as_deref(),
                 action.previous_common_config_snippet.as_deref(),
                 apply_common_config,
@@ -1299,6 +1301,7 @@ impl ProviderService {
             app_type: app_type.clone(),
             provider,
             previous_provider: None,
+            claude_live_merge_base: None,
             backup: Self::capture_live_snapshot(app_type)?,
             sync_mcp: matches!(app_type, AppType::Codex) && !takeover_active,
             refresh_snapshot: false,
@@ -1965,6 +1968,7 @@ impl ProviderService {
                     app_type: app_type_clone.clone(),
                     provider: provider_to_store.clone(),
                     previous_provider: None,
+                    claude_live_merge_base: None,
                     backup,
                     // Codex current-provider saves rewrite live config from the stored snapshot,
                     // so managed MCP must be synced back after the write.
@@ -2127,6 +2131,7 @@ impl ProviderService {
                     app_type: app_type_clone.clone(),
                     provider: merged,
                     previous_provider,
+                    claude_live_merge_base: None,
                     backup,
                     // Codex current-provider saves rewrite live config from the stored snapshot,
                     // so managed MCP must be synced back after the write.
@@ -2792,6 +2797,7 @@ impl ProviderService {
                 app_type: app_type.clone(),
                 provider,
                 previous_provider: None,
+                claude_live_merge_base: None,
                 backup: Self::capture_live_snapshot(app_type)?,
                 sync_mcp: matches!(app_type, AppType::OpenCode),
                 refresh_snapshot: false,
@@ -2811,6 +2817,14 @@ impl ProviderService {
                     .and_then(|manager| manager.providers.get(current_id))
                     .cloned()
             });
+        let claude_live_merge_base =
+            if matches!(app_type, AppType::Claude) && get_claude_settings_path().exists() {
+                previous_provider
+                    .as_ref()
+                    .map(|provider| provider.settings_config.clone())
+            } else {
+                None
+            };
         let provider = match app_type {
             AppType::Codex => {
                 Self::prepare_switch_codex(config, provider_id, effective_current_provider)?
@@ -2830,6 +2844,7 @@ impl ProviderService {
             app_type: app_type.clone(),
             provider,
             previous_provider,
+            claude_live_merge_base,
             backup,
             sync_mcp: true,
             refresh_snapshot: true,
@@ -2955,6 +2970,7 @@ impl ProviderService {
             app_type,
             provider,
             None,
+            None,
             common_config_snippet,
             previous_common_config_snippet,
             apply_common_config,
@@ -2967,6 +2983,7 @@ impl ProviderService {
         app_type: &AppType,
         provider: &Provider,
         previous_provider: Option<&Provider>,
+        claude_live_merge_base: Option<&Value>,
         common_config_snippet: Option<&str>,
         previous_common_config_snippet: Option<&str>,
         apply_common_config: bool,
@@ -2990,7 +3007,7 @@ impl ProviderService {
             ),
             AppType::Claude => Self::prepare_claude_live_write(
                 provider,
-                previous_provider,
+                claude_live_merge_base,
                 common_config_snippet,
                 previous_common_config_snippet,
                 apply_common_config,

--- a/src-tauri/src/services/provider/tests.rs
+++ b/src-tauri/src/services/provider/tests.rs
@@ -1063,6 +1063,131 @@ fn preview_switch_live_conflicts_reports_real_local_provider_changes() {
     assert_eq!(conflicts[0].incoming, "token2");
 }
 
+#[test]
+#[serial]
+fn preview_switch_live_conflicts_ignores_missing_claude_settings_file() {
+    let temp_home = TempDir::new().expect("create temp home");
+    let _env = TestEnvGuard::isolated(temp_home.path());
+    std::fs::create_dir_all(crate::config::get_claude_config_dir()).expect("create ~/.claude");
+
+    let mut config = MultiAppConfig::default();
+    config.ensure_app(&AppType::Claude);
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "p1".to_string();
+        manager.providers.insert(
+            "p1".to_string(),
+            Provider::with_id(
+                "p1".to_string(),
+                "First".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_AUTH_TOKEN": "token1",
+                        "ANTHROPIC_BASE_URL": "https://claude.one"
+                    }
+                }),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "p2".to_string(),
+            Provider::with_id(
+                "p2".to_string(),
+                "Second".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_AUTH_TOKEN": "token2",
+                        "ANTHROPIC_BASE_URL": "https://claude.two"
+                    }
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = state_from_config(config);
+    state
+        .db
+        .set_current_provider(AppType::Claude.as_str(), "p1")
+        .expect("set db current provider");
+
+    let conflicts = ProviderService::preview_switch_live_conflicts(&state, AppType::Claude, "p2")
+        .expect("preview switch conflicts");
+
+    assert_eq!(
+        conflicts,
+        Vec::new(),
+        "missing live settings should be treated as an empty destination, not as removed current-provider fields"
+    );
+}
+
+#[test]
+#[serial]
+fn switch_claude_with_missing_settings_file_creates_target_live_settings() {
+    let temp_home = TempDir::new().expect("create temp home");
+    let _env = TestEnvGuard::isolated(temp_home.path());
+    std::fs::create_dir_all(crate::config::get_claude_config_dir()).expect("create ~/.claude");
+
+    let mut config = MultiAppConfig::default();
+    config.ensure_app(&AppType::Claude);
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "p1".to_string();
+        manager.providers.insert(
+            "p1".to_string(),
+            Provider::with_id(
+                "p1".to_string(),
+                "First".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_AUTH_TOKEN": "token1",
+                        "ANTHROPIC_BASE_URL": "https://claude.one"
+                    }
+                }),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "p2".to_string(),
+            Provider::with_id(
+                "p2".to_string(),
+                "Second".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_AUTH_TOKEN": "token2",
+                        "ANTHROPIC_BASE_URL": "https://claude.two"
+                    }
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = state_from_config(config);
+    state
+        .db
+        .set_current_provider(AppType::Claude.as_str(), "p1")
+        .expect("set db current provider");
+
+    ProviderService::switch(&state, AppType::Claude, "p2").expect("switch to p2");
+
+    let live: Value = read_json_file(&get_claude_settings_path()).expect("read live settings");
+    assert_eq!(
+        live.pointer("/env/ANTHROPIC_AUTH_TOKEN")
+            .and_then(Value::as_str),
+        Some("token2")
+    );
+    assert_eq!(
+        live.pointer("/env/ANTHROPIC_BASE_URL")
+            .and_then(Value::as_str),
+        Some("https://claude.two")
+    );
+}
+
 #[tokio::test]
 #[serial]
 async fn switch_updates_running_proxy_takeover_target_without_restart() {
@@ -2709,6 +2834,75 @@ fn provider_update_does_not_infer_claude_common_config_opt_in() {
             .and_then(Value::as_bool),
         Some(false),
         "matching common fields remain provider-owned when not explicitly enabled"
+    );
+}
+
+#[test]
+#[serial]
+fn provider_update_keeps_claude_live_conflict_detection_without_switch_base() {
+    let temp_home = TempDir::new().expect("create temp home");
+    let _env = TestEnvGuard::isolated(temp_home.path());
+    std::fs::create_dir_all(crate::config::get_claude_config_dir())
+        .expect("create ~/.claude (initialized)");
+
+    let mut config = MultiAppConfig::default();
+    config.ensure_app(&AppType::Claude);
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "p1".to_string();
+        manager.providers.insert(
+            "p1".to_string(),
+            Provider::with_id(
+                "p1".to_string(),
+                "First".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_AUTH_TOKEN": "token-old",
+                        "ANTHROPIC_BASE_URL": "https://claude.old"
+                    }
+                }),
+                None,
+            ),
+        );
+    }
+
+    write_json_file(
+        &get_claude_settings_path(),
+        &json!({
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": "token-old",
+                "ANTHROPIC_BASE_URL": "https://claude.old"
+            }
+        }),
+    )
+    .expect("seed live settings");
+
+    let state = state_from_config(config);
+    state
+        .db
+        .set_current_provider(AppType::Claude.as_str(), "p1")
+        .expect("set db current provider");
+
+    let provider = Provider::with_id(
+        "p1".to_string(),
+        "First Updated".to_string(),
+        json!({
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": "token-new",
+                "ANTHROPIC_BASE_URL": "https://claude.new"
+            }
+        }),
+        None,
+    );
+
+    let err = ProviderService::update(&state, AppType::Claude, provider)
+        .expect_err("update should still use normal live conflict detection");
+    let message = err.to_string();
+    assert!(
+        message.contains("env.ANTHROPIC_AUTH_TOKEN"),
+        "expected token conflict, got: {message}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Scope Claude base-aware live merges to provider switch actions instead of all live writes using previous_provider.
- Avoid using the previous provider as a merge base when Claude settings.json is missing, so missing live config is treated as an empty destination.
- Add regression coverage for missing Claude settings on preview/switch and for preserving normal Claude update conflict detection.

Follow-up to #289.
Fixes #287.

## Tests

- cargo fmt -- --check
- git diff --check
- cargo test preview_switch_live_conflicts -- --nocapture
- cargo test switch_claude_with_missing_settings_file_creates_target_live_settings -- --nocapture
- cargo test provider_update_keeps_claude_live_conflict_detection_without_switch_base -- --nocapture
- cargo test provider_switch -- --nocapture