### PR TITLE
fix(proxy): refresh takeover backup on hot-switch

### DIFF
--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -4270,12 +4270,10 @@ pub mod texts {
             } else {
                 "修改监听地址：需先停止本地代理。监听端口可以修改。改完后重新启动路由生效。"
             }
+        } else if current_app_is_active {
+            "Listen address: stop the proxy to edit. Listen port: stop this app's route to edit. Restart routing after changes."
         } else {
-            if current_app_is_active {
-                "Listen address: stop the proxy to edit. Listen port: stop this app's route to edit. Restart routing after changes."
-            } else {
-                "Listen address: stop the proxy to edit. Listen port can be edited. Restart routing after changes."
-            }
+            "Listen address: stop the proxy to edit. Listen port can be edited. Restart routing after changes."
         }
     }
 

--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -63,6 +63,7 @@ pub fn get_providers() -> Result<Map<String, Value>, AppError> {
         .unwrap_or_default())
 }
 
+#[allow(dead_code)]
 pub fn set_provider(id: &str, provider: Value) -> Result<(), AppError> {
     set_provider_value(id, provider, true)
 }

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -173,15 +173,14 @@ pub fn anthropic_to_openai_with_reasoning_content(
             .iter()
             .filter(|t| t.get("type").and_then(|v| v.as_str()) != Some("BatchTool"))
             .map(|t| {
-                let mut tool = json!({
+                json!({
                     "type": "function",
                     "function": {
                         "name": t.get("name").and_then(|n| n.as_str()).unwrap_or(""),
                         "description": t.get("description"),
                         "parameters": clean_schema(t.get("input_schema").cloned().unwrap_or(json!({})))
                     }
-                });
-                tool
+                })
             })
             .collect();
 

--- a/src-tauri/src/services/provider/claude.rs
+++ b/src-tauri/src/services/provider/claude.rs
@@ -311,14 +311,18 @@ impl ProviderService {
             json!({})
         };
         let settings = match live_merge_base {
-            Some(base) => live_merge::merge_json_with_base_live(
-                &AppType::Claude,
-                "settings.json",
-                local,
-                base,
-                &content_to_write,
-                resolution,
-            )?,
+            Some(base) => {
+                let mut local = local;
+                Self::backfill_missing_claude_incoming_keys(&mut local, base, &content_to_write);
+                live_merge::merge_json_with_base_live(
+                    &AppType::Claude,
+                    "settings.json",
+                    local,
+                    base,
+                    &content_to_write,
+                    resolution,
+                )?
+            }
             None => live_merge::merge_json_live(
                 &AppType::Claude,
                 "settings.json",
@@ -329,6 +333,33 @@ impl ProviderService {
         };
 
         Ok(PreparedLiveWrite::Claude { settings })
+    }
+
+    fn backfill_missing_claude_incoming_keys(local: &mut Value, base: &Value, incoming: &Value) {
+        let (Value::Object(local_map), Value::Object(base_map), Value::Object(incoming_map)) =
+            (local, base, incoming)
+        else {
+            return;
+        };
+
+        for (key, incoming_value) in incoming_map {
+            match local_map.get_mut(key) {
+                Some(local_value) => {
+                    if let Some(base_value) = base_map.get(key) {
+                        Self::backfill_missing_claude_incoming_keys(
+                            local_value,
+                            base_value,
+                            incoming_value,
+                        );
+                    }
+                }
+                None => {
+                    if base_map.contains_key(key) {
+                        local_map.insert(key.clone(), incoming_value.clone());
+                    }
+                }
+            }
+        }
     }
 
     pub(super) fn apply_claude_live_write(prepared: &PreparedLiveWrite) -> Result<(), AppError> {

--- a/src-tauri/src/services/provider/claude.rs
+++ b/src-tauri/src/services/provider/claude.rs
@@ -311,18 +311,14 @@ impl ProviderService {
             json!({})
         };
         let settings = match live_merge_base {
-            Some(base) => {
-                let mut local = local;
-                Self::backfill_missing_claude_incoming_keys(&mut local, base, &content_to_write);
-                live_merge::merge_json_with_base_live(
-                    &AppType::Claude,
-                    "settings.json",
-                    local,
-                    base,
-                    &content_to_write,
-                    resolution,
-                )?
-            }
+            Some(base) => live_merge::merge_json_with_base_live(
+                &AppType::Claude,
+                "settings.json",
+                local,
+                base,
+                &content_to_write,
+                resolution,
+            )?,
             None => live_merge::merge_json_live(
                 &AppType::Claude,
                 "settings.json",
@@ -333,33 +329,6 @@ impl ProviderService {
         };
 
         Ok(PreparedLiveWrite::Claude { settings })
-    }
-
-    fn backfill_missing_claude_incoming_keys(local: &mut Value, base: &Value, incoming: &Value) {
-        let (Value::Object(local_map), Value::Object(base_map), Value::Object(incoming_map)) =
-            (local, base, incoming)
-        else {
-            return;
-        };
-
-        for (key, incoming_value) in incoming_map {
-            match local_map.get_mut(key) {
-                Some(local_value) => {
-                    if let Some(base_value) = base_map.get(key) {
-                        Self::backfill_missing_claude_incoming_keys(
-                            local_value,
-                            base_value,
-                            incoming_value,
-                        );
-                    }
-                }
-                None => {
-                    if base_map.contains_key(key) {
-                        local_map.insert(key.clone(), incoming_value.clone());
-                    }
-                }
-            }
-        }
     }
 
     pub(super) fn apply_claude_live_write(prepared: &PreparedLiveWrite) -> Result<(), AppError> {

--- a/src-tauri/src/services/provider/live_merge.rs
+++ b/src-tauri/src/services/provider/live_merge.rs
@@ -258,6 +258,10 @@ fn merge_json_value(
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "recursive merge carries immutable context plus per-node state"
+)]
 fn merge_json_value_with_base(
     app_type: &AppType,
     target: &str,
@@ -449,6 +453,35 @@ pub fn merge_toml_live(
     Ok(local_doc.to_string())
 }
 
+pub fn merge_toml_with_base_live(
+    app_type: &AppType,
+    target: impl Into<String>,
+    local_text: &str,
+    base_text: &str,
+    incoming_text: &str,
+    resolution: ConflictResolution<'_>,
+) -> Result<String, AppError> {
+    let target = target.into();
+    let mut local_doc = parse_toml_live(local_text, &target)?;
+    let base_doc = parse_toml_live(base_text, &target)?;
+    let incoming_doc = parse_toml_live(incoming_text, &target)?;
+    let mut conflicts = Vec::new();
+    merge_toml_table_like_with_base(
+        app_type,
+        &target,
+        String::new(),
+        local_doc.as_table_mut(),
+        Some(base_doc.as_table()),
+        incoming_doc.as_table(),
+        resolution,
+        &mut conflicts,
+    )?;
+    if resolution.collects_failures() && !conflicts.is_empty() {
+        return Err(conflict_error(&conflicts));
+    }
+    Ok(local_doc.to_string())
+}
+
 fn parse_toml_live(text: &str, target: &str) -> Result<DocumentMut, AppError> {
     text.trim()
         .parse::<DocumentMut>()
@@ -500,6 +533,69 @@ fn merge_toml_item(
     Ok(())
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "recursive TOML item merge carries immutable context plus per-node state"
+)]
+fn merge_toml_item_with_base(
+    app_type: &AppType,
+    target: &str,
+    path: String,
+    local: &mut Item,
+    base: Option<&Item>,
+    incoming: &Item,
+    resolution: ConflictResolution<'_>,
+    conflicts: &mut Vec<ConfigConflict>,
+) -> Result<(), AppError> {
+    if base.is_some_and(|base| toml_items_equal(base, incoming)) {
+        return Ok(());
+    }
+
+    if let Some(incoming_table) = incoming.as_table_like() {
+        if let Some(local_table) = local.as_table_like_mut() {
+            let base_table = base.and_then(Item::as_table_like);
+            return merge_toml_table_like_with_base(
+                app_type,
+                target,
+                path,
+                local_table,
+                base_table,
+                incoming_table,
+                resolution,
+                conflicts,
+            );
+        }
+    }
+
+    if toml_items_equal(local, incoming) {
+        return Ok(());
+    }
+
+    let local_matches_base = base.is_some_and(|base| toml_items_equal(local, base));
+    let incoming_changed_from_base = base.is_none_or(|base| !toml_items_equal(incoming, base));
+    if local_matches_base || !incoming_changed_from_base {
+        *local = incoming.clone();
+        return Ok(());
+    }
+
+    let conflict = ConfigConflict {
+        app_type: app_type.clone(),
+        target: target.to_string(),
+        path: display_path(&path),
+        local: toml_display(local),
+        incoming: toml_display(incoming),
+    };
+    if resolution.collects_failures() {
+        conflicts.push(conflict);
+    } else if matches!(
+        resolution.resolve(&[conflict])?,
+        Some(ConflictChoice::UseIncoming)
+    ) {
+        *local = incoming.clone();
+    }
+    Ok(())
+}
+
 fn merge_toml_table_like(
     app_type: &AppType,
     target: &str,
@@ -529,13 +625,121 @@ fn merge_toml_table_like(
     Ok(())
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "recursive TOML table merge carries immutable context plus per-node state"
+)]
+fn merge_toml_table_like_with_base(
+    app_type: &AppType,
+    target: &str,
+    path: String,
+    local: &mut dyn TableLike,
+    base: Option<&dyn TableLike>,
+    incoming: &dyn TableLike,
+    resolution: ConflictResolution<'_>,
+    conflicts: &mut Vec<ConfigConflict>,
+) -> Result<(), AppError> {
+    for (key, incoming_item) in incoming.iter() {
+        let next_path = toml_child_path(&path, key);
+        let base_item = base.and_then(|table| table.get(key));
+        match local.get_mut(key) {
+            Some(local_item) => merge_toml_item_with_base(
+                app_type,
+                target,
+                next_path,
+                local_item,
+                base_item,
+                incoming_item,
+                resolution,
+                conflicts,
+            )?,
+            None => {
+                if let Some(base_item) = base_item {
+                    if toml_items_equal(incoming_item, base_item) {
+                        continue;
+                    }
+
+                    let conflict = ConfigConflict {
+                        app_type: app_type.clone(),
+                        target: target.to_string(),
+                        path: display_path(&next_path),
+                        local: "<removed>".to_string(),
+                        incoming: toml_display(incoming_item),
+                    };
+                    if resolution.collects_failures() {
+                        conflicts.push(conflict);
+                    } else if matches!(
+                        resolution.resolve(&[conflict])?,
+                        Some(ConflictChoice::UseIncoming)
+                    ) {
+                        local.insert(key, incoming_item.clone());
+                    }
+                } else {
+                    local.insert(key, incoming_item.clone());
+                }
+            }
+        }
+    }
+
+    if let Some(base) = base {
+        let removed_keys = base
+            .iter()
+            .filter(|(key, _)| !incoming.contains_key(key) && local.contains_key(key))
+            .map(|(key, base_item)| (key.to_string(), base_item.clone()))
+            .collect::<Vec<_>>();
+        for (key, base_item) in removed_keys {
+            let Some(local_item) = local.get(&key) else {
+                continue;
+            };
+            let next_path = toml_child_path(&path, &key);
+            if toml_items_equal(local_item, &base_item) {
+                local.remove(&key);
+                continue;
+            }
+
+            let conflict = ConfigConflict {
+                app_type: app_type.clone(),
+                target: target.to_string(),
+                path: display_path(&next_path),
+                local: toml_display(local_item),
+                incoming: "<removed>".to_string(),
+            };
+            if resolution.collects_failures() {
+                conflicts.push(conflict);
+            } else if matches!(
+                resolution.resolve(&[conflict])?,
+                Some(ConflictChoice::UseIncoming)
+            ) {
+                local.remove(&key);
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn toml_items_equal(left: &Item, right: &Item) -> bool {
-    match (left.as_value(), right.as_value()) {
-        (Some(left_value), Some(right_value)) => {
+    match (
+        left.as_value(),
+        right.as_value(),
+        left.as_table_like(),
+        right.as_table_like(),
+    ) {
+        (Some(left_value), Some(right_value), _, _) => {
             left_value.to_string().trim() == right_value.to_string().trim()
         }
+        (_, _, Some(left_table), Some(right_table)) => toml_tables_equal(left_table, right_table),
         _ => left.to_string().trim() == right.to_string().trim(),
     }
+}
+
+fn toml_tables_equal(left: &dyn TableLike, right: &dyn TableLike) -> bool {
+    left.iter().count() == right.iter().count()
+        && left.iter().all(|(key, left_item)| {
+            right
+                .get(key)
+                .is_some_and(|right_item| toml_items_equal(left_item, right_item))
+        })
 }
 
 fn json_child_path(parent: &str, key: &str) -> String {
@@ -918,6 +1122,63 @@ api_key_env_var = "KEY"
         .unwrap_err();
 
         assert!(err.to_string().contains("model"));
+    }
+
+    #[test]
+    fn toml_merge_with_base_removes_deleted_incoming_sections_when_local_matches_base() {
+        let base = r#"
+model_provider = "rightcode"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "https://rightcode.example/v1"
+wire_api = "responses"
+"#;
+        let local = r#"
+model_provider = "rightcode"
+local_only = "kept"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "https://rightcode.example/v1"
+wire_api = "responses"
+"#;
+        let incoming = r#"
+model_provider = "aihubmix"
+
+[model_providers.aihubmix]
+name = "AiHubMix"
+base_url = "https://aihubmix.example/v1"
+wire_api = "responses"
+"#;
+
+        let merged = merge_toml_with_base_live(
+            &AppType::Codex,
+            "config.toml",
+            local,
+            base,
+            incoming,
+            ConflictPolicy::PreferIncoming.into(),
+        )
+        .unwrap();
+        let parsed: toml::Value = toml::from_str(&merged).expect("parse merged TOML");
+        let providers = parsed
+            .get("model_providers")
+            .and_then(|value| value.as_table())
+            .expect("model providers table");
+
+        assert!(providers.get("rightcode").is_none());
+        assert_eq!(
+            providers
+                .get("aihubmix")
+                .and_then(|provider| provider.get("base_url"))
+                .and_then(|value| value.as_str()),
+            Some("https://aihubmix.example/v1")
+        );
+        assert_eq!(
+            parsed.get("local_only").and_then(|value| value.as_str()),
+            Some("kept")
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -812,6 +812,7 @@ impl ProviderService {
                     .prepare_live_backup_from_provider_with_resolution(
                         action.app_type.as_str(),
                         &action.provider,
+                        action.previous_provider.as_ref(),
                         resolution,
                     ),
             )
@@ -2979,6 +2980,10 @@ impl ProviderService {
         Self::apply_prepared_live_snapshot(&prepared)
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "dispatch wrapper threads app-specific live sync context"
+    )]
     fn prepare_live_snapshot_with_resolution(
         app_type: &AppType,
         provider: &Provider,

--- a/src-tauri/src/services/provider/tests.rs
+++ b/src-tauri/src/services/provider/tests.rs
@@ -1065,6 +1065,59 @@ fn preview_switch_live_conflicts_reports_real_local_provider_changes() {
 
 #[test]
 #[serial]
+fn preview_switch_live_conflicts_reports_removed_local_provider_field() {
+    let (_temp_home, _env, state) = setup_claude_switch_preview_state(json!({
+        "env": {
+            "ANTHROPIC_BASE_URL": "https://claude.one"
+        }
+    }));
+
+    let conflicts = ProviderService::preview_switch_live_conflicts(&state, AppType::Claude, "p2")
+        .expect("preview switch conflicts");
+
+    assert!(
+        conflicts.iter().any(|conflict| {
+            conflict.path == "env.ANTHROPIC_AUTH_TOKEN"
+                && conflict.local == "<removed>"
+                && conflict.incoming == "token2"
+        }),
+        "expected removed token conflict, got {conflicts:?}"
+    );
+}
+
+#[test]
+#[serial]
+fn switch_fails_when_live_removed_current_provider_field_changed_by_target() {
+    let (_temp_home, _env, state) = setup_claude_switch_preview_state(json!({
+        "env": {
+            "ANTHROPIC_BASE_URL": "https://claude.one"
+        }
+    }));
+
+    let err = ProviderService::switch(&state, AppType::Claude, "p2")
+        .expect_err("switch should report removed live field conflict");
+    let message = err.to_string();
+    assert!(
+        message.contains("env.ANTHROPIC_AUTH_TOKEN")
+            && message.contains("local: <removed>")
+            && message.contains("cc-switch: token2"),
+        "unexpected error: {message}"
+    );
+
+    let live: Value = read_json_file(&get_claude_settings_path()).expect("read live settings");
+    assert!(
+        live.pointer("/env/ANTHROPIC_AUTH_TOKEN").is_none(),
+        "failed switch should preserve the locally removed token"
+    );
+    assert_eq!(
+        live.pointer("/env/ANTHROPIC_BASE_URL")
+            .and_then(Value::as_str),
+        Some("https://claude.one")
+    );
+}
+
+#[test]
+#[serial]
 fn preview_switch_live_conflicts_ignores_missing_claude_settings_file() {
     let temp_home = TempDir::new().expect("create temp home");
     let _env = TestEnvGuard::isolated(temp_home.path());

--- a/src-tauri/src/services/provider/tests.rs
+++ b/src-tauri/src/services/provider/tests.rs
@@ -1270,8 +1270,8 @@ async fn switch_updates_running_proxy_takeover_target_without_restart() {
             .and_then(Value::as_object)
             .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
             .and_then(Value::as_str),
-        Some("https://api.one.example"),
-        "hot-switch should preserve the original live backup used for restore"
+        Some("https://api.two.example"),
+        "hot-switch should refresh the restore backup to the selected provider"
     );
 
     let snapshot = state

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1600,6 +1600,7 @@ impl ProxyService {
         Self::merge_live_backup_snapshot(
             app_type,
             Some(original_live),
+            None,
             provider_snapshot,
             live_merge::ConflictPolicy::PreferIncoming.into(),
         )
@@ -2101,6 +2102,7 @@ impl ProxyService {
         let backup_snapshot = Self::merge_live_backup_snapshot(
             &app_type_enum,
             existing_backup_value.as_ref(),
+            None,
             backup_snapshot,
             live_merge::ConflictPolicy::PreferIncoming.into(),
         )?;
@@ -2112,6 +2114,7 @@ impl ProxyService {
         &self,
         app_type: &str,
         provider: &Provider,
+        previous_provider: Option<&Provider>,
         resolution: live_merge::ConflictResolution<'_>,
     ) -> Result<Value, String> {
         let app_type = Self::takeover_app_from_str(app_type)?;
@@ -2121,10 +2124,22 @@ impl ProxyService {
             provider,
             &mut backup_snapshot,
         )?;
+        let previous_backup_snapshot = previous_provider
+            .map(|provider| {
+                let mut snapshot = self.build_live_snapshot_from_provider(&app_type, provider)?;
+                Self::apply_codex_unified_session_bucket_to_backup(
+                    &app_type,
+                    provider,
+                    &mut snapshot,
+                )?;
+                Ok::<Value, String>(snapshot)
+            })
+            .transpose()?;
         let existing_backup_value = self.load_live_backup_value(&app_type).await?;
         Self::merge_live_backup_snapshot(
             &app_type,
             existing_backup_value.as_ref(),
+            previous_backup_snapshot.as_ref(),
             backup_snapshot,
             resolution,
         )
@@ -2172,12 +2187,22 @@ impl ProxyService {
     fn merge_live_backup_snapshot(
         app_type: &AppType,
         existing_backup: Option<&Value>,
+        previous_backup_snapshot: Option<&Value>,
         backup_snapshot: Value,
         resolution: live_merge::ConflictResolution<'_>,
     ) -> Result<Value, String> {
         match app_type {
-            AppType::Claude => match existing_backup {
-                Some(existing) => live_merge::merge_json_live(
+            AppType::Claude => match (existing_backup, previous_backup_snapshot) {
+                (Some(existing), Some(base)) => live_merge::merge_json_with_base_live(
+                    app_type,
+                    "proxy live backup",
+                    existing.clone(),
+                    base,
+                    &backup_snapshot,
+                    resolution,
+                )
+                .map_err(|error| error.to_string()),
+                (Some(existing), None) => live_merge::merge_json_live(
                     app_type,
                     "proxy live backup",
                     existing.clone(),
@@ -2185,19 +2210,35 @@ impl ProxyService {
                     resolution,
                 )
                 .map_err(|error| error.to_string()),
-                None => Ok(backup_snapshot),
+                (None, _) => Ok(backup_snapshot),
             },
-            AppType::Codex => {
-                Self::merge_codex_live_backup(existing_backup, backup_snapshot, resolution)
-            }
+            AppType::Codex => Self::merge_codex_live_backup(
+                existing_backup,
+                previous_backup_snapshot,
+                backup_snapshot,
+                resolution,
+            ),
             AppType::Gemini => {
                 let incoming_env = backup_snapshot
                     .get("env")
                     .cloned()
                     .unwrap_or_else(|| json!({}));
                 let incoming_snapshot = json!({ "env": incoming_env });
-                match existing_backup {
-                    Some(existing) => live_merge::merge_json_live(
+                let base_snapshot = previous_backup_snapshot.map(|base| {
+                    let base_env = base.get("env").cloned().unwrap_or_else(|| json!({}));
+                    json!({ "env": base_env })
+                });
+                match (existing_backup, base_snapshot.as_ref()) {
+                    (Some(existing), Some(base)) => live_merge::merge_json_with_base_live(
+                        app_type,
+                        "proxy live backup",
+                        existing.clone(),
+                        base,
+                        &incoming_snapshot,
+                        resolution,
+                    )
+                    .map_err(|error| error.to_string()),
+                    (Some(existing), None) => live_merge::merge_json_live(
                         app_type,
                         "proxy live backup",
                         existing.clone(),
@@ -2205,7 +2246,7 @@ impl ProxyService {
                         resolution,
                     )
                     .map_err(|error| error.to_string()),
-                    None => Ok(incoming_snapshot),
+                    (None, _) => Ok(incoming_snapshot),
                 }
             }
             AppType::OpenCode | AppType::Hermes | AppType::OpenClaw => Ok(backup_snapshot),
@@ -2214,6 +2255,7 @@ impl ProxyService {
 
     fn merge_codex_live_backup(
         existing_backup: Option<&Value>,
+        previous_backup_snapshot: Option<&Value>,
         mut incoming_backup: Value,
         resolution: live_merge::ConflictResolution<'_>,
     ) -> Result<Value, String> {
@@ -2226,34 +2268,64 @@ impl ProxyService {
             .get("auth")
             .cloned()
             .unwrap_or_else(|| json!({}));
+        let base_auth = previous_backup_snapshot
+            .and_then(|base| base.get("auth"))
+            .cloned()
+            .unwrap_or_else(|| json!({}));
         let incoming_auth = incoming_backup
             .get("auth")
             .cloned()
             .unwrap_or_else(|| json!({}));
-        let merged_auth = live_merge::merge_json_live(
-            &AppType::Codex,
-            "proxy live backup auth",
-            existing_auth,
-            &incoming_auth,
-            resolution,
-        )
+        let merged_auth = if previous_backup_snapshot.is_some() {
+            live_merge::merge_json_with_base_live(
+                &AppType::Codex,
+                "proxy live backup auth",
+                existing_auth,
+                &base_auth,
+                &incoming_auth,
+                resolution,
+            )
+        } else {
+            live_merge::merge_json_live(
+                &AppType::Codex,
+                "proxy live backup auth",
+                existing_auth,
+                &incoming_auth,
+                resolution,
+            )
+        }
         .map_err(|error| error.to_string())?;
 
         let existing_config = existing_backup
             .get("config")
             .and_then(Value::as_str)
             .unwrap_or_default();
+        let base_config = previous_backup_snapshot
+            .and_then(|base| base.get("config"))
+            .and_then(Value::as_str)
+            .unwrap_or_default();
         let incoming_config = incoming_backup
             .get("config")
             .and_then(Value::as_str)
             .unwrap_or_default();
-        let merged_config = live_merge::merge_toml_live(
-            &AppType::Codex,
-            "proxy live backup config",
-            existing_config,
-            incoming_config,
-            resolution,
-        )
+        let merged_config = if previous_backup_snapshot.is_some() {
+            live_merge::merge_toml_with_base_live(
+                &AppType::Codex,
+                "proxy live backup config",
+                existing_config,
+                base_config,
+                incoming_config,
+                resolution,
+            )
+        } else {
+            live_merge::merge_toml_live(
+                &AppType::Codex,
+                "proxy live backup config",
+                existing_config,
+                incoming_config,
+                resolution,
+            )
+        }
         .map_err(|error| error.to_string())?;
 
         if let Some(root) = merged.as_object_mut() {
@@ -2289,11 +2361,25 @@ impl ProxyService {
             .map_err(|e| format!("读取供应商失败: {e}"))?
             .ok_or_else(|| format!("供应商不存在: {provider_id}"))?;
 
-        let logical_target_changed =
+        let current_provider_id =
             crate::settings::get_effective_current_provider(&self.db, &app_type_enum)
-                .map_err(|e| format!("读取当前供应商失败: {e}"))?
-                .as_deref()
-                != Some(provider_id);
+                .map_err(|e| format!("读取当前供应商失败: {e}"))?;
+        let logical_target_changed = current_provider_id.as_deref() != Some(provider_id);
+        let previous_provider = current_provider_id
+            .as_deref()
+            .filter(|current_id| *current_id != provider_id)
+            .and_then(|current_id| {
+                self.db
+                    .get_provider_by_id(current_id, app_type)
+                    .map_err(|error| {
+                        log::warn!(
+                            "load previous provider {current_id} for {app_type} failed while hot-switching: {error}"
+                        );
+                        error
+                    })
+                    .ok()
+                    .flatten()
+            });
 
         let has_backup = self
             .db
@@ -2311,7 +2397,15 @@ impl ProxyService {
             .map_err(|e| format!("更新本地当前供应商失败: {e}"))?;
 
         if should_sync_live {
-            self.update_live_backup_from_provider(app_type_enum.as_str(), &provider)
+            let backup_snapshot = self
+                .prepare_live_backup_from_provider_with_resolution(
+                    app_type_enum.as_str(),
+                    &provider,
+                    previous_provider.as_ref(),
+                    live_merge::ConflictPolicy::PreferIncoming.into(),
+                )
+                .await?;
+            self.save_live_backup_snapshot(app_type_enum.as_str(), &backup_snapshot)
                 .await?;
             self.write_failover_live_snapshot_for_provider(&app_type_enum, &provider)
                 .await?;
@@ -7245,6 +7339,22 @@ requires_openai_auth = true
             Some("kept"),
             "hot switch should preserve local-only live backup fields while refreshing provider-owned fields"
         );
+        let backup_model_providers = parsed_backup
+            .get("model_providers")
+            .and_then(|v| v.as_table())
+            .expect("backup model_providers");
+        assert!(
+            backup_model_providers.get("rightcode").is_none(),
+            "hot switch should remove stale provider-owned config sections from the restore backup"
+        );
+        assert_eq!(
+            backup_model_providers
+                .get("aihubmix")
+                .and_then(|v| v.get("base_url"))
+                .and_then(|v| v.as_str()),
+            Some("https://aihubmix.example/v1"),
+            "hot switch should keep the selected provider config section in the restore backup"
+        );
 
         let snapshot = db
             .get_failover_live_snapshot("codex", "b")
@@ -7342,6 +7452,22 @@ requires_openai_auth = true
             parsed_restored.get("local_only").and_then(|v| v.as_str()),
             Some("kept"),
             "restore should preserve local-only live backup fields"
+        );
+        let restored_model_providers = parsed_restored
+            .get("model_providers")
+            .and_then(|v| v.as_table())
+            .expect("restored model_providers");
+        assert!(
+            restored_model_providers.get("rightcode").is_none(),
+            "restore should not bring back stale provider-owned config sections"
+        );
+        assert_eq!(
+            restored_model_providers
+                .get("aihubmix")
+                .and_then(|v| v.get("base_url"))
+                .and_then(|v| v.as_str()),
+            Some("https://aihubmix.example/v1"),
+            "restore should keep the selected provider config section"
         );
         assert_eq!(
             restored

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -149,6 +149,8 @@ struct AutoFailoverActivation {
     app_type: AppType,
     previous_db_current_provider: Option<String>,
     previous_local_current_provider: Option<String>,
+    previous_live_backup: Option<String>,
+    rollback_live_backup: String,
 }
 
 fn proxy_runtime_registry() -> &'static StdMutex<HashMap<String, Weak<ProxyRuntimeState>>> {
@@ -1834,14 +1836,29 @@ impl ProxyService {
             .get_current_provider(app_key)
             .map_err(|error| format!("load current provider for {app_key} failed: {error}"))?;
         let previous_local_current_provider = crate::settings::get_current_provider(&app_type);
+        let previous_live_backup = self
+            .db
+            .get_live_backup(app_key)
+            .await
+            .map_err(|error| format!("load live backup for {app_key} failed: {error}"))?
+            .map(|backup| backup.original_config);
         self.regenerate_failover_live_snapshots_for_app(&app_type, Some(&first_provider_id))
             .await?;
+        let rollback_live_backup = self
+            .db
+            .get_live_backup(app_key)
+            .await
+            .map_err(|error| format!("load rollback backup for {app_key} failed: {error}"))?
+            .map(|backup| backup.original_config)
+            .ok_or_else(|| format!("missing rollback backup for {app_key}"))?;
         self.switch_proxy_target(app_key, &first_provider_id)
             .await?;
         Ok(AutoFailoverActivation {
             app_type,
             previous_db_current_provider,
             previous_local_current_provider,
+            previous_live_backup,
+            rollback_live_backup,
         })
     }
 
@@ -1894,12 +1911,33 @@ impl ProxyService {
             {
                 let _guard =
                     crate::services::state_coordination::acquire_restore_mutation_guard().await?;
+                self.db
+                    .save_live_backup(app_key, &activation.rollback_live_backup)
+                    .await
+                    .map_err(|rollback_error| {
+                        format!(
+                            "enable proxy and auto failover failed: {start_error}; rollback failed: restore live backup for {app_key} failed: {rollback_error}"
+                        )
+                    })?;
                 if let Err(rollback_error) = self
                     .disable_takeover_for_app_unlocked(&activation.app_type, false)
                     .await
                 {
                     return Err(format!(
                         "enable proxy and auto failover failed: {start_error}; rollback failed: {rollback_error}"
+                    ));
+                }
+                let restore_backup_result = match activation.previous_live_backup.as_deref() {
+                    Some(previous_live_backup) => {
+                        self.db
+                            .save_live_backup(app_key, previous_live_backup)
+                            .await
+                    }
+                    None => self.db.delete_live_backup(app_key).await,
+                };
+                if let Err(rollback_error) = restore_backup_result {
+                    return Err(format!(
+                        "enable proxy and auto failover failed: {start_error}; rollback failed: restore prior live backup for {app_key} failed: {rollback_error}"
                     ));
                 }
                 if let Err(rollback_error) =
@@ -2273,6 +2311,8 @@ impl ProxyService {
             .map_err(|e| format!("更新本地当前供应商失败: {e}"))?;
 
         if should_sync_live {
+            self.update_live_backup_from_provider(app_type_enum.as_str(), &provider)
+                .await?;
             self.write_failover_live_snapshot_for_provider(&app_type_enum, &provider)
                 .await?;
         }
@@ -4570,7 +4610,25 @@ mod tests {
             .expect("backup exists");
         let stored_backup: Value =
             serde_json::from_str(&backup.original_config).expect("parse original live backup");
-        assert_eq!(stored_backup, original_live);
+        assert_eq!(
+            stored_backup
+                .pointer("/env/ANTHROPIC_BASE_URL")
+                .and_then(Value::as_str),
+            Some("https://b.example"),
+            "enabling auto-failover should refresh the restore backup to the queue head"
+        );
+        assert_eq!(
+            stored_backup
+                .pointer("/env/ANTHROPIC_AUTH_TOKEN")
+                .and_then(Value::as_str),
+            Some("b")
+        );
+        assert_eq!(
+            stored_backup
+                .pointer("/env/LOCAL_ONLY")
+                .and_then(Value::as_str),
+            Some("kept")
+        );
 
         for (provider_id, token, base_url) in [
             ("provider-a", "a", "https://a.example"),
@@ -7059,7 +7117,7 @@ wire_api = "responses"
 
     #[tokio::test]
     #[serial]
-    async fn hot_switch_codex_provider_uses_failover_snapshot_without_mutating_live_backup() {
+    async fn hot_switch_codex_provider_refreshes_restore_backup_to_selected_provider() {
         let temp_home = TempDir::new().expect("create temp home");
         let _env = TestHomeEnvGuard::set(temp_home.path());
 
@@ -7113,7 +7171,21 @@ requires_openai_auth = true
             .expect("set current provider");
         crate::settings::set_current_provider(&AppType::Codex, Some("a"))
             .expect("set local current provider");
-        let original_backup = provider_a.settings_config.clone();
+        let original_backup = json!({
+            "auth": {
+                "OPENAI_API_KEY": "rightcode-key"
+            },
+            "config": r#"model_provider = "rightcode"
+model = "gpt-5.4"
+local_only = "kept"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "https://rightcode.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+        });
         db.save_live_backup(
             "codex",
             &serde_json::to_string(&original_backup).expect("serialize provider a"),
@@ -7149,7 +7221,30 @@ requires_openai_auth = true
             .expect("backup exists");
         let stored_backup: Value =
             serde_json::from_str(&backup.original_config).expect("parse backup json");
-        assert_eq!(stored_backup, original_backup);
+        assert_eq!(
+            stored_backup
+                .get("auth")
+                .and_then(|auth| auth.get("OPENAI_API_KEY"))
+                .and_then(Value::as_str),
+            Some("aihubmix-key"),
+            "hot switch should refresh the restore backup auth to the selected provider"
+        );
+        let backup_config = stored_backup
+            .get("config")
+            .and_then(Value::as_str)
+            .expect("backup config string");
+        let parsed_backup: toml::Value =
+            toml::from_str(backup_config).expect("parse backup config");
+        assert_eq!(
+            parsed_backup.get("model_provider").and_then(|v| v.as_str()),
+            Some("aihubmix"),
+            "hot switch should refresh the restore backup config to the selected provider"
+        );
+        assert_eq!(
+            parsed_backup.get("local_only").and_then(|v| v.as_str()),
+            Some("kept"),
+            "hot switch should preserve local-only live backup fields while refreshing provider-owned fields"
+        );
 
         let snapshot = db
             .get_failover_live_snapshot("codex", "b")
@@ -7240,16 +7335,21 @@ requires_openai_auth = true
             parsed_restored
                 .get("model_provider")
                 .and_then(|v| v.as_str()),
-            Some("rightcode"),
-            "restore should use the original local backup"
+            Some("aihubmix"),
+            "restore should use the hot-switched provider backup"
+        );
+        assert_eq!(
+            parsed_restored.get("local_only").and_then(|v| v.as_str()),
+            Some("kept"),
+            "restore should preserve local-only live backup fields"
         );
         assert_eq!(
             restored
                 .get("auth")
                 .and_then(|auth| auth.get("OPENAI_API_KEY"))
                 .and_then(Value::as_str),
-            Some("rightcode-key"),
-            "restore should use the original local backup auth"
+            Some("aihubmix-key"),
+            "restore should use the hot-switched provider backup auth"
         );
     }
 
@@ -7321,6 +7421,126 @@ requires_openai_auth = true
         assert!(
             stored.get("config").is_none(),
             "Gemini live backup should not snapshot settings.json/config; upstream keeps only env"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn hot_switch_gemini_provider_refreshes_restore_backup_to_selected_provider() {
+        let temp_home = TempDir::new().expect("create temp home");
+        let _env = TestHomeEnvGuard::set(temp_home.path());
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider_a = Provider::with_id(
+            "a".to_string(),
+            "A".to_string(),
+            json!({
+                "env": {
+                    "GEMINI_API_KEY": "a-key"
+                }
+            }),
+            None,
+        );
+        let provider_b = Provider::with_id(
+            "b".to_string(),
+            "B".to_string(),
+            json!({
+                "env": {
+                    "GEMINI_API_KEY": "b-key"
+                },
+                "config": {
+                    "theme": "selected"
+                }
+            }),
+            None,
+        );
+        db.save_provider("gemini", &provider_a)
+            .expect("save provider a");
+        db.save_provider("gemini", &provider_b)
+            .expect("save provider b");
+        db.set_current_provider("gemini", "a")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Gemini, Some("a"))
+            .expect("set local current provider");
+        db.save_live_backup(
+            "gemini",
+            r#"{"env":{"GEMINI_API_KEY":"a-key","LOCAL_ONLY":"kept"}}"#,
+        )
+        .await
+        .expect("seed live backup");
+        service
+            .write_gemini_live(&json!({
+                "env": {
+                    "GOOGLE_GEMINI_BASE_URL": "http://127.0.0.1:15721",
+                    "GEMINI_API_KEY": PROXY_TOKEN_PLACEHOLDER
+                }
+            }))
+            .expect("seed taken-over Gemini live config");
+
+        service
+            .hot_switch_provider("gemini", "b")
+            .await
+            .expect("hot switch Gemini provider");
+
+        let backup = db
+            .get_live_backup("gemini")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        let stored_backup: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+        assert_eq!(
+            stored_backup
+                .pointer("/env/GEMINI_API_KEY")
+                .and_then(Value::as_str),
+            Some("b-key"),
+            "hot switch should refresh Gemini restore backup to the selected provider"
+        );
+        assert_eq!(
+            stored_backup
+                .pointer("/env/LOCAL_ONLY")
+                .and_then(Value::as_str),
+            Some("kept"),
+            "hot switch should preserve local-only Gemini backup values"
+        );
+        assert!(
+            stored_backup.get("config").is_none(),
+            "Gemini restore backup should keep only env data"
+        );
+
+        let live = service.read_gemini_live().expect("read Gemini live config");
+        assert_eq!(
+            live.pointer("/env/GEMINI_API_KEY").and_then(Value::as_str),
+            Some(PROXY_TOKEN_PLACEHOLDER),
+            "active Gemini live config should remain proxy-managed during takeover"
+        );
+        assert_eq!(
+            live.pointer("/env/GOOGLE_GEMINI_BASE_URL")
+                .and_then(Value::as_str),
+            Some("http://127.0.0.1:15721"),
+            "active Gemini live config should keep the proxy base URL"
+        );
+
+        service
+            .restore_live_config_for_app(&AppType::Gemini)
+            .await
+            .expect("restore Gemini live config");
+        let restored = service
+            .read_gemini_live()
+            .expect("read restored Gemini live config");
+        assert_eq!(
+            restored
+                .pointer("/env/GEMINI_API_KEY")
+                .and_then(Value::as_str),
+            Some("b-key"),
+            "restore should use the hot-switched Gemini provider backup"
+        );
+        assert_eq!(
+            restored.pointer("/env/LOCAL_ONLY").and_then(Value::as_str),
+            Some("kept"),
+            "restore should preserve local-only Gemini backup values"
         );
     }
 
@@ -7432,7 +7652,7 @@ requires_openai_auth = true
 
     #[tokio::test]
     #[serial]
-    async fn switch_proxy_target_uses_failover_snapshot_without_mutating_live_backup() {
+    async fn switch_proxy_target_refreshes_restore_backup_to_selected_provider() {
         let temp_home = TempDir::new().expect("create temp home");
         let _env = TestHomeEnvGuard::set(temp_home.path());
 
@@ -7501,7 +7721,20 @@ requires_openai_auth = true
             .expect("backup exists");
         let stored_backup: Value =
             serde_json::from_str(&backup.original_config).expect("parse live backup");
-        assert_eq!(stored_backup, original_live);
+        assert_eq!(
+            stored_backup
+                .pointer("/env/ANTHROPIC_API_KEY")
+                .and_then(Value::as_str),
+            Some("b-key"),
+            "switching proxy target should refresh the restore backup to the selected provider"
+        );
+        assert_eq!(
+            stored_backup
+                .pointer("/env/LOCAL_ONLY")
+                .and_then(Value::as_str),
+            Some("kept"),
+            "switching proxy target should preserve local-only backup values"
+        );
 
         let snapshot = db
             .get_failover_live_snapshot("claude", "b")

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -1801,6 +1801,7 @@ async fn switch_provider_under_takeover_refreshes_claude_restore_backup_to_selec
     let provider_a_live = json!({
         "env": {
             "ANTHROPIC_API_KEY": "stale-key",
+            "ANTHROPIC_BASE_URL": "https://a.example",
             "LOCAL_ONLY": "preserve-me"
         },
         "workspace": {
@@ -1826,7 +1827,10 @@ async fn switch_provider_under_takeover_refreshes_claude_restore_backup_to_selec
                 "old-provider".to_string(),
                 "Legacy Claude".to_string(),
                 json!({
-                    "env": { "ANTHROPIC_API_KEY": "stale-key" },
+                    "env": {
+                        "ANTHROPIC_API_KEY": "stale-key",
+                        "ANTHROPIC_BASE_URL": "https://a.example"
+                    },
                     "workspace": { "path": "/tmp/old-workspace" }
                 }),
                 None,
@@ -1932,6 +1936,13 @@ async fn switch_provider_under_takeover_refreshes_claude_restore_backup_to_selec
         Some("preserve-me"),
         "takeover-time switch should keep local-only live config values in the restore backup"
     );
+    assert!(
+        backup_after_switch
+            .get("env")
+            .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
+            .is_none(),
+        "takeover-time switch should remove provider-owned keys that are absent from the selected provider"
+    );
     assert_eq!(
         backup_after_switch
             .get("env")
@@ -1981,6 +1992,13 @@ async fn switch_provider_under_takeover_refreshes_claude_restore_backup_to_selec
             .and_then(|value| value.as_str()),
         Some("preserve-me"),
         "restore after a takeover-time switch should keep local-only live config values"
+    );
+    assert!(
+        restored_live
+            .get("env")
+            .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
+            .is_none(),
+        "restore after a takeover-time switch should not restore stale provider-owned keys"
     );
     assert_ne!(
         restored_live

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -1788,8 +1788,7 @@ fn switch_provider_codex_rejects_missing_auth() {
 
 #[tokio::test]
 #[serial]
-async fn switch_provider_under_takeover_keeps_claude_live_pointing_to_proxy_and_preserves_restore_backup(
-) {
+async fn switch_provider_under_takeover_refreshes_claude_restore_backup_to_selected_provider() {
     let _guard = lock_test_mutex();
     reset_test_fs();
     let _home = ensure_test_home();
@@ -1799,19 +1798,19 @@ async fn switch_provider_under_takeover_keeps_claude_live_pointing_to_proxy_and_
         std::fs::create_dir_all(parent).expect("create claude settings dir");
     }
 
-    let legacy_live = json!({
+    let provider_a_live = json!({
         "env": {
-            "ANTHROPIC_API_KEY": "fresh-key",
+            "ANTHROPIC_API_KEY": "stale-key",
             "LOCAL_ONLY": "preserve-me"
         },
         "workspace": {
-            "path": "/tmp/new-workspace",
+            "path": "/tmp/old-workspace",
             "localOnly": true
         }
     });
     std::fs::write(
         &settings_path,
-        serde_json::to_string_pretty(&legacy_live).expect("serialize legacy live"),
+        serde_json::to_string_pretty(&provider_a_live).expect("serialize provider A live"),
     )
     .expect("seed claude live config");
 
@@ -1827,7 +1826,8 @@ async fn switch_provider_under_takeover_keeps_claude_live_pointing_to_proxy_and_
                 "old-provider".to_string(),
                 "Legacy Claude".to_string(),
                 json!({
-                    "env": { "ANTHROPIC_API_KEY": "stale-key" }
+                    "env": { "ANTHROPIC_API_KEY": "stale-key" },
+                    "workspace": { "path": "/tmp/old-workspace" }
                 }),
                 None,
             ),
@@ -1848,6 +1848,18 @@ async fn switch_provider_under_takeover_keeps_claude_live_pointing_to_proxy_and_
         manager
             .providers
             .insert("new-provider".to_string(), new_provider);
+        manager.providers.insert(
+            "future-provider".to_string(),
+            Provider::with_id(
+                "future-provider".to_string(),
+                "Future Claude".to_string(),
+                json!({
+                    "env": { "ANTHROPIC_API_KEY": "future-key" },
+                    "workspace": { "path": "/tmp/future-workspace" }
+                }),
+                None,
+            ),
+        );
     }
     config.common_config_snippets.claude = Some(
         serde_json::json!({
@@ -1907,18 +1919,26 @@ async fn switch_provider_under_takeover_keeps_claude_live_pointing_to_proxy_and_
     assert_eq!(
         backup_after_switch
             .get("env")
+            .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+            .and_then(|value| value.as_str()),
+        Some("fresh-key"),
+        "takeover-time switch should refresh the restore backup to the selected provider"
+    );
+    assert_eq!(
+        backup_after_switch
+            .get("env")
             .and_then(|env| env.get("LOCAL_ONLY"))
             .and_then(|value| value.as_str()),
         Some("preserve-me"),
-        "takeover-time switch should preserve the original live backup used for restore"
+        "takeover-time switch should keep local-only live config values in the restore backup"
     );
     assert_eq!(
         backup_after_switch
             .get("env")
             .and_then(|env| env.get("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"))
             .and_then(|value| value.as_str()),
-        None,
-        "provider common config belongs in generated failover snapshots, not the restore backup"
+        Some("1"),
+        "selected-provider restore backup should use normal Claude common snippet semantics"
     );
 
     let failover_snapshot = state
@@ -1952,7 +1972,7 @@ async fn switch_provider_under_takeover_keeps_claude_live_pointing_to_proxy_and_
             .and_then(|env| env.get("ANTHROPIC_API_KEY"))
             .and_then(|value| value.as_str()),
         Some("fresh-key"),
-        "restore after a takeover-time switch should recover the original local live config"
+        "restore after a takeover-time switch should recover the selected provider"
     );
     assert_eq!(
         restored_live
@@ -1962,12 +1982,37 @@ async fn switch_provider_under_takeover_keeps_claude_live_pointing_to_proxy_and_
         Some("preserve-me"),
         "restore after a takeover-time switch should keep local-only live config values"
     );
-    assert_eq!(
+    assert_ne!(
         restored_live
             .get("env")
-            .and_then(|env| env.get("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"))
+            .and_then(|env| env.get("ANTHROPIC_API_KEY"))
             .and_then(|value| value.as_str()),
-        None,
-        "restore after takeover should not write provider common config into the preserved local backup"
+        Some("stale-key"),
+        "disable takeover must not restore the provider that was current when takeover started"
+    );
+
+    ProviderService::switch(&state, AppType::Claude, "future-provider")
+        .expect("switching away after takeover restore should succeed");
+
+    let saved_new_provider = saved_provider(AppType::Claude, "new-provider");
+    assert_eq!(
+        saved_new_provider
+            .settings_config
+            .get("env")
+            .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+            .and_then(|value| value.as_str()),
+        Some("fresh-key"),
+        "switching after takeover restore should not backfill stale provider A into provider B"
+    );
+
+    let live_after_future_switch: serde_json::Value =
+        read_json_file(&settings_path).expect("read claude live settings after future switch");
+    assert_eq!(
+        live_after_future_switch
+            .get("env")
+            .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+            .and_then(|value| value.as_str()),
+        Some("future-key"),
+        "switching after takeover restore should write provider C instead of stale provider A"
     );
 }


### PR DESCRIPTION
Refresh the restore backup from the selected provider during takeover hot-switches so disabling proxy restores the provider the user chose instead of the one active when takeover began.

Fixes #292 