### PR TITLE
feat: resolve providers by name in use/provider switch

### DIFF
--- a/src-tauri/src/cli/commands/provider.rs
+++ b/src-tauri/src/cli/commands/provider.rs
@@ -17,6 +17,7 @@ use crate::error::AppError;
 use crate::provider::{AuthBinding, AuthBindingSource, ClaudeApiKeyField, Provider, ProviderMeta};
 use crate::services::{AuthService, ManagedAuthAccount, ProviderService};
 use crate::store::AppState;
+use indexmap::IndexMap;
 use inquire::{Confirm, Select};
 
 const AUTH_PROVIDER_CODEX_OAUTH: &str = "codex_oauth";
@@ -683,16 +684,53 @@ fn get_state() -> Result<AppState, AppError> {
     AppState::try_new()
 }
 
+/// Resolve a switch argument to a real provider id and its provider record.
+///
+/// An exact id match always wins, so a provider whose name happens to collide
+/// with another provider's id never shadows the id lookup. When the id lookup
+/// misses, fall back to a case- and whitespace-insensitive `name` match. A
+/// single name match resolves to that provider's real id; multiple matches
+/// return an ambiguity error listing the candidate ids so the user can pick one.
+fn resolve_provider_for_switch(
+    providers: &IndexMap<String, Provider>,
+    arg: &str,
+) -> Result<(String, Provider), AppError> {
+    if let Some(provider) = providers.get(arg) {
+        return Ok((arg.to_string(), provider.clone()));
+    }
+
+    let needle = arg.trim();
+    let matches: Vec<(&String, &Provider)> = providers
+        .iter()
+        .filter(|(_, provider)| provider.name.trim().eq_ignore_ascii_case(needle))
+        .collect();
+
+    match matches.as_slice() {
+        [] => Err(AppError::Message(format!("Provider '{}' not found", arg))),
+        [(id, provider)] => Ok(((*id).clone(), (*provider).clone())),
+        multiple => {
+            let candidate_ids = multiple
+                .iter()
+                .map(|(id, _)| id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(AppError::Message(format!(
+                "Multiple providers named '{}'. Specify one by id: {}",
+                arg, candidate_ids
+            )))
+        }
+    }
+}
+
 fn switch_provider(app_type: AppType, id: &str) -> Result<(), AppError> {
     let state = get_state()?;
     let app_str = app_type.as_str().to_string();
     let skip_live_sync = !crate::sync_policy::should_sync_live(&app_type);
 
-    // 检查 provider 是否存在
+    // 检查 provider 是否存在（支持按 id 或名称解析）
     let providers = ProviderService::list(&state, app_type.clone())?;
-    let Some(provider) = providers.get(id).cloned() else {
-        return Err(AppError::Message(format!("Provider '{}' not found", id)));
-    };
+    let (resolved_id, provider) = resolve_provider_for_switch(&providers, id)?;
+    let id = resolved_id.as_str();
 
     // 执行切换（upstream parity：干净写入，无冲突提示）
     ProviderService::switch(&state, app_type.clone(), id)?;

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -2034,3 +2034,146 @@ async fn switch_provider_under_takeover_refreshes_claude_restore_backup_to_selec
         "switching after takeover restore should write provider C instead of stale provider A"
     );
 }
