### PR TITLE
fix(proxy): avoid per-app port collision on the default proxy port

### DIFF
--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -16,7 +16,7 @@ fn default_app_preferred_port(app_type: &str) -> u16 {
         "claude" => 15721,
         "codex" => 15722,
         "gemini" => 15723,
-        _ => 15721,
+        _ => 15724,
     }
 }
 
@@ -649,7 +649,9 @@ impl Database {
         }
 
         if let Some(port) = self.get_legacy_app_proxy_listen_port(app_type)? {
-            return Ok(port);
+            if app_type == "claude" || port != default_app_preferred_port("claude") {
+                return Ok(port);
+            }
         }
 
         Ok(default_app_preferred_port(app_type))

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Instant};
+use std::{collections::HashMap, io::ErrorKind, net::SocketAddr, sync::Arc, time::Instant};
 
 use axum::{
     extract::DefaultBodyLimit,
@@ -232,9 +232,25 @@ impl ProxyServer {
                 .parse()
                 .map_err(|e| format!("invalid bind address: {e}"))?;
 
-        let listener = tokio::net::TcpListener::bind(addr)
-            .await
-            .map_err(|e| format!("bind proxy listener failed: {e}"))?;
+        let listener = match tokio::net::TcpListener::bind(addr).await {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == ErrorKind::AddrInUse && addr.port() != 0 => {
+                let fallback_addr = SocketAddr::new(addr.ip(), 0);
+                log::warn!(
+                    "proxy listen address {} is already in use; retrying with ephemeral port",
+                    addr
+                );
+                tokio::net::TcpListener::bind(fallback_addr)
+                    .await
+                    .map_err(|fallback_error| {
+                        format!(
+                            "bind proxy listener failed after {} was in use: {}",
+                            addr, fallback_error
+                        )
+                    })?
+            }
+            Err(error) => return Err(format!("bind proxy listener failed: {error}")),
+        };
         let local_addr = listener
             .local_addr()
             .map_err(|e| format!("read proxy listener address failed: {e}"))?;

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -7578,7 +7578,7 @@ requires_openai_auth = true
         service
             .write_gemini_live(&json!({
                 "env": {
-                    "GOOGLE_GEMINI_BASE_URL": "http://127.0.0.1:15721",
+                    "GOOGLE_GEMINI_BASE_URL": "http://127.0.0.1:15723",
                     "GEMINI_API_KEY": PROXY_TOKEN_PLACEHOLDER
                 }
             }))
@@ -7624,7 +7624,7 @@ requires_openai_auth = true
         assert_eq!(
             live.pointer("/env/GOOGLE_GEMINI_BASE_URL")
                 .and_then(Value::as_str),
-            Some("http://127.0.0.1:15721"),
+            Some("http://127.0.0.1:15723"),
             "active Gemini live config should keep the proxy base URL"
         );
 

--- a/src-tauri/tests/proxy_database.rs
+++ b/src-tauri/tests/proxy_database.rs
@@ -193,6 +193,18 @@ fn app_proxy_preferred_ports_round_trip() -> Result<(), AppError> {
     Ok(())
 }
 
+#[test]
+fn default_app_proxy_preferred_ports_are_distinct() -> Result<(), AppError> {
+    let db = Database::memory()?;
+
+    assert_eq!(db.get_app_proxy_preferred_port("claude")?, 15721);
+    assert_eq!(db.get_app_proxy_preferred_port("codex")?, 15722);
+    assert_eq!(db.get_app_proxy_preferred_port("gemini")?, 15723);
+    assert_eq!(db.get_app_proxy_preferred_port("unknown")?, 15724);
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn app_preferred_port_falls_back_to_legacy_proxy_config() -> Result<(), AppError> {
     let db = Database::memory()?;

--- a/src-tauri/tests/proxy_database.rs
+++ b/src-tauri/tests/proxy_database.rs
@@ -213,9 +213,25 @@ async fn app_preferred_port_falls_back_to_legacy_proxy_config() -> Result<(), Ap
     db.update_proxy_config(config).await?;
 
     assert_eq!(db.get_app_proxy_preferred_port("claude")?, 17021);
+    assert_eq!(db.get_app_proxy_preferred_port("codex")?, 17021);
+    assert_eq!(db.get_app_proxy_preferred_port("gemini")?, 17021);
 
     db.set_app_proxy_preferred_port("claude", 17022)?;
     assert_eq!(db.get_app_proxy_preferred_port("claude")?, 17022);
+    Ok(())
+}
+
+#[tokio::test]
+async fn app_preferred_port_ignores_legacy_claude_default_for_other_apps() -> Result<(), AppError> {
+    let db = Database::memory()?;
+    let mut config = db.get_proxy_config().await?;
+    config.listen_port = 15721;
+    db.update_proxy_config(config).await?;
+
+    assert_eq!(db.get_app_proxy_preferred_port("claude")?, 15721);
+    assert_eq!(db.get_app_proxy_preferred_port("codex")?, 15722);
+    assert_eq!(db.get_app_proxy_preferred_port("gemini")?, 15723);
+
     Ok(())
 }
 

--- a/src-tauri/tests/proxy_service.rs
+++ b/src-tauri/tests/proxy_service.rs
@@ -252,6 +252,56 @@ async fn proxy_service_runtime_override_does_not_persist_proxy_config() {
 }
 
 #[tokio::test]
+async fn proxy_service_falls_back_to_ephemeral_port_when_configured_port_is_in_use() {
+    let occupied = TcpListener::bind(("127.0.0.1", 0)).expect("bind occupied local port");
+    let occupied_port = occupied
+        .local_addr()
+        .expect("read occupied listener address")
+        .port();
+    let db = Arc::new(Database::memory().expect("create database"));
+    let service = ProxyService::new(db);
+
+    let mut config = service.get_config().await.expect("get config");
+    config.listen_port = occupied_port;
+
+    let started = service
+        .start_with_runtime_config(config)
+        .await
+        .expect("start proxy on fallback port");
+    assert_ne!(
+        started.port, occupied_port,
+        "proxy should not report the occupied configured port"
+    );
+    assert!(started.port > 0, "fallback port should be bound");
+
+    let status = service.get_status().await;
+    assert_eq!(
+        status.port, started.port,
+        "status should report the actual fallback port"
+    );
+
+    service.stop().await.expect("stop proxy");
+}
+
+#[tokio::test]
+async fn proxy_service_preserves_non_address_in_use_bind_errors() {
+    let db = Arc::new(Database::memory().expect("create database"));
+    let service = ProxyService::new(db);
+
+    let mut config = service.get_config().await.expect("get config");
+    config.listen_address = "not-an-address".to_string();
+
+    let error = service
+        .start_with_runtime_config(config)
+        .await
+        .expect_err("invalid listen address should fail");
+    assert!(
+        error.contains("invalid bind address"),
+        "unexpected bind error: {error}"
+    );
+}
+
+#[tokio::test]
 async fn proxy_service_status_tracks_runtime_uptime() {
     let db = Arc::new(Database::memory().expect("create database"));
     let service = ProxyService::new(db);
@@ -835,7 +885,6 @@ async fn managed_session_allows_second_supported_app_to_start_its_own_worker() {
 
     let state = AppState::try_new().expect("create app state");
     set_claude_proxy_port(&state.db, 0).await;
-    set_codex_proxy_port(&state.db, find_free_port()).await;
 
     state
         .proxy_service
@@ -844,6 +893,17 @@ async fn managed_session_allows_second_supported_app_to_start_its_own_worker() {
         .expect("start managed proxy for claude");
     let claude_pid = load_runtime_session_pid_for_app(&state, "claude");
     let _claude_cleanup = ManagedSessionCleanup::new(claude_pid);
+    let claude_port = state
+        .proxy_service
+        .get_status()
+        .await
+        .active_workers
+        .iter()
+        .find(|worker| worker.app_type == "claude")
+        .expect("claude worker status after start")
+        .port;
+    assert!(claude_port > 0, "claude worker should report a bound port");
+    set_codex_proxy_port(&state.db, claude_port).await;
 
     state
         .proxy_service
@@ -872,6 +932,25 @@ async fn managed_session_allows_second_supported_app_to_start_its_own_worker() {
         "attaching a second app should persist one worker per app"
     );
     let status = state.proxy_service.get_status().await;
+    let claude_worker = status
+        .active_workers
+        .iter()
+        .find(|worker| worker.app_type == "claude")
+        .expect("claude worker status");
+    let codex_worker = status
+        .active_workers
+        .iter()
+        .find(|worker| worker.app_type == "codex")
+        .expect("codex worker status");
+    assert_eq!(
+        claude_worker.port, claude_port,
+        "claude worker should keep its original bound port"
+    );
+    assert_ne!(
+        codex_worker.port, claude_port,
+        "second worker should fall back from the occupied claude port"
+    );
+    assert!(codex_worker.port > 0, "fallback port should be reported");
     assert_eq!(
         status.active_workers.len(),
         2,


### PR DESCRIPTION
## Summary

Starting a second proxy worker failed with `bind proxy listener failed: Address in use (os error 98)`, surfaced as `codex worker exited before hello`. The root cause is a port collision: `default_app_preferred_port` returned `15721` for every app type except `codex`/`gemini`, which is the same port `claude` uses. So once the Claude proxy was bound to 15721, any other app that fell through to the default tried to bind the same port and the worker died before it could start.

This gives non-Claude apps a distinct default port (`15724`) and stops the legacy stored-port lookup from handing back Claude's default port to a different app. As defense in depth, the proxy listener now retries on an ephemeral port if its configured port is already in use, instead of failing the worker outright.

## Why this matters

The collision made it impossible to run a second app's proxy alongside Claude's: the worker exited immediately with an OS-level "Address in use" error and no recovery path. Issue #290 reports exactly this failure. Separating the default ports removes the collision at the source, and the ephemeral fallback keeps a worker alive even if its preferred port is taken by something else on the machine, so the previously-bound port is preserved when free and a free port is chosen otherwise.

## Changes

`default_app_preferred_port` now returns `15724` for the fallback app type so it no longer overlaps Claude's `15721`, and the legacy listen-port lookup no longer returns Claude's default port for a non-Claude app. In `server.rs`, a bind that fails with `AddrInUse` on a fixed port retries once against port `0` (ephemeral), logs a warning, and reports the real bound address; other bind errors and the explicit-ephemeral case are unchanged.

## Testing

Added coverage in `proxy_database.rs` and `proxy_service.rs` for the distinct-default-port behavior and the in-use fallback. Run locally: `cargo test --test proxy_database` (17 pass) and `cargo test --test proxy_service` (30 pass). `cargo fmt --check` is clean.

Fixes #290
