### PR TITLE
docs(proxy): document Windows managed-session limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,14 @@ cc-switch proxy serve --takeover claude           # Foreground debug mode; refus
 
 Normal CLI/TUI proxy enable/disable actions are routed through the daemon. The daemon auto-starts when the first app proxy route is activated, runs one worker per active supported app (Claude, Codex, Gemini), and exits automatically when no proxy routes remain active.
 
+> **Platform support:** The daemon-managed proxy relies on a Unix-domain-socket supervisor and is available **only on macOS and Linux**. On Windows, `proxy enable` / `proxy disable` and the `daemon` subcommand are unavailable and fail with `managed sessions are only supported on unix`. To run the local proxy on Windows, use the foreground mode instead, which starts the relay without the supervisor:
+>
+> ```bash
+> cc-switch proxy serve --takeover claude
+> ```
+>
+> `proxy show` and `proxy config` work on all platforms. See [#294](https://github.com/SaladDay/cc-switch-cli/issues/294).
+
 ### 🧪 Environment & Local Tools
 
 Inspect environment conflicts and whether required local CLIs are installed.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -455,6 +455,14 @@ cc-switch proxy serve --takeover claude           # 前台调试模式；存在 
 
 普通 CLI/TUI 的代理启用/禁用操作都会通过 daemon 执行。首次启用任一应用代理路由时 daemon 会自动启动；每个活跃的受支持应用（Claude、Codex、Gemini）各有一个 worker；当没有任何活跃代理路由时 daemon 会自动退出。
 
+> **平台支持：** 由 daemon 托管的代理依赖 Unix 域 socket 的 supervisor，**仅在 macOS 和 Linux 上可用**。在 Windows 上，`proxy enable` / `proxy disable` 以及 `daemon` 子命令不可用，会报错 `managed sessions are only supported on unix`。Windows 上如需本地代理，请改用前台模式直接启动中转（不依赖 supervisor）：
+>
+> ```bash
+> cc-switch proxy serve --takeover claude
+> ```
+>
+> `proxy show` 与 `proxy config` 在所有平台均可用。参见 [#294](https://github.com/SaladDay/cc-switch-cli/issues/294)。
+
 ### 🧪 环境与本地工具
 
 检查环境变量冲突，以及 Claude/Codex/Gemini/OpenCode/Hermes/OpenClaw CLI 是否已经装好。


### PR DESCRIPTION
## Summary

Closes #294.

The daemon-managed proxy relies on a Unix-domain-socket supervisor and is **not available on Windows**. On Windows these commands fail with:

    Error: managed sessions are only supported on unix

Affected surface (verified in source):
- `proxy enable` / `proxy disable` → `set_managed_session_for_app` → `daemon_ensure_worker` / `daemon_drop_takeover` (`#[cfg(not(unix))]` returns the error; `src/services/proxy.rs:588,657`)
- the `daemon` subcommand itself (`#[cfg(unix)]`, not registered on Windows; `src/cli/mod.rs:99`)

**Works on Windows:** `proxy show`, `proxy config`, and the foreground `proxy serve --takeover <app>` (the `#[cfg(not(unix))]` branch in `src/cli/commands/proxy.rs:247` skips the daemon handshake).

## Changes

Doc-only. Adds a "Platform support" callout to the Proxy Management section of both `README.md` and `README_ZH.md`, stating the macOS/Linux requirement and pointing Windows users at `proxy serve`. No code changes.

## Why

Issue #294 (a Windows 11 user) requests this be stated explicitly in the README to save other Windows users the setup/troubleshooting time.