+
+fn seed_claude_provider(config: &mut MultiAppConfig, id: &str, name: &str) {
+    let manager = config
+        .get_manager_mut(&AppType::Claude)
+        .expect("claude manager");
+    let provider = Provider::with_id(
+        id.to_string(),
+        name.to_string(),
+        json!({
+            "env": {
+                "ANTHROPIC_API_KEY": format!("sk-{id}")
+            }
+        }),
+        None,
+    );
+    manager.providers.insert(id.to_string(), provider);
+}
+
+#[test]
+#[serial]
+fn provider_switch_resolves_by_name_case_and_whitespace_insensitive() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "id-alpha".to_string();
+    }
+    seed_claude_provider(&mut config, "id-alpha", "Alpha");
+    seed_claude_provider(&mut config, "id-beta", "Beta Provider");
+
+    let state = state_from_config(config);
+    state.save().expect("persist test providers");
+    drop(state);
+
+    provider_command(
+        ProviderCommand::Switch {
+            id: "  beta provider  ".to_string(),
+        },
+        AppType::Claude,
+    );
+
+    let refreshed = cc_switch_lib::AppState::try_new().expect("reload provider state");
+    assert_eq!(
+        ProviderService::current(&refreshed, AppType::Claude).expect("read current provider"),
+        "id-beta"
+    );
+}
+
+#[test]
+#[serial]
+fn provider_switch_prefers_exact_id_over_name_collision() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "id-other".to_string();
+    }
+    // A provider whose id is "shared" and another whose *name* is "shared".
+    seed_claude_provider(&mut config, "shared", "Real Id Provider");
+    seed_claude_provider(&mut config, "id-other", "shared");
+
+    let state = state_from_config(config);
+    state.save().expect("persist test providers");
+    drop(state);
+
+    provider_command(
+        ProviderCommand::Switch {
+            id: "shared".to_string(),
+        },
+        AppType::Claude,
+    );
+
+    let refreshed = cc_switch_lib::AppState::try_new().expect("reload provider state");
+    assert_eq!(
+        ProviderService::current(&refreshed, AppType::Claude).expect("read current provider"),
+        "shared",
+        "exact id match must win over a colliding provider name"
+    );
+}
+
+#[test]
+#[serial]
+fn provider_switch_unknown_name_or_id_reports_not_found() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    seed_claude_provider(&mut config, "id-alpha", "Alpha");
+
+    let state = state_from_config(config);
+    state.save().expect("persist test providers");
+    drop(state);
+
+    let err = provider_command_result(
+        ProviderCommand::Switch {
+            id: "nonexistent".to_string(),
+        },
+        AppType::Claude,
+    )
+    .expect_err("unknown provider should error");
+    assert!(
+        err.to_string().contains("not found"),
+        "expected not-found error, got: {err}"
+    );
+}
+
+#[test]
+#[serial]
+fn provider_switch_ambiguous_name_lists_candidate_ids() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    seed_claude_provider(&mut config, "id-one", "Duplicate");
+    seed_claude_provider(&mut config, "id-two", "Duplicate");
+
+    let state = state_from_config(config);
+    state.save().expect("persist test providers");
+    drop(state);
+
+    let err = provider_command_result(
+        ProviderCommand::Switch {
+            id: "duplicate".to_string(),
+        },
+        AppType::Claude,
+    )
+    .expect_err("ambiguous name should error");
+    let message = err.to_string();
+    assert!(message.contains("id-one"), "expected id-one in: {message}");
+    assert!(message.contains("id-two"), "expected id-two in: {message}");
+}


### PR DESCRIPTION
## Summary
`cc-switch use <name>` and `cc-switch provider switch <name>` now accept a provider's human-readable name, not just its id. An exact id match still takes precedence, so existing id-based usage is unchanged.

## Why this matters
Issue #301 reports that provider ids are long UUID-like strings users cannot remember, so the id-only lookup in `switch_provider` (src-tauri/src/cli/commands/provider.rs) was hard to use. Both `use` (dispatched in main.rs as `ProviderCommand::Switch`) and `provider switch` funnel through `switch_provider`, so resolving the argument once there covers both commands.

## What changed
When the exact-id lookup misses, `switch_provider` now falls back to a case- and whitespace-insensitive match on the provider `name`. A single name match resolves to that provider's real id, which is then used for the `ProviderService::switch` call, plugin sync, and success message. If two providers share a name, it returns an error listing the candidate ids so the user can disambiguate by id. The original "Provider '<arg>' not found" wording is preserved when nothing matches.

## Testing
Added four integration tests in src-tauri/tests/provider_commands.rs covering: switch by name (case/whitespace-insensitive), exact-id precedence over a colliding name, unknown id/name not-found, and the ambiguity error listing candidate ids. Ran `cargo fmt --check`, `cargo clippy --tests`, and `cargo test --test provider_commands provider_switch` plus the provider unit tests; all pass.

Fixes #301
