### PR TITLE
fix(proxy): emit spec-complete message_start (content/stop_reason/stop_sequence)

### DIFF
--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -166,6 +166,15 @@ pub fn create_anthropic_sse_stream(
                                         "id": message_id.clone().unwrap_or_default(),
                                         "type": "message",
                                         "role": "assistant",
+                                        // Anthropic SSE spec requires these fields in the
+                                        // message snapshot; the official SDK's stream
+                                        // accumulator does `snapshot.content.push(...)` and
+                                        // crashes ("Cannot read properties of undefined")
+                                        // when `content` is missing, forcing clients into
+                                        // non-streaming fallback (or silent stream loss).
+                                        "content": [],
+                                        "stop_reason": serde_json::Value::Null,
+                                        "stop_sequence": serde_json::Value::Null,
                                         "model": current_model.clone().unwrap_or_default(),
                                         "usage": start_usage
                                     }
@@ -817,6 +826,27 @@ mod tests {
             message_start["message"]["usage"]["cache_read_input_tokens"],
             0
         );
+    }
+
+    #[tokio::test]
+    async fn streaming_message_start_is_spec_complete() {
+        // message_start must carry content/stop_reason/stop_sequence or the
+        // official Anthropic SDK stream accumulator crashes on snapshot.content.
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_events(input).await;
+        let message = &events
+            .iter()
+            .find(|event| event["type"] == "message_start")
+            .expect("message_start event")["message"];
+
+        assert_eq!(message["content"], serde_json::json!([]));
+        assert_eq!(message["stop_reason"], serde_json::Value::Null);
+        assert_eq!(message["stop_sequence"], serde_json::Value::Null);
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/streaming_gemini.rs
+++ b/src-tauri/src/proxy/providers/streaming_gemini.rs
@@ -316,6 +316,11 @@ pub fn create_anthropic_sse_stream_from_gemini<E: std::error::Error + Send + 'st
                                     "id": message_id.clone().unwrap_or_default(),
                                     "type": "message",
                                     "role": "assistant",
+                                    // Spec-required fields; missing `content` crashes the
+                                    // official Anthropic SDK stream accumulator.
+                                    "content": [],
+                                    "stop_reason": serde_json::Value::Null,
+                                    "stop_sequence": serde_json::Value::Null,
                                     "model": current_model.clone().unwrap_or_default(),
                                     "usage": build_anthropic_usage(chunk_json.get("usageMetadata"))
                                 }
@@ -423,6 +428,11 @@ pub fn create_anthropic_sse_stream_from_gemini<E: std::error::Error + Send + 'st
                     "id": message_id.clone().unwrap_or_default(),
                     "type": "message",
                     "role": "assistant",
+                    // Spec-required fields; missing `content` crashes the
+                    // official Anthropic SDK stream accumulator.
+                    "content": [],
+                    "stop_reason": serde_json::Value::Null,
+                    "stop_sequence": serde_json::Value::Null,
                     "model": current_model.clone().unwrap_or_default(),
                     "usage": build_anthropic_usage(latest_usage.as_ref())
                 }
