### PR TITLE
fix(tui): prefer ansi256 for bare TERM=xterm without truecolor signal

### DIFF
--- a/src-tauri/src/cli/tui/theme.rs
+++ b/src-tauri/src/cli/tui/theme.rs
@@ -75,11 +75,10 @@ fn known_ansi256_terminal() -> bool {
         .unwrap_or(false)
 }
 
-fn ssh_plain_xterm_prefers_ansi256() -> bool {
-    std::env::var_os("SSH_TTY").is_some()
-        && std::env::var("TERM")
-            .map(|value| value.eq_ignore_ascii_case("xterm"))
-            .unwrap_or(false)
+fn plain_xterm_prefers_ansi256() -> bool {
+    std::env::var("TERM")
+        .map(|value| value.eq_ignore_ascii_case("xterm"))
+        .unwrap_or(false)
 }
 
 fn detected_color_mode() -> ColorMode {
@@ -99,7 +98,7 @@ fn detected_color_mode() -> ColorMode {
         return ColorMode::TrueColor;
     }
 
-    if ssh_plain_xterm_prefers_ansi256() {
+    if plain_xterm_prefers_ansi256() {
         return ColorMode::Ansi256;
     }
 
@@ -379,10 +378,28 @@ mod tests {
     }
 
     #[test]
-    fn theme_keeps_truecolor_for_plain_xterm_without_ssh_signal() {
+    fn theme_uses_ansi256_for_plain_xterm_without_truecolor_signal() {
         let _lock = env_lock().lock().expect("env lock poisoned");
         let _no_color = EnvGuard::remove("NO_COLOR");
         let _color_mode = EnvGuard::remove("CC_SWITCH_COLOR_MODE");
+        let _colorterm = EnvGuard::remove("COLORTERM");
+        let _term = EnvGuard::set("TERM", "xterm");
+        let _term_program = EnvGuard::remove("TERM_PROGRAM");
+        let _ssh_tty = EnvGuard::remove("SSH_TTY");
+
+        let theme = theme_for(&AppType::Claude);
+
+        assert_eq!(detected_color_mode(), ColorMode::Ansi256);
+        assert_eq!(theme.accent, Color::Indexed(rgb_to_ansi256(139, 233, 253)));
+        assert_eq!(theme.surface, Color::Indexed(rgb_to_ansi256(68, 71, 90)));
+        assert!(!theme.no_color);
+    }
+
+    #[test]
+    fn explicit_truecolor_override_beats_plain_xterm_auto_fallback() {
+        let _lock = env_lock().lock().expect("env lock poisoned");
+        let _no_color = EnvGuard::remove("NO_COLOR");
+        let _color_mode = EnvGuard::set("CC_SWITCH_COLOR_MODE", "truecolor");
         let _colorterm = EnvGuard::remove("COLORTERM");
         let _term = EnvGuard::set("TERM", "xterm");
         let _term_program = EnvGuard::remove("TERM_PROGRAM");


### PR DESCRIPTION
## What

Make bare `TERM=xterm` (with no truecolor signal) prefer `ColorMode::Ansi256` instead of falling through to `TrueColor`, regardless of whether the session is over SSH.

## Why

Issue #60 reports garbled colors in the TUI on Xshell 8. The decisive diagnostic from the reporter was `TERM=xterm`, empty `COLORTERM`, no `TMUX`, no `SSH_TTY`, running directly in Xshell, with `CC_SWITCH_COLOR_MODE=ansi256 cc-switch` confirmed as the working fix.

In `detected_color_mode()` that environment fell through every branch (`known_ansi256_terminal`, the `COLORTERM`/`TERM` truecolor checks, and `ssh_plain_xterm_prefers_ansi256` which also required an `SSH_TTY`) and hit the final `ColorMode::TrueColor` fallback. Emitting 24-bit escape sequences to a terminal that doesn't reliably support them produces the wrong colors. A bare `TERM=xterm` (exactly `xterm`, not `xterm-256color`) with no `COLORTERM` is a strong signal the terminal is not truecolor-capable, and the existing SSH-only gate was too narrow since the same terminal misbehaves locally.

## Change

- Generalize `ssh_plain_xterm_prefers_ansi256` into `plain_xterm_prefers_ansi256`: it now matches an exact `TERM=xterm` (case-insensitive) and no longer requires an SSH session. The `COLORTERM`/`TERM` truecolor checks still run first in `detected_color_mode()`, so reaching this branch already means no truecolor signal was advertised.
- `xterm-256color`, explicit `COLORTERM=truecolor`/`24bit`, and the `CC_SWITCH_COLOR_MODE` override all stay on the truecolor path, so genuinely-capable terminals are unaffected. An unset `TERM` also still falls through to truecolor.

Tradeoff: a small number of terminals advertise `TERM=xterm` yet do support truecolor. This change trades that rare case for correct rendering on the common plain-`xterm` case; those users can still force truecolor with `CC_SWITCH_COLOR_MODE=truecolor`.

## Testing

Tests use the existing `EnvGuard` harness in `theme.rs`:

- The previous `theme_keeps_truecolor_for_plain_xterm_without_ssh_signal` test (which asserted the reported-buggy behavior) is updated to `theme_uses_ansi256_for_plain_xterm_without_truecolor_signal` and now asserts `Ansi256`.
- Added `explicit_truecolor_override_beats_plain_xterm_auto_fallback`: `CC_SWITCH_COLOR_MODE=truecolor` with `TERM=xterm` still returns `TrueColor`.
- `xterm-256color` + `COLORTERM=truecolor`, unset `TERM`, the SSH plain-xterm case, and `NO_COLOR`/`none` remain covered and pass.

```
cd src-tauri && cargo test --lib cli::tui::theme
# 17 passed; 0 failed
```

`cargo fmt --check` and `cargo clippy --lib` are clean for the touched file.

Closes #60