@@ -655,6 +665,29 @@ mod tests {
         assert!(output.contains("\"text\":\"lo\""));
         assert!(output.contains("\"stop_reason\":\"end_turn\""));
         assert!(output.contains("event: message_stop"));
+    }
+
+    #[test]
+    fn message_start_is_spec_complete() {
+        // message_start must carry content/stop_reason/stop_sequence or the
+        // official Anthropic SDK stream accumulator crashes on snapshot.content.
+        let output = collect_stream_output(vec![
+            "data: {\"responseId\":\"resp_1\",\"modelVersion\":\"gemini-2.5-pro\",\"candidates\":[{\"finishReason\":\"STOP\",\"content\":{\"parts\":[{\"text\":\"Hi\"}]}}],\"usageMetadata\":{\"promptTokenCount\":4,\"totalTokenCount\":6}}\n\n",
+        ]);
+
+        let data = output
+            .split("\n\n")
+            .find_map(|block| {
+                let line = block.lines().find(|l| l.starts_with("data: "))?;
+                let value: Value = serde_json::from_str(line.trim_start_matches("data: ")).ok()?;
+                (value["type"] == "message_start").then_some(value)
+            })
+            .expect("message_start event");
+        let message = &data["message"];
+
+        assert_eq!(message["content"], serde_json::json!([]));
+        assert_eq!(message["stop_reason"], Value::Null);
+        assert_eq!(message["stop_sequence"], Value::Null);
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -170,6 +170,11 @@ pub fn create_anthropic_sse_stream_from_responses(
                                         "id": message_id.clone().unwrap_or_default(),
                                         "type": "message",
                                         "role": "assistant",
+                                        // Spec-required fields; missing `content` crashes the
+                                        // official Anthropic SDK stream accumulator.
+                                        "content": [],
+                                        "stop_reason": serde_json::Value::Null,
+                                        "stop_sequence": serde_json::Value::Null,
                                         "model": current_model.clone().unwrap_or_default(),
                                         "usage": build_anthropic_usage_from_responses(response_obj.get("usage"))
                                     }
@@ -185,6 +190,11 @@ pub fn create_anthropic_sse_stream_from_responses(
                                             "id": message_id.clone().unwrap_or_default(),
                                             "type": "message",
                                             "role": "assistant",
+                                            // Spec-required fields; missing `content` crashes the
+                                            // official Anthropic SDK stream accumulator.
+                                            "content": [],
+                                            "stop_reason": serde_json::Value::Null,
+                                            "stop_sequence": serde_json::Value::Null,
                                             "model": current_model.clone().unwrap_or_default(),
                                             "usage": { "input_tokens": 0, "output_tokens": 0 }
                                         }
@@ -301,6 +311,11 @@ pub fn create_anthropic_sse_stream_from_responses(
                                                     "id": message_id.clone().unwrap_or_default(),
                                                     "type": "message",
                                                     "role": "assistant",
+                                                    // Spec-required fields; missing `content` crashes the
+                                                    // official Anthropic SDK stream accumulator.
+                                                    "content": [],
+                                                    "stop_reason": serde_json::Value::Null,
+                                                    "stop_sequence": serde_json::Value::Null,
                                                     "model": current_model.clone().unwrap_or_default(),
                                                     "usage": { "input_tokens": 0, "output_tokens": 0 }
                                                 }
@@ -746,6 +761,34 @@ data: {\"response\":{\"status\":\"completed\"}}\r\n\
         assert!(merged.contains("\"type\":\"input_json_delta\""));
         assert!(merged.contains("\\\"city\\\":\\\"Tokyo\\\""));
         assert!(merged.contains("\"stop_reason\":\"tool_use\""));
+    }
+
+    #[tokio::test]
+    async fn tool_first_message_start_is_spec_complete() {
+        // A response that opens with a function_call (no preceding text) emits
+        // message_start from the tool path; it must still carry the spec-required
+        // fields or the official Anthropic SDK stream accumulator crashes.
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"response\":{\"id\":\"resp_tool\",\"model\":\"gpt-5.4\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"item\":{\"id\":\"fc_1\",\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"get_weather\"}}\n\n",
+            "event: response.function_call_arguments.done\n",
+            "data: {\"item_id\":\"fc_1\",\"arguments\":\"{}\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+
+        let (merged, _) = collect_stream(vec![Bytes::from(input)]).await;
+        let events = parse_anthropic_events(&merged);
+        let message = &events
+            .iter()
+            .find(|event| event["type"] == "message_start")
+            .expect("message_start event")["message"];
+
+        assert_eq!(message["content"], serde_json::json!([]));
+        assert_eq!(message["stop_reason"], Value::Null);
+        assert_eq!(message["stop_sequence"], Value::Null);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

When the proxy converts non-Anthropic backends (OpenAI-compatible chat, Gemini, OpenAI Responses) into an Anthropic `/v1/messages` SSE stream, the `message_start` event's `message` snapshot omitted `content`, `stop_reason`, and `stop_sequence`.

The Anthropic streaming spec requires that snapshot to be a full Message with `content: []`. The official `@anthropic-ai/sdk` stream accumulator runs `snapshot.content.push(...)` and throws `Cannot read properties of undefined (reading 'push')` when `content` is missing — forcing clients into per-turn non-streaming fallback (double billing) or intermittently surfacing as a silent empty end-of-turn that terminates agent sessions mid-task.

## Fix

Add the three spec-required fields (`content: []`, `stop_reason: null`, `stop_sequence: null`) to **every** `message_start` construction site across the three transform paths:

- `streaming.rs` — Anthropic / OpenAI-compatible chat (1 site)
- `streaming_gemini.rs` — Gemini → Anthropic (2 sites)
- `streaming_responses.rs` — OpenAI Responses → Anthropic (3 sites, including the tool-call fallback path)

Verified field-for-field against the documented `message_start` shape in the Anthropic streaming docs.

## Tests

Adds a regression test per transform path asserting `message_start` carries the spec-required fields (including the Responses tool-only path).

- `cargo fmt --check` clean
- `cargo clippy` clean (no new warnings in the changed files)
- Streaming unit tests + `proxy_claude_streaming` / `proxy_claude_response_parity` / `proxy_claude_openai_chat` integration targets pass
