### PR TITLE
feat(session-search): full-content deep search + all-providers TUI view

### DIFF
--- a/src-tauri/src/cli/commands/sessions.rs
+++ b/src-tauri/src/cli/commands/sessions.rs
@@ -144,9 +144,7 @@ pub fn execute(cmd: SessionsCommand, app: Option<AppType>) -> Result<(), AppErro
             all,
             yes,
         } => delete_session(app, provider, all, &selector, yes),
-        SessionsCommand::Search { query, json } => {
-            search_sessions_cmd(&query, json)
-        }
+        SessionsCommand::Search { query, json } => search_sessions_cmd(&query, json),
         SessionsCommand::SyncUsage {
             provider,
             all,
@@ -379,10 +377,18 @@ fn search_sessions_cmd(query: &str, json: bool) -> Result<(), AppError> {
         println!();
         println!(
             "{}",
-            info(&format!("=== {} / {} ===", hit.provider_id, short_session_id(&hit.session_id)))
+            info(&format!(
+                "=== {} / {} ===",
+                hit.provider_id,
+                short_session_id(&hit.session_id)
+            ))
         );
         for snippet in &hit.snippets {
-            println!("  [{}] {}", snippet.role, truncate_chars(&snippet.snippet, 200));
+            println!(
+                "  [{}] {}",
+                snippet.role,
+                truncate_chars(&snippet.snippet, 200)
+            );
         }
     }
 

--- a/src-tauri/src/cli/commands/sessions.rs
+++ b/src-tauri/src/cli/commands/sessions.rs
@@ -9,7 +9,7 @@ use crate::cli::ui::{create_table, info, success, to_json, warning};
 use crate::database::Database;
 use crate::error::AppError;
 use crate::services::session_usage::SessionSyncResult;
-use crate::session_manager::{self, SessionMessage, SessionMeta};
+use crate::session_manager::{self, SessionMessage, SessionMeta, SessionSearchHit};
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum SessionsCommand {
@@ -81,6 +81,14 @@ pub enum SessionsCommand {
         #[arg(long)]
         yes: bool,
     },
+    /// Search full conversation content across all sessions
+    Search {
+        /// Search query (case-insensitive, matches message content)
+        query: String,
+        /// Print machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Sync local session logs into usage statistics
     SyncUsage {
         /// Sync a specific provider instead of --app
@@ -136,6 +144,9 @@ pub fn execute(cmd: SessionsCommand, app: Option<AppType>) -> Result<(), AppErro
             all,
             yes,
         } => delete_session(app, provider, all, &selector, yes),
+        SessionsCommand::Search { query, json } => {
+            search_sessions_cmd(&query, json)
+        }
         SessionsCommand::SyncUsage {
             provider,
             all,
@@ -319,6 +330,62 @@ fn delete_session(
             session.provider_id
         ))
     );
+    Ok(())
+}
+
+fn search_sessions_cmd(query: &str, json: bool) -> Result<(), AppError> {
+    let sessions = session_manager::scan_sessions();
+    let hits = session_manager::search_sessions_in(&sessions, query);
+
+    if json {
+        println!(
+            "{}",
+            to_json(&hits).map_err(|source| AppError::JsonSerialize { source })?
+        );
+        return Ok(());
+    }
+
+    if hits.is_empty() {
+        println!("{}", info("No matches found."));
+        return Ok(());
+    }
+
+    let mut table = create_table();
+    table.set_header(vec!["Provider", "Session", "Title", "Snippets"]);
+    for hit in &hits {
+        let session = sessions
+            .iter()
+            .find(|s| s.source_path.as_deref() == Some(&hit.source_path))
+            .map(session_title)
+            .unwrap_or_else(|| short_session_id(&hit.session_id));
+        let snippet_preview = hit
+            .snippets
+            .iter()
+            .take(2)
+            .map(|s| truncate_chars(&s.snippet, 80))
+            .collect::<Vec<_>>()
+            .join(" | ");
+        table.add_row(vec![
+            hit.provider_id.clone(),
+            short_session_id(&hit.session_id),
+            session,
+            snippet_preview,
+        ]);
+    }
+    println!("{table}");
+
+    // Show full snippets for each hit
+    for hit in &hits {
+        println!();
+        println!(
+            "{}",
+            info(&format!("=== {} / {} ===", hit.provider_id, short_session_id(&hit.session_id)))
+        );
+        for snippet in &hit.snippets {
+            println!("  [{}] {}", snippet.role, truncate_chars(&snippet.snippet, 200));
+        }
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/cli/tui/app/app_state.rs
+++ b/src-tauri/src/cli/tui/app/app_state.rs
@@ -11,6 +11,9 @@ pub enum Action {
     LocalEnvRefresh,
 
     SessionsRefresh,
+    SessionsDeepSearch {
+        query: String,
+    },
     SessionMessagesLoad {
         key: String,
         provider_id: String,
@@ -544,6 +547,8 @@ pub struct App {
     pub overlay: Overlay,
     pub toast: Option<Toast>,
     pub should_quit: bool,
+    /// When set, the main loop should fire a SessionsDeepSearch action.
+    pub pending_deep_search: Option<String>,
     pub last_size: Size,
     pub tick: u64,
     pub proxy_input_activity_samples: Vec<u64>,

--- a/src-tauri/src/cli/tui/app/content_entities.rs
+++ b/src-tauri/src/cli/tui/app/content_entities.rs
@@ -34,10 +34,13 @@ impl App {
         let visible = visible_sessions_for_state(
             &self.filter,
             &self.app_type,
+            self.sessions.show_all_providers,
             &self.sessions.rows,
             self.sessions.detail_key.as_deref(),
             self.sessions.messages_loaded,
             &self.sessions.messages,
+            self.sessions.deep_search_query.as_deref(),
+            &self.sessions.deep_search_results,
         );
         let Some(session) = visible.get(self.sessions.selected_idx) else {
             return Action::None;
@@ -456,10 +459,13 @@ impl App {
         let visible = visible_sessions_for_state(
             &self.filter,
             &self.app_type,
+            self.sessions.show_all_providers,
             &self.sessions.rows,
             self.sessions.detail_key.as_deref(),
             self.sessions.messages_loaded,
             &self.sessions.messages,
+            self.sessions.deep_search_query.as_deref(),
+            &self.sessions.deep_search_results,
         );
         match key.code {
             KeyCode::Left => self.move_sessions_focus_left(),
@@ -618,6 +624,16 @@ impl App {
                 Action::None
             }
             KeyCode::Char('r') => Action::SessionsRefresh,
+            KeyCode::Char('a') => {
+                // Enter "show all providers" mode (the "全部" tab)
+                if !self.sessions.show_all_providers {
+                    self.sessions.show_all_providers = true;
+                    self.sessions.loaded_once = false;
+                    self.sessions.selected_idx = 0;
+                    self.sessions.clear_detail();
+                }
+                Action::None
+            }
             _ => Action::None,
         }
     }

--- a/src-tauri/src/cli/tui/app/content_entities.rs
+++ b/src-tauri/src/cli/tui/app/content_entities.rs
@@ -67,6 +67,44 @@ impl App {
         }
     }
 
+    /// Automatically load the detail (messages) for the currently selected
+    /// session in the list, without switching to the Detail pane. This allows
+    /// users to browse session details with Up/Down keys without pressing Enter.
+    fn auto_load_selected_detail(&mut self, _data: &UiData) -> Action {
+        let visible = visible_sessions_for_state(
+            &self.filter,
+            &self.app_type,
+            self.sessions.show_all_providers,
+            &self.sessions.rows,
+            self.sessions.detail_key.as_deref(),
+            self.sessions.messages_loaded,
+            &self.sessions.messages,
+            self.sessions.deep_search_query.as_deref(),
+            &self.sessions.deep_search_results,
+        );
+        let Some(session) = visible.get(self.sessions.selected_idx) else {
+            return Action::None;
+        };
+        let key = session_key(session);
+        // If detail already matches the current selection, no need to reload.
+        if self.sessions.detail_key.as_deref() == Some(key.as_str()) {
+            return Action::None;
+        }
+        let provider_id = session.provider_id.clone();
+        let source_path = session.source_path.clone();
+        self.sessions.open_detail(key.clone());
+        // Stay in List pane during navigation; don't switch to Detail.
+        self.sessions.pane = SessionsPane::List;
+        match source_path {
+            Some(source_path) => Action::SessionMessagesLoad {
+                key,
+                provider_id,
+                source_path,
+            },
+            None => Action::None,
+        }
+    }
+
     fn is_provider_read_only(&self, row: &super::data::ProviderRow) -> bool {
         super::data::provider_is_read_only(&self.app_type, row)
     }
@@ -474,6 +512,7 @@ impl App {
                 match self.sessions.pane {
                     SessionsPane::List => {
                         self.sessions.selected_idx = self.sessions.selected_idx.saturating_sub(1);
+                        return self.auto_load_selected_detail(data);
                     }
                     SessionsPane::Detail => {
                         let next_idx = {
@@ -502,6 +541,7 @@ impl App {
                             self.sessions.selected_idx =
                                 (self.sessions.selected_idx + 1).min(visible.len() - 1);
                         }
+                        return self.auto_load_selected_detail(data);
                     }
                     SessionsPane::Detail => {
                         let next_idx = {
@@ -528,6 +568,7 @@ impl App {
                     let page = self.sessions_list_page_size();
                     self.sessions.selected_idx =
                         (self.sessions.selected_idx + page).min(visible.len() - 1);
+                    return self.auto_load_selected_detail(data);
                 }
                 Action::None
             }
@@ -535,18 +576,21 @@ impl App {
                 if matches!(self.sessions.pane, SessionsPane::List) {
                     let page = self.sessions_list_page_size();
                     self.sessions.selected_idx = self.sessions.selected_idx.saturating_sub(page);
+                    return self.auto_load_selected_detail(data);
                 }
                 Action::None
             }
             KeyCode::Home => {
                 if matches!(self.sessions.pane, SessionsPane::List) {
                     self.sessions.selected_idx = 0;
+                    return self.auto_load_selected_detail(data);
                 }
                 Action::None
             }
             KeyCode::End => {
                 if matches!(self.sessions.pane, SessionsPane::List) && !visible.is_empty() {
                     self.sessions.selected_idx = visible.len() - 1;
+                    return self.auto_load_selected_detail(data);
                 }
                 Action::None
             }

--- a/src-tauri/src/cli/tui/app/helpers.rs
+++ b/src-tauri/src/cli/tui/app/helpers.rs
@@ -791,10 +791,13 @@ pub(crate) fn visible_sessions<'a>(
 pub(crate) fn visible_sessions_for_state<'a>(
     filter: &FilterState,
     app_type: &AppType,
+    show_all: bool,
     rows: &'a [crate::session_manager::SessionMeta],
     detail_key: Option<&str>,
     messages_loaded: bool,
     messages: &[crate::session_manager::SessionMessage],
+    deep_search_query: Option<&str>,
+    deep_search_results: &[crate::session_manager::SessionSearchHit],
 ) -> Vec<&'a crate::session_manager::SessionMeta> {
     let query = filter.query_lower();
     let provider_id = app_type.as_str();
@@ -802,15 +805,50 @@ pub(crate) fn visible_sessions_for_state<'a>(
         loaded_detail_message_match_key(filter, detail_key, messages_loaded, messages)
     });
 
+    // If deep search is active, only show sessions that appear in search hits
+    // (merged with metadata matches).
+    let deep_search_source_paths: Option<std::collections::HashSet<&str>> =
+        if let Some(_q) = deep_search_query {
+            Some(
+                deep_search_results
+                    .iter()
+                    .map(|h| h.source_path.as_str())
+                    .collect(),
+            )
+        } else {
+            None
+        };
+
     rows.iter()
-        .filter(|row| row.provider_id == provider_id)
-        .filter(|row| match &query {
-            None => true,
-            Some(q) => {
-                session_matches_filter(row, q)
-                    || message_match_key
-                        .as_deref()
-                        .is_some_and(|key| session_key(row) == key)
+        .filter(|row| show_all || row.provider_id == provider_id)
+        .filter(|row| {
+            // Deep search filtering: if active, show session if it's in search hits
+            // OR matches metadata filter
+            if let Some(ref hit_paths) = deep_search_source_paths {
+                let in_hits = row
+                    .source_path
+                    .as_deref()
+                    .is_some_and(|sp| hit_paths.contains(sp));
+                let meta_match = match &query {
+                    None => false,
+                    Some(q) => {
+                        session_matches_filter(row, q)
+                            || message_match_key
+                                .as_deref()
+                                .is_some_and(|key| session_key(row) == key)
+                    }
+                };
+                return in_hits || meta_match;
+            }
+            // Normal metadata filter
+            match &query {
+                None => true,
+                Some(q) => {
+                    session_matches_filter(row, q)
+                        || message_match_key
+                            .as_deref()
+                            .is_some_and(|key| session_key(row) == key)
+                }
             }
         })
         .collect()

--- a/src-tauri/src/cli/tui/app/menu.rs
+++ b/src-tauri/src/cli/tui/app/menu.rs
@@ -711,6 +711,9 @@ impl App {
                     self.sessions.deep_search_query = None;
                     self.sessions.deep_search_results.clear();
                     self.sessions.deep_search_pending = None;
+                    // Drop any in-flight search too, so its result is ignored on
+                    // arrival and the "searching" spinner stops immediately.
+                    self.sessions.deep_search_active = None;
                 }
                 if is_daily_memory {
                     self.openclaw_daily_memory_search_results.clear();
@@ -734,6 +737,7 @@ impl App {
                         self.sessions.deep_search_query = None;
                         self.sessions.deep_search_results.clear();
                         self.sessions.deep_search_pending = None;
+                        self.sessions.deep_search_active = None;
                         Action::None
                     } else {
                         // If deep search has already completed for this query,
@@ -793,8 +797,13 @@ impl App {
                         self.sessions.deep_search_pending = None;
                         self.sessions.deep_search_query = None;
                         self.sessions.deep_search_results.clear();
+                        self.sessions.deep_search_active = None;
                     } else {
                         self.sessions.deep_search_pending = Some((q, 0));
+                        // The query changed, so any in-flight search is now
+                        // stale: invalidate it so its result is not accepted
+                        // under the new query text.
+                        self.sessions.deep_search_active = None;
                     }
                 }
                 if is_daily_memory && edit.changed && self.filter.input.value.is_empty() {

--- a/src-tauri/src/cli/tui/app/menu.rs
+++ b/src-tauri/src/cli/tui/app/menu.rs
@@ -749,7 +749,11 @@ impl App {
                 if edit.changed && matches!(self.route, Route::Sessions) {
                     let q = self.filter.input.value.trim().to_string();
                     // Only re-trigger if the query string actually changed
-                    let current_query = self.sessions.deep_search_pending.as_ref().map(|(q, _)| q.as_str())
+                    let current_query = self
+                        .sessions
+                        .deep_search_pending
+                        .as_ref()
+                        .map(|(q, _)| q.as_str())
                         .or(self.sessions.deep_search_query.as_deref());
                     if q == current_query.unwrap_or("") {
                         // Query didn't change (just cursor moved), don't reset pending

--- a/src-tauri/src/cli/tui/app/menu.rs
+++ b/src-tauri/src/cli/tui/app/menu.rs
@@ -739,6 +739,21 @@ impl App {
                     Action::None
                 }
             }
+            // Allow session list navigation (Up/Down/PageUp/PageDown/Home/End)
+            // while the filter is active, so users can browse search results
+            // without pressing Enter to exit filter mode first.
+            KeyCode::Up
+            | KeyCode::Down
+            | KeyCode::PageUp
+            | KeyCode::PageDown
+            | KeyCode::Home
+            | KeyCode::End
+                if matches!(self.route, Route::Sessions) && !is_daily_memory =>
+            {
+                let action = self.on_sessions_key(key, data);
+                self.clamp_selections(data);
+                action
+            }
             _ => {
                 let Some(edit) = self.active_filter_input_mut().apply_key(key) else {
                     return Action::None;

--- a/src-tauri/src/cli/tui/app/menu.rs
+++ b/src-tauri/src/cli/tui/app/menu.rs
@@ -724,7 +724,6 @@ impl App {
                         query: self.filter.input.value.clone(),
                     }
                 } else if matches!(self.route, Route::Sessions) {
-                    // Enter immediately fires the deep search (no debounce wait)
                     let q = self.filter.input.value.trim().to_string();
                     if q.is_empty() {
                         self.sessions.deep_search_query = None;
@@ -732,6 +731,19 @@ impl App {
                         self.sessions.deep_search_pending = None;
                         Action::None
                     } else {
+                        // If deep search has already completed for this query,
+                        // open the selected session's detail directly instead
+                        // of re-triggering the search — saving the user an extra
+                        // Enter press.
+                        let search_completed = self.sessions.deep_search_active.is_none()
+                            && self.sessions.deep_search_query.as_deref() == Some(q.as_str());
+                        if search_completed {
+                            // Return early to skip sync_after_filter_key —
+                            // move_sessions_focus_right calls clamp_selections
+                            // and sets pane to Detail internally.
+                            return self.move_sessions_focus_right(data);
+                        }
+                        // Search not yet done — fire it now.
                         self.sessions.deep_search_pending = None;
                         Action::SessionsDeepSearch { query: q }
                     }

--- a/src-tauri/src/cli/tui/app/menu.rs
+++ b/src-tauri/src/cli/tui/app/menu.rs
@@ -702,10 +702,15 @@ impl App {
                 filter_changed = !self.active_filter_input_mut().value.is_empty();
                 self.filter.active = false;
                 self.active_filter_input_mut().set("");
-                // Clear deep search when filter is cleared
-                if matches!(self.route, Route::Sessions) {
+                // Clear deep search when the session list filter is cleared.
+                // Scope to the Global (list) filter so clearing an in-detail
+                // message filter does not wipe list-level search state, and
+                // also drop any queued (debounced) search so it doesn't revive
+                // after Esc.
+                if matches!(self.route, Route::Sessions) && matches!(scope, FilterScope::Global) {
                     self.sessions.deep_search_query = None;
                     self.sessions.deep_search_results.clear();
+                    self.sessions.deep_search_pending = None;
                 }
                 if is_daily_memory {
                     self.openclaw_daily_memory_search_results.clear();

--- a/src-tauri/src/cli/tui/app/menu.rs
+++ b/src-tauri/src/cli/tui/app/menu.rs
@@ -59,6 +59,7 @@ impl App {
             overlay: Overlay::None,
             toast: None,
             should_quit: false,
+            pending_deep_search: None,
             last_size: Size::new(0, 0),
             tick: 0,
             proxy_input_activity_samples: Vec::new(),
@@ -258,6 +259,18 @@ impl App {
     pub fn on_tick(&mut self) {
         self.tick = self.tick.wrapping_add(1);
         self.expire_managed_auth_login_if_needed();
+
+        // Deep search debounce: count ticks since last input, fire after threshold
+        const DEEP_SEARCH_DEBOUNCE_TICKS: u64 = 2; // ~2 ticks ≈ 400ms at 200ms/tick
+        if let Some((query, ticks)) = &mut self.sessions.deep_search_pending {
+            *ticks += 1;
+            if *ticks >= DEEP_SEARCH_DEBOUNCE_TICKS {
+                let q = std::mem::take(query);
+                self.sessions.deep_search_pending = None;
+                self.pending_deep_search = Some(q);
+            }
+        }
+
         if let Some(toast) = &mut self.toast {
             if !toast.persistent && toast.remaining_ticks > 0 {
                 toast.remaining_ticks -= 1;
@@ -638,6 +651,15 @@ impl App {
                 return self.on_usage_key(key, data);
             }
             KeyCode::Char('q') | KeyCode::Esc => {
+                // If in sessions "show all providers" mode, Esc exits that mode
+                // instead of navigating back.
+                if matches!(self.route, Route::Sessions) && self.sessions.show_all_providers {
+                    self.sessions.show_all_providers = false;
+                    self.sessions.loaded_once = false;
+                    self.sessions.selected_idx = 0;
+                    self.sessions.clear_detail();
+                    return Action::None;
+                }
                 return self.on_back_key();
             }
             _ => {}
@@ -680,6 +702,11 @@ impl App {
                 filter_changed = !self.active_filter_input_mut().value.is_empty();
                 self.filter.active = false;
                 self.active_filter_input_mut().set("");
+                // Clear deep search when filter is cleared
+                if matches!(self.route, Route::Sessions) {
+                    self.sessions.deep_search_query = None;
+                    self.sessions.deep_search_results.clear();
+                }
                 if is_daily_memory {
                     self.openclaw_daily_memory_search_results.clear();
                     self.daily_memory_idx = 0;
@@ -696,6 +723,18 @@ impl App {
                     Action::OpenClawDailyMemorySearch {
                         query: self.filter.input.value.clone(),
                     }
+                } else if matches!(self.route, Route::Sessions) {
+                    // Enter immediately fires the deep search (no debounce wait)
+                    let q = self.filter.input.value.trim().to_string();
+                    if q.is_empty() {
+                        self.sessions.deep_search_query = None;
+                        self.sessions.deep_search_results.clear();
+                        self.sessions.deep_search_pending = None;
+                        Action::None
+                    } else {
+                        self.sessions.deep_search_pending = None;
+                        Action::SessionsDeepSearch { query: q }
+                    }
                 } else {
                     Action::None
                 }
@@ -705,6 +744,23 @@ impl App {
                     return Action::None;
                 };
                 filter_changed = edit.changed;
+                // In sessions page, set pending deep search only when text content changes
+                // (not on cursor movement via Left/Right keys)
+                if edit.changed && matches!(self.route, Route::Sessions) {
+                    let q = self.filter.input.value.trim().to_string();
+                    // Only re-trigger if the query string actually changed
+                    let current_query = self.sessions.deep_search_pending.as_ref().map(|(q, _)| q.as_str())
+                        .or(self.sessions.deep_search_query.as_deref());
+                    if q == current_query.unwrap_or("") {
+                        // Query didn't change (just cursor moved), don't reset pending
+                    } else if q.is_empty() {
+                        self.sessions.deep_search_pending = None;
+                        self.sessions.deep_search_query = None;
+                        self.sessions.deep_search_results.clear();
+                    } else {
+                        self.sessions.deep_search_pending = Some((q, 0));
+                    }
+                }
                 if is_daily_memory && edit.changed && self.filter.input.value.is_empty() {
                     Action::OpenClawDailyMemorySearch {
                         query: String::new(),
@@ -833,10 +889,13 @@ impl App {
         let visible_session_rows = visible_sessions_for_state(
             &self.filter,
             &self.app_type,
+            self.sessions.show_all_providers,
             &self.sessions.rows,
             self.sessions.detail_key.as_deref(),
             self.sessions.messages_loaded,
             &self.sessions.messages,
+            self.sessions.deep_search_query.as_deref(),
+            &self.sessions.deep_search_results,
         );
         let sessions_len = visible_session_rows.len();
         if sessions_len == 0 {

--- a/src-tauri/src/cli/tui/app/types.rs
+++ b/src-tauri/src/cli/tui/app/types.rs
@@ -428,10 +428,14 @@ impl SessionsState {
             return false;
         }
         self.selected_idx = self.selected_idx.min(self.rows.len().saturating_sub(1));
-        if let Some(provider_id) = self.provider_id.clone() {
-            if let Some(cached) = self.scan_cache.get_mut(&provider_id) {
-                cached.rows = self.rows.clone();
-            }
+        // Drop the deleted session from every cached bucket (current provider,
+        // the virtual "all" bucket, and any other provider bucket) so it cannot
+        // resurrect as a phantom row when the list is restored from cache after
+        // switching provider/all views.
+        for cached in self.scan_cache.values_mut() {
+            cached
+                .rows
+                .retain(|session| crate::cli::tui::app::session_key(session) != key);
         }
         if self.detail_key.as_deref() == Some(key) {
             self.clear_detail();

--- a/src-tauri/src/cli/tui/app/types.rs
+++ b/src-tauri/src/cli/tui/app/types.rs
@@ -191,6 +191,16 @@ pub struct SessionsState {
     pub delete_seq: u64,
     pub delete_active: HashSet<u64>,
     pub scan_cache: std::collections::HashMap<String, CachedScan>,
+    /// When true, the session list shows all providers (the "全部" tab).
+    /// When false (default), only the currently selected provider is shown.
+    pub show_all_providers: bool,
+    /// Deep search state: query string and results from backend full-content search.
+    pub deep_search_query: Option<String>,
+    pub deep_search_seq: u64,
+    pub deep_search_active: Option<u64>,
+    pub deep_search_results: Vec<crate::session_manager::SessionSearchHit>,
+    /// Pending deep search: (query, ticks since last input). When ticks >= threshold, fire search.
+    pub deep_search_pending: Option<(String, u64)>,
 }
 
 impl Default for SessionsState {
@@ -219,6 +229,12 @@ impl Default for SessionsState {
             delete_seq: 0,
             delete_active: HashSet::new(),
             scan_cache: std::collections::HashMap::new(),
+            show_all_providers: false,
+            deep_search_query: None,
+            deep_search_seq: 0,
+            deep_search_active: None,
+            deep_search_results: Vec::new(),
+            deep_search_pending: None,
         }
     }
 }

--- a/src-tauri/src/cli/tui/mod.rs
+++ b/src-tauri/src/cli/tui/mod.rs
@@ -1186,6 +1186,7 @@ fn cache_invalidation_for_action(action: &Action) -> CacheInvalidation {
         | Action::SetAppType(_)
         | Action::LocalEnvRefresh
         | Action::SessionsRefresh
+        | Action::SessionsDeepSearch { .. }
         | Action::SessionMessagesLoad { .. }
         | Action::SessionResume { .. }
         | Action::SessionDelete { .. }
@@ -1564,7 +1565,13 @@ fn queue_sessions_refresh_if_needed(
     if !matches!(app.route, route::Route::Sessions) {
         return;
     }
-    let provider_id = app.app_type.as_str().to_string();
+    // When "show all providers" is on, use "all" as the virtual provider id
+    // so the worker scans every provider and the cache is keyed separately.
+    let provider_id = if app.sessions.show_all_providers {
+        "all".to_string()
+    } else {
+        app.app_type.as_str().to_string()
+    };
     if app.sessions.loaded_for_provider(&provider_id) || app.sessions.loading {
         return;
     }
@@ -2022,6 +2029,26 @@ pub fn run(app_override: Option<AppType>) -> Result<(), AppError> {
                 last_tick = Instant::now();
             }
 
+            // Fire pending deep search from debounce timer
+            if let Some(query) = app.pending_deep_search.take() {
+                // Directly send search request without full handle_tui_action
+                if let Some(sessions_sys) = sessions.as_ref() {
+                    let request_id = {
+                        app.sessions.deep_search_query = Some(query.clone());
+                        app.sessions.deep_search_results.clear();
+                        app.sessions.deep_search_seq = app.sessions.deep_search_seq.wrapping_add(1);
+                        app.sessions.deep_search_active = Some(app.sessions.deep_search_seq);
+                        app.sessions.deep_search_seq
+                    };
+                    let sessions_snapshot = app.sessions.rows.clone();
+                    let _ = sessions_sys.req_tx.send(runtime_systems::SessionReq::Search {
+                        request_id,
+                        query,
+                        sessions: sessions_snapshot,
+                    });
+                }
+            }
+
             if app.should_quit {
                 break;
             }
@@ -2333,6 +2360,23 @@ pub fn run(app_override: Option<AppType>) -> Result<(), AppError> {
                 quota.as_ref().map(|s| &s.req_tx),
             );
             last_tick = Instant::now();
+        }
+
+        // Fire pending deep search from debounce timer
+        if let Some(query) = app.pending_deep_search.take() {
+            if let Some(sessions_sys) = sessions.as_ref() {
+                app.sessions.deep_search_query = Some(query.clone());
+                app.sessions.deep_search_results.clear();
+                app.sessions.deep_search_seq = app.sessions.deep_search_seq.wrapping_add(1);
+                app.sessions.deep_search_active = Some(app.sessions.deep_search_seq);
+                let request_id = app.sessions.deep_search_seq;
+                let sessions_snapshot = app.sessions.rows.clone();
+                let _ = sessions_sys.req_tx.send(runtime_systems::SessionReq::Search {
+                    request_id,
+                    query,
+                    sessions: sessions_snapshot,
+                });
+            }
         }
 
         if app.should_quit {

--- a/src-tauri/src/cli/tui/mod.rs
+++ b/src-tauri/src/cli/tui/mod.rs
@@ -2041,11 +2041,13 @@ pub fn run(app_override: Option<AppType>) -> Result<(), AppError> {
                         app.sessions.deep_search_seq
                     };
                     let sessions_snapshot = app.sessions.rows.clone();
-                    let _ = sessions_sys.req_tx.send(runtime_systems::SessionReq::Search {
-                        request_id,
-                        query,
-                        sessions: sessions_snapshot,
-                    });
+                    let _ = sessions_sys
+                        .req_tx
+                        .send(runtime_systems::SessionReq::Search {
+                            request_id,
+                            query,
+                            sessions: sessions_snapshot,
+                        });
                 }
             }
 
@@ -2371,11 +2373,13 @@ pub fn run(app_override: Option<AppType>) -> Result<(), AppError> {
                 app.sessions.deep_search_active = Some(app.sessions.deep_search_seq);
                 let request_id = app.sessions.deep_search_seq;
                 let sessions_snapshot = app.sessions.rows.clone();
-                let _ = sessions_sys.req_tx.send(runtime_systems::SessionReq::Search {
-                    request_id,
-                    query,
-                    sessions: sessions_snapshot,
-                });
+                let _ = sessions_sys
+                    .req_tx
+                    .send(runtime_systems::SessionReq::Search {
+                        request_id,
+                        query,
+                        sessions: sessions_snapshot,
+                    });
             }
         }
 

--- a/src-tauri/src/cli/tui/runtime_actions/mod.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/mod.rs
@@ -237,6 +237,25 @@ pub(crate) fn handle_action(
             }
             Ok(())
         }
+        Action::SessionsDeepSearch { query } => {
+            let Some(tx) = ctx.session_req_tx else {
+                return Ok(());
+            };
+            // Set the query immediately so the UI shows "searching" state
+            ctx.app.sessions.deep_search_query = Some(query.clone());
+            ctx.app.sessions.deep_search_results.clear();
+            ctx.app.sessions.deep_search_seq = ctx.app.sessions.deep_search_seq.wrapping_add(1);
+            let request_id = ctx.app.sessions.deep_search_seq;
+            ctx.app.sessions.deep_search_active = Some(request_id);
+            // Snapshot the sessions to search (respecting show_all / provider filter)
+            let sessions = ctx.app.sessions.rows.clone();
+            let _ = tx.send(SessionReq::Search {
+                request_id,
+                query,
+                sessions,
+            });
+            Ok(())
+        }
         Action::SessionResume { command, cwd } => {
             let preferred_terminal = crate::settings::get_preferred_terminal();
             let target = session_terminal_target(preferred_terminal.as_deref());

--- a/src-tauri/src/cli/tui/runtime_actions/mod.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/mod.rs
@@ -223,7 +223,14 @@ pub(crate) fn handle_action(
                 );
                 return Ok(());
             };
-            let provider_id = ctx.app.app_type.as_str().to_string();
+            // In "show all providers" mode, refresh must rescan every provider
+            // (the virtual "all" id), otherwise `r` would only refresh the
+            // current app and the stale "all" cache would be restored afterward.
+            let provider_id = if ctx.app.sessions.show_all_providers {
+                "all".to_string()
+            } else {
+                ctx.app.app_type.as_str().to_string()
+            };
             let request_id = ctx.app.sessions.start_scan(provider_id.clone());
             if let Err(err) = tx.send(SessionReq::Refresh {
                 request_id,

--- a/src-tauri/src/cli/tui/runtime_systems/handlers.rs
+++ b/src-tauri/src/cli/tui/runtime_systems/handlers.rs
@@ -128,6 +128,14 @@ pub(crate) fn handle_session_msg(app: &mut App, msg: SessionMsg) {
                     } else {
                         app.sessions.selected_idx = app.sessions.selected_idx.min(visible_len - 1);
                     }
+                    // If a deep search is active, the freshly-scanned rows may
+                    // contain sessions the previous search snapshot missed (e.g.
+                    // the scan was still in flight when the search fired, or the
+                    // user entered "all providers" mode). Re-run the search over
+                    // the new rows via the debounce/firing path.
+                    if app.sessions.deep_search_query.is_some() {
+                        app.pending_deep_search = app.sessions.deep_search_query.clone();
+                    }
                 }
             }
             Err(error) => {

--- a/src-tauri/src/cli/tui/runtime_systems/handlers.rs
+++ b/src-tauri/src/cli/tui/runtime_systems/handlers.rs
@@ -114,10 +114,13 @@ pub(crate) fn handle_session_msg(app: &mut App, msg: SessionMsg) {
                     let visible_len = crate::cli::tui::app::visible_sessions_for_state(
                         &app.filter,
                         &app.app_type,
+                        app.sessions.show_all_providers,
                         &app.sessions.rows,
                         app.sessions.detail_key.as_deref(),
                         app.sessions.messages_loaded,
                         &app.sessions.messages,
+                        app.sessions.deep_search_query.as_deref(),
+                        &app.sessions.deep_search_results,
                     )
                     .len();
                     if visible_len == 0 {
@@ -164,10 +167,13 @@ pub(crate) fn handle_session_msg(app: &mut App, msg: SessionMsg) {
                     let visible_len = crate::cli::tui::app::visible_sessions_for_state(
                         &app.filter,
                         &app.app_type,
+                        app.sessions.show_all_providers,
                         &app.sessions.rows,
                         app.sessions.detail_key.as_deref(),
                         app.sessions.messages_loaded,
                         &app.sessions.messages,
+                        app.sessions.deep_search_query.as_deref(),
+                        &app.sessions.deep_search_results,
                     )
                     .len();
                     if visible_len == 0 {
@@ -189,6 +195,22 @@ pub(crate) fn handle_session_msg(app: &mut App, msg: SessionMsg) {
                 );
             }
         },
+        SessionMsg::SearchFinished { request_id, result } => {
+            // Only apply if this is the latest search request
+            if app.sessions.deep_search_active != Some(request_id) {
+                return;
+            }
+            app.sessions.deep_search_active = None;
+            match result {
+                Ok(hits) => {
+                    app.sessions.deep_search_results = hits;
+                    app.sessions.selected_idx = 0;
+                }
+                Err(_) => {
+                    app.sessions.deep_search_results.clear();
+                }
+            }
+        }
     }
 }
 

--- a/src-tauri/src/cli/tui/runtime_systems/types.rs
+++ b/src-tauri/src/cli/tui/runtime_systems/types.rs
@@ -82,6 +82,11 @@ pub(crate) enum SessionReq {
         session_id: String,
         source_path: String,
     },
+    Search {
+        request_id: u64,
+        query: String,
+        sessions: Vec<crate::session_manager::SessionMeta>,
+    },
 }
 
 pub(crate) enum SessionMsg {
@@ -98,6 +103,10 @@ pub(crate) enum SessionMsg {
         request_id: u64,
         key: String,
         result: Result<(), String>,
+    },
+    SearchFinished {
+        request_id: u64,
+        result: Result<Vec<crate::session_manager::SessionSearchHit>, String>,
     },
 }
 

--- a/src-tauri/src/cli/tui/runtime_systems/workers.rs
+++ b/src-tauri/src/cli/tui/runtime_systems/workers.rs
@@ -686,7 +686,11 @@ fn handle_session_req(req: SessionReq, tx: &mpsc::Sender<SessionMsg>) -> Result<
             provider_id,
         } => {
             let result = std::panic::catch_unwind(|| {
-                crate::session_manager::scan_sessions_for_provider(&provider_id)
+                if provider_id == "all" {
+                    crate::session_manager::scan_sessions()
+                } else {
+                    crate::session_manager::scan_sessions_for_provider(&provider_id)
+                }
             })
             .map_err(|_| "session scan panicked".to_string());
             tx.send(SessionMsg::ScanFinished { request_id, result })
@@ -728,6 +732,18 @@ fn handle_session_req(req: SessionReq, tx: &mpsc::Sender<SessionMsg>) -> Result<
                 result,
             })
             .map_err(|_| ())
+        }
+        SessionReq::Search {
+            request_id,
+            query,
+            sessions,
+        } => {
+            let result = std::panic::catch_unwind(|| {
+                crate::session_manager::search_sessions_in(&sessions, &query)
+            })
+            .map_err(|_| "session search panicked".to_string());
+            tx.send(SessionMsg::SearchFinished { request_id, result })
+                .map_err(|_| ())
         }
     }
 }

--- a/src-tauri/src/cli/tui/runtime_systems/workers.rs
+++ b/src-tauri/src/cli/tui/runtime_systems/workers.rs
@@ -668,6 +668,10 @@ fn session_worker_loop(rx: mpsc::Receiver<SessionReq>, tx: mpsc::Sender<SessionM
             match (&req, &next) {
                 (SessionReq::Refresh { .. }, SessionReq::Refresh { .. }) => req = next,
                 (SessionReq::LoadMessages { .. }, SessionReq::LoadMessages { .. }) => req = next,
+                // Drop a superseded search: only the latest query matters, and
+                // stale results are ignored by request id anyway, so skip the
+                // wasted full scan.
+                (SessionReq::Search { .. }, SessionReq::Search { .. }) => req = next,
                 _ => {
                     let _ = handle_session_req(req, &tx);
                     req = next;

--- a/src-tauri/src/cli/tui/ui/sessions.rs
+++ b/src-tauri/src/cli/tui/ui/sessions.rs
@@ -12,10 +12,13 @@ pub(super) fn render_sessions(
     let visible = app::visible_sessions_for_state(
         &app.filter,
         &app.app_type,
+        app.sessions.show_all_providers,
         &app.sessions.rows,
         app.sessions.detail_key.as_deref(),
         app.sessions.messages_loaded,
         &app.sessions.messages,
+        app.sessions.deep_search_query.as_deref(),
+        &app.sessions.deep_search_results,
     );
 
     let outer = Block::default()
@@ -47,12 +50,23 @@ pub(super) fn render_sessions(
                 ("R", texts::tui_key_restore()),
                 ("d", texts::tui_key_delete()),
                 ("r", texts::tui_key_refresh()),
+                ("a", if app.sessions.show_all_providers { "全部 (Esc返回)" } else { "全部" }),
             ],
         );
     }
 
     let summary = if app.sessions.loading && !app.sessions.loaded_once {
         texts::tui_sessions_loading_summary().to_string()
+    } else if app.sessions.deep_search_active.is_some() {
+        // Show spinner animation while deep search is running
+        let spinner = match app.tick % 4 {
+            0 => "⠋",
+            1 => "⠙",
+            2 => "⠹",
+            _ => "⠸",
+        };
+        let query = app.sessions.deep_search_query.as_deref().unwrap_or("");
+        format!("{spinner} 搜索中: \"{query}\"...")
     } else {
         texts::tui_sessions_summary(app.sessions.rows.len(), visible.len())
     };
@@ -129,10 +143,20 @@ fn render_session_list(
         return;
     }
 
-    let header = Row::new(vec![
-        Cell::from(texts::tui_sessions_header_title()),
-        Cell::from(texts::tui_sessions_header_time()),
-    ])
+    let show_all = app.sessions.show_all_providers;
+
+    let header = if show_all {
+        Row::new(vec![
+            Cell::from("Provider"),
+            Cell::from(texts::tui_sessions_header_title()),
+            Cell::from(texts::tui_sessions_header_time()),
+        ])
+    } else {
+        Row::new(vec![
+            Cell::from(texts::tui_sessions_header_title()),
+            Cell::from(texts::tui_sessions_header_time()),
+        ])
+    }
     .style(Style::default().fg(theme.dim).add_modifier(Modifier::BOLD));
 
     // Only build Row objects for the rows actually on screen. Without this the
@@ -163,14 +187,33 @@ fn render_session_list(
             ]),
             None => Line::raw(title),
         };
-        Row::new(vec![Cell::from(title_line), Cell::from(time)])
+        if show_all {
+            Row::new(vec![
+                Cell::from(session.provider_id.clone()),
+                Cell::from(title_line),
+                Cell::from(time),
+            ])
+        } else {
+            Row::new(vec![Cell::from(title_line), Cell::from(time)])
+        }
     });
 
-    let table = Table::new(rows, [Constraint::Percentage(72), Constraint::Length(12)])
-        .header(header)
-        .block(Block::default().borders(Borders::NONE))
-        .row_highlight_style(selection_style(theme))
-        .highlight_symbol(highlight_symbol(theme));
+    let table = if show_all {
+        Table::new(
+            rows,
+            [
+                Constraint::Length(10),
+                Constraint::Percentage(62),
+                Constraint::Length(12),
+            ],
+        )
+    } else {
+        Table::new(rows, [Constraint::Percentage(72), Constraint::Length(12)])
+    }
+    .header(header)
+    .block(Block::default().borders(Borders::NONE))
+    .row_highlight_style(selection_style(theme))
+    .highlight_symbol(highlight_symbol(theme));
 
     // The rows are pre-sliced to the window, so the highlight index is relative
     // to `start`.

--- a/src-tauri/src/cli/tui/ui/sessions.rs
+++ b/src-tauri/src/cli/tui/ui/sessions.rs
@@ -50,7 +50,14 @@ pub(super) fn render_sessions(
                 ("R", texts::tui_key_restore()),
                 ("d", texts::tui_key_delete()),
                 ("r", texts::tui_key_refresh()),
-                ("a", if app.sessions.show_all_providers { "全部 (Esc返回)" } else { "全部" }),
+                (
+                    "a",
+                    if app.sessions.show_all_providers {
+                        "全部 (Esc返回)"
+                    } else {
+                        "全部"
+                    },
+                ),
             ],
         );
     }

--- a/src-tauri/src/session_manager/mod.rs
+++ b/src-tauri/src/session_manager/mod.rs
@@ -113,6 +113,95 @@ pub fn scan_sessions_for_provider(provider_id: &str) -> Vec<SessionMeta> {
     sessions
 }
 
+/// A single search hit (matched message snippet inside a session).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchSnippet {
+    pub role: String,
+    pub snippet: String,
+}
+
+/// Result of searching a session's full conversation content.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionSearchHit {
+    pub provider_id: String,
+    pub session_id: String,
+    pub source_path: String,
+    pub snippets: Vec<SearchSnippet>,
+}
+
+/// Search the full conversation content of every session (across all providers)
+/// for the given query. Returns one `SessionSearchHit` per session that contains
+/// at least one match. This is a live, full-scan search — no index, always fresh.
+pub fn search_sessions(query: &str) -> Vec<SessionSearchHit> {
+    let sessions = scan_sessions();
+    search_sessions_in(&sessions, query)
+}
+
+/// Same as `search_sessions`, but operates on an already-loaded session list.
+pub fn search_sessions_in(sessions: &[SessionMeta], query: &str) -> Vec<SessionSearchHit> {
+    let needle = query.trim();
+    if needle.is_empty() {
+        return Vec::new();
+    }
+
+    let mut buckets: std::collections::HashMap<&str, Vec<&SessionMeta>> =
+        std::collections::HashMap::new();
+    for s in sessions {
+        buckets.entry(&s.provider_id).or_default().push(s);
+    }
+
+    let results: Vec<Vec<SessionSearchHit>> = std::thread::scope(|s| {
+        let handles: Vec<_> = buckets
+            .iter()
+            .map(|(provider_id, metas)| {
+                s.spawn(move || search_provider(provider_id, metas, needle))
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| h.join().unwrap_or_default())
+            .collect()
+    });
+
+    let mut flat: Vec<SessionSearchHit> = results.into_iter().flatten().collect();
+    flat.sort_by(|a, b| {
+        a.provider_id
+            .cmp(&b.provider_id)
+            .then_with(|| a.session_id.cmp(&b.session_id))
+    });
+    flat
+}
+
+fn search_provider(
+    provider_id: &str,
+    metas: &[&SessionMeta],
+    needle: &str,
+) -> Vec<SessionSearchHit> {
+    match provider_id {
+        "codex" => metas
+            .iter()
+            .filter_map(|m| codex::search_session(m, needle))
+            .collect(),
+        "claude" => metas
+            .iter()
+            .filter_map(|m| claude::search_session(m, needle))
+            .collect(),
+        "opencode" => opencode::search_sessions(metas, needle),
+        "openclaw" => metas
+            .iter()
+            .filter_map(|m| openclaw::search_session(m, needle))
+            .collect(),
+        "gemini" => metas
+            .iter()
+            .filter_map(|m| gemini::search_session(m, needle))
+            .collect(),
+        "hermes" => hermes::search_sessions(metas, needle),
+        _ => Vec::new(),
+    }
+}
+
 pub fn load_messages(provider_id: &str, source_path: &str) -> Result<Vec<SessionMessage>, String> {
     // SQLite sessions use a "sqlite:" prefixed source_path
     if provider_id == "opencode" && source_path.starts_with("sqlite:") {

--- a/src-tauri/src/session_manager/mod.rs
+++ b/src-tauri/src/session_manager/mod.rs
@@ -134,6 +134,7 @@ pub struct SessionSearchHit {
 /// Search the full conversation content of every session (across all providers)
 /// for the given query. Returns one `SessionSearchHit` per session that contains
 /// at least one match. This is a live, full-scan search — no index, always fresh.
+#[allow(dead_code)]
 pub fn search_sessions(query: &str) -> Vec<SessionSearchHit> {
     let sessions = scan_sessions();
     search_sessions_in(&sessions, query)

--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -5,11 +5,11 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 use crate::config::get_claude_config_dir;
-use crate::session_manager::{SessionMessage, SessionMeta};
+use crate::session_manager::{SessionMessage, SessionMeta, SessionSearchHit, SearchSnippet};
 
 use super::utils::{
-    extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines, truncate_summary,
-    TITLE_MAX_CHARS,
+    build_snippet, extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines,
+    truncate_summary, TITLE_MAX_CHARS,
 };
 
 const PROVIDER_ID: &str = "claude";
@@ -76,6 +76,45 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
     }
 
     Ok(messages)
+}
+
+/// Search a single Claude session file for `needle` (case-insensitive).
+pub fn search_session(meta: &SessionMeta, needle: &str) -> Option<SessionSearchHit> {
+    let source_path = meta.source_path.as_deref()?;
+    let path = Path::new(source_path);
+    let file = File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    let lower_needle = needle.to_lowercase();
+    let mut snippets: Vec<SearchSnippet> = Vec::new();
+    const MAX_SNIPPETS: usize = 5;
+
+    for line in reader.lines() {
+        let line = match line { Ok(l) => l, Err(_) => continue };
+        let value: Value = match serde_json::from_str(&line) { Ok(v) => v, Err(_) => continue };
+        if value.get("isMeta").and_then(Value::as_bool) == Some(true) { continue; }
+        let message = match value.get("message") { Some(m) => m, None => continue };
+        let mut role = message.get("role").and_then(Value::as_str).unwrap_or("unknown").to_string();
+        if role == "user" {
+            if let Some(Value::Array(items)) = message.get("content") {
+                let all_tool_results = !items.is_empty()
+                    && items.iter().all(|item| item.get("type").and_then(Value::as_str) == Some("tool_result"));
+                if all_tool_results { role = "tool".to_string(); }
+            }
+        }
+        let content = message.get("content").map(extract_text).unwrap_or_default();
+        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) { continue; }
+        if let Some(snippet) = build_snippet(&content, needle) {
+            snippets.push(SearchSnippet { role, snippet });
+            if snippets.len() >= MAX_SNIPPETS { break; }
+        }
+    }
+    if snippets.is_empty() { return None; }
+    Some(SessionSearchHit {
+        provider_id: PROVIDER_ID.to_string(),
+        session_id: meta.session_id.clone(),
+        source_path: source_path.to_string(),
+        snippets,
+    })
 }
 
 pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<bool, String> {

--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 use crate::config::get_claude_config_dir;
-use crate::session_manager::{SessionMessage, SessionMeta, SessionSearchHit, SearchSnippet};
+use crate::session_manager::{SearchSnippet, SessionMessage, SessionMeta, SessionSearchHit};
 
 use super::utils::{
     build_snippet, extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines,
@@ -89,26 +89,51 @@ pub fn search_session(meta: &SessionMeta, needle: &str) -> Option<SessionSearchH
     const MAX_SNIPPETS: usize = 5;
 
     for line in reader.lines() {
-        let line = match line { Ok(l) => l, Err(_) => continue };
-        let value: Value = match serde_json::from_str(&line) { Ok(v) => v, Err(_) => continue };
-        if value.get("isMeta").and_then(Value::as_bool) == Some(true) { continue; }
-        let message = match value.get("message") { Some(m) => m, None => continue };
-        let mut role = message.get("role").and_then(Value::as_str).unwrap_or("unknown").to_string();
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if value.get("isMeta").and_then(Value::as_bool) == Some(true) {
+            continue;
+        }
+        let message = match value.get("message") {
+            Some(m) => m,
+            None => continue,
+        };
+        let mut role = message
+            .get("role")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
         if role == "user" {
             if let Some(Value::Array(items)) = message.get("content") {
                 let all_tool_results = !items.is_empty()
-                    && items.iter().all(|item| item.get("type").and_then(Value::as_str) == Some("tool_result"));
-                if all_tool_results { role = "tool".to_string(); }
+                    && items.iter().all(|item| {
+                        item.get("type").and_then(Value::as_str) == Some("tool_result")
+                    });
+                if all_tool_results {
+                    role = "tool".to_string();
+                }
             }
         }
         let content = message.get("content").map(extract_text).unwrap_or_default();
-        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) { continue; }
+        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) {
+            continue;
+        }
         if let Some(snippet) = build_snippet(&content, needle) {
             snippets.push(SearchSnippet { role, snippet });
-            if snippets.len() >= MAX_SNIPPETS { break; }
+            if snippets.len() >= MAX_SNIPPETS {
+                break;
+            }
         }
     }
-    if snippets.is_empty() { return None; }
+    if snippets.is_empty() {
+        return None;
+    }
     Some(SessionSearchHit {
         provider_id: PROVIDER_ID.to_string(),
         session_id: meta.session_id.clone(),

--- a/src-tauri/src/session_manager/providers/codex.rs
+++ b/src-tauri/src/session_manager/providers/codex.rs
@@ -7,11 +7,11 @@ use regex::Regex;
 use serde_json::Value;
 
 use crate::codex_config::get_codex_config_dir;
-use crate::session_manager::{SessionMessage, SessionMeta};
+use crate::session_manager::{SessionMessage, SessionMeta, SessionSearchHit, SearchSnippet};
 
 use super::utils::{
-    extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines, truncate_summary,
-    TITLE_MAX_CHARS,
+    build_snippet, extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines,
+    truncate_summary, TITLE_MAX_CHARS,
 };
 
 const PROVIDER_ID: &str = "codex";
@@ -101,6 +101,53 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
     }
 
     Ok(messages)
+}
+
+/// Search a single Codex session file for `needle` (case-insensitive).
+pub fn search_session(meta: &SessionMeta, needle: &str) -> Option<SessionSearchHit> {
+    let source_path = meta.source_path.as_deref()?;
+    let path = Path::new(source_path);
+    let file = File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    let lower_needle = needle.to_lowercase();
+    let mut snippets: Vec<SearchSnippet> = Vec::new();
+    const MAX_SNIPPETS: usize = 5;
+
+    for line in reader.lines() {
+        let line = match line { Ok(l) => l, Err(_) => continue };
+        let value: Value = match serde_json::from_str(&line) { Ok(v) => v, Err(_) => continue };
+        if value.get("type").and_then(Value::as_str) != Some("response_item") { continue; }
+        let payload = match value.get("payload") { Some(p) => p, None => continue };
+        let payload_type = payload.get("type").and_then(Value::as_str).unwrap_or("");
+        let (role, content) = match payload_type {
+            "message" => {
+                let role = payload.get("role").and_then(Value::as_str).unwrap_or("unknown").to_string();
+                let content = payload.get("content").map(extract_text).unwrap_or_default();
+                (role, content)
+            }
+            "function_call" => {
+                let name = payload.get("name").and_then(Value::as_str).unwrap_or("unknown");
+                ("assistant".to_string(), format!("[Tool: {name}]"))
+            }
+            "function_call_output" => {
+                let output = payload.get("output").and_then(Value::as_str).unwrap_or("").to_string();
+                ("tool".to_string(), output)
+            }
+            _ => continue,
+        };
+        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) { continue; }
+        if let Some(snippet) = build_snippet(&content, needle) {
+            snippets.push(SearchSnippet { role, snippet });
+            if snippets.len() >= MAX_SNIPPETS { break; }
+        }
+    }
+    if snippets.is_empty() { return None; }
+    Some(SessionSearchHit {
+        provider_id: PROVIDER_ID.to_string(),
+        session_id: meta.session_id.clone(),
+        source_path: source_path.to_string(),
+        snippets,
+    })
 }
 
 pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<bool, String> {

--- a/src-tauri/src/session_manager/providers/codex.rs
+++ b/src-tauri/src/session_manager/providers/codex.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 use serde_json::Value;
 
 use crate::codex_config::get_codex_config_dir;
-use crate::session_manager::{SessionMessage, SessionMeta, SessionSearchHit, SearchSnippet};
+use crate::session_manager::{SearchSnippet, SessionMessage, SessionMeta, SessionSearchHit};
 
 use super::utils::{
     build_snippet, extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines,
@@ -114,34 +114,62 @@ pub fn search_session(meta: &SessionMeta, needle: &str) -> Option<SessionSearchH
     const MAX_SNIPPETS: usize = 5;
 
     for line in reader.lines() {
-        let line = match line { Ok(l) => l, Err(_) => continue };
-        let value: Value = match serde_json::from_str(&line) { Ok(v) => v, Err(_) => continue };
-        if value.get("type").and_then(Value::as_str) != Some("response_item") { continue; }
-        let payload = match value.get("payload") { Some(p) => p, None => continue };
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if value.get("type").and_then(Value::as_str) != Some("response_item") {
+            continue;
+        }
+        let payload = match value.get("payload") {
+            Some(p) => p,
+            None => continue,
+        };
         let payload_type = payload.get("type").and_then(Value::as_str).unwrap_or("");
         let (role, content) = match payload_type {
             "message" => {
-                let role = payload.get("role").and_then(Value::as_str).unwrap_or("unknown").to_string();
+                let role = payload
+                    .get("role")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown")
+                    .to_string();
                 let content = payload.get("content").map(extract_text).unwrap_or_default();
                 (role, content)
             }
             "function_call" => {
-                let name = payload.get("name").and_then(Value::as_str).unwrap_or("unknown");
+                let name = payload
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown");
                 ("assistant".to_string(), format!("[Tool: {name}]"))
             }
             "function_call_output" => {
-                let output = payload.get("output").and_then(Value::as_str).unwrap_or("").to_string();
+                let output = payload
+                    .get("output")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
                 ("tool".to_string(), output)
             }
             _ => continue,
         };
-        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) { continue; }
+        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) {
+            continue;
+        }
         if let Some(snippet) = build_snippet(&content, needle) {
             snippets.push(SearchSnippet { role, snippet });
-            if snippets.len() >= MAX_SNIPPETS { break; }
+            if snippets.len() >= MAX_SNIPPETS {
+                break;
+            }
         }
     }
-    if snippets.is_empty() { return None; }
+    if snippets.is_empty() {
+        return None;
+    }
     Some(SessionSearchHit {
         provider_id: PROVIDER_ID.to_string(),
         session_id: meta.session_id.clone(),

--- a/src-tauri/src/session_manager/providers/gemini.rs
+++ b/src-tauri/src/session_manager/providers/gemini.rs
@@ -2,9 +2,9 @@ use std::path::Path;
 
 use serde_json::Value;
 
-use crate::session_manager::{SessionMessage, SessionMeta};
+use crate::session_manager::{SessionMessage, SessionMeta, SessionSearchHit, SearchSnippet};
 
-use super::utils::{parse_timestamp_to_ms, truncate_summary};
+use super::utils::{build_snippet, parse_timestamp_to_ms, truncate_summary};
 
 const PROVIDER_ID: &str = "gemini";
 
@@ -110,6 +110,53 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
     }
 
     Ok(result)
+}
+
+/// Search a single Gemini session JSON file for `needle` (case-insensitive).
+pub fn search_session(meta: &SessionMeta, needle: &str) -> Option<SessionSearchHit> {
+    let source_path = meta.source_path.as_deref()?;
+    let path = Path::new(source_path);
+    let data = std::fs::read_to_string(path).ok()?;
+    let value: Value = serde_json::from_str(&data).ok()?;
+    let messages = value.get("messages").and_then(Value::as_array)?;
+    let lower_needle = needle.to_lowercase();
+    let mut snippets: Vec<SearchSnippet> = Vec::new();
+    const MAX_SNIPPETS: usize = 5;
+
+    for msg in messages {
+        let role = match msg.get("type").and_then(Value::as_str) {
+            Some("gemini") => "assistant",
+            Some("user") => "user",
+            _ => continue,
+        };
+        let mut content = match msg.get("content") {
+            Some(Value::String(s)) => s.to_string(),
+            Some(Value::Array(items)) => items.iter()
+                .filter_map(|item| item.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>().join("\n"),
+            _ => String::new(),
+        };
+        if let Some(Value::Array(calls)) = msg.get("toolCalls") {
+            for call in calls {
+                if let Some(name) = call.get("name").and_then(Value::as_str) {
+                    if !content.is_empty() { content.push('\n'); }
+                    content.push_str(&format!("[Tool: {name}]"));
+                }
+            }
+        }
+        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) { continue; }
+        if let Some(snippet) = build_snippet(&content, needle) {
+            snippets.push(SearchSnippet { role: role.to_string(), snippet });
+            if snippets.len() >= MAX_SNIPPETS { break; }
+        }
+    }
+    if snippets.is_empty() { return None; }
+    Some(SessionSearchHit {
+        provider_id: PROVIDER_ID.to_string(),
+        session_id: meta.session_id.clone(),
+        source_path: source_path.to_string(),
+        snippets,
+    })
 }
 
 pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<bool, String> {

--- a/src-tauri/src/session_manager/providers/gemini.rs
+++ b/src-tauri/src/session_manager/providers/gemini.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use serde_json::Value;
 
-use crate::session_manager::{SessionMessage, SessionMeta, SessionSearchHit, SearchSnippet};
+use crate::session_manager::{SearchSnippet, SessionMessage, SessionMeta, SessionSearchHit};
 
 use super::utils::{build_snippet, parse_timestamp_to_ms, truncate_summary};
 
@@ -131,26 +131,39 @@ pub fn search_session(meta: &SessionMeta, needle: &str) -> Option<SessionSearchH
         };
         let mut content = match msg.get("content") {
             Some(Value::String(s)) => s.to_string(),
-            Some(Value::Array(items)) => items.iter()
+            Some(Value::Array(items)) => items
+                .iter()
                 .filter_map(|item| item.get("text").and_then(Value::as_str))
-                .collect::<Vec<_>>().join("\n"),
+                .collect::<Vec<_>>()
+                .join("\n"),
             _ => String::new(),
         };
         if let Some(Value::Array(calls)) = msg.get("toolCalls") {
             for call in calls {
                 if let Some(name) = call.get("name").and_then(Value::as_str) {
-                    if !content.is_empty() { content.push('\n'); }
+                    if !content.is_empty() {
+                        content.push('\n');
+                    }
                     content.push_str(&format!("[Tool: {name}]"));
                 }
             }
         }
-        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) { continue; }
+        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) {
+            continue;
+        }
         if let Some(snippet) = build_snippet(&content, needle) {
-            snippets.push(SearchSnippet { role: role.to_string(), snippet });
-            if snippets.len() >= MAX_SNIPPETS { break; }
+            snippets.push(SearchSnippet {
+                role: role.to_string(),
+                snippet,
+            });
+            if snippets.len() >= MAX_SNIPPETS {
+                break;
+            }
         }
     }
-    if snippets.is_empty() { return None; }
+    if snippets.is_empty() {
+        return None;
+    }
     Some(SessionSearchHit {
         provider_id: PROVIDER_ID.to_string(),
         session_id: meta.session_id.clone(),

--- a/src-tauri/src/session_manager/providers/hermes.rs
+++ b/src-tauri/src/session_manager/providers/hermes.rs
@@ -6,10 +6,11 @@ use rusqlite::Connection;
 use serde_json::Value;
 
 use crate::hermes_config::get_hermes_dir;
-use crate::session_manager::{SessionMessage, SessionMeta};
+use crate::session_manager::{SessionMessage, SessionMeta, SessionSearchHit, SearchSnippet};
 
 use super::utils::{
-    extract_text, parse_timestamp_to_ms, read_head_tail_lines, truncate_summary, TITLE_MAX_CHARS,
+    build_snippet, extract_text, parse_timestamp_to_ms, read_head_tail_lines, truncate_summary,
+    TITLE_MAX_CHARS,
 };
 
 const PROVIDER_ID: &str = "hermes";
@@ -482,6 +483,96 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
     }
 
     Ok(messages)
+}
+
+/// Search Hermes sessions (JSONL or SQLite) for `needle` (case-insensitive).
+pub fn search_sessions(metas: &[&SessionMeta], needle: &str) -> Vec<SessionSearchHit> {
+    metas
+        .iter()
+        .filter_map(|m| {
+            let source = m.source_path.as_deref()?;
+            if source.starts_with("sqlite:") {
+                search_session_sqlite(m, needle)
+            } else {
+                search_session_jsonl(m, needle)
+            }
+        })
+        .collect()
+}
+
+fn search_session_jsonl(meta: &SessionMeta, needle: &str) -> Option<SessionSearchHit> {
+    let source_path = meta.source_path.as_deref()?;
+    let path = Path::new(source_path);
+    let file = File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    let lower_needle = needle.to_lowercase();
+    let mut snippets: Vec<SearchSnippet> = Vec::new();
+    const MAX_SNIPPETS: usize = 5;
+
+    for line in reader.lines() {
+        let line = match line { Ok(l) => l, Err(_) => continue };
+        if line.trim().is_empty() { continue; }
+        let value: Value = match serde_json::from_str(&line) { Ok(v) => v, Err(_) => continue };
+        let (role_val, content_val) =
+            if value.get("type").and_then(Value::as_str) == Some("message") {
+                let msg = match value.get("message") { Some(m) => m, None => continue };
+                (msg.get("role"), msg.get("content"))
+            } else {
+                (value.get("role"), value.get("content"))
+            };
+        let role = match role_val.and_then(Value::as_str) { Some(r) => r.to_string(), None => continue };
+        let content = content_val.map(extract_text).unwrap_or_default();
+        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) { continue; }
+        if let Some(snippet) = build_snippet(&content, needle) {
+            snippets.push(SearchSnippet { role, snippet });
+            if snippets.len() >= MAX_SNIPPETS { break; }
+        }
+    }
+    if snippets.is_empty() { return None; }
+    Some(SessionSearchHit {
+        provider_id: PROVIDER_ID.to_string(),
+        session_id: meta.session_id.clone(),
+        source_path: source_path.to_string(),
+        snippets,
+    })
+}
+
+fn search_session_sqlite(meta: &SessionMeta, needle: &str) -> Option<SessionSearchHit> {
+    let source_path = meta.source_path.as_deref()?;
+    let (db_path, session_id) = parse_sqlite_source(source_path)?;
+    let conn = Connection::open_with_flags(
+        &db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ).ok()?;
+    let mut stmt = conn
+        .prepare("SELECT role, content FROM messages WHERE session_id = ?1 AND content LIKE ?2 ORDER BY created_at ASC")
+        .ok()?;
+    let like_pattern = format!("%{needle}%");
+    let rows = stmt
+        .query_map(rusqlite::params![session_id.as_str(), like_pattern.as_str()], |row| {
+            let role: String = row.get(0)?;
+            let content: String = row.get(1)?;
+            Ok((role, content))
+        })
+        .ok()?;
+    let lower_needle = needle.to_lowercase();
+    let mut snippets: Vec<SearchSnippet> = Vec::new();
+    const MAX_SNIPPETS: usize = 5;
+    for row in rows.flatten() {
+        let (role, content) = row;
+        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) { continue; }
+        if let Some(snippet) = build_snippet(&content, needle) {
+            snippets.push(SearchSnippet { role, snippet });
+            if snippets.len() >= MAX_SNIPPETS { break; }
+        }
+    }
+    if snippets.is_empty() { return None; }
+    Some(SessionSearchHit {
+        provider_id: PROVIDER_ID.to_string(),
+        session_id: meta.session_id.clone(),
+        source_path: source_path.to_string(),
+        snippets,
+    })
 }
 
 /// Delete a Hermes JSONL session file.

--- a/src-tauri/src/session_manager/providers/hermes.rs
+++ b/src-tauri/src/session_manager/providers/hermes.rs
@@ -6,7 +6,7 @@ use rusqlite::Connection;
 use serde_json::Value;
 
 use crate::hermes_config::get_hermes_dir;
-use crate::session_manager::{SessionMessage, SessionMeta, SessionSearchHit, SearchSnippet};
+use crate::session_manager::{SearchSnippet, SessionMessage, SessionMeta, SessionSearchHit};
 
 use super::utils::{
     build_snippet, extract_text, parse_timestamp_to_ms, read_head_tail_lines, truncate_summary,
@@ -510,25 +510,45 @@ fn search_session_jsonl(meta: &SessionMeta, needle: &str) -> Option<SessionSearc
     const MAX_SNIPPETS: usize = 5;
 
     for line in reader.lines() {
-        let line = match line { Ok(l) => l, Err(_) => continue };
-        if line.trim().is_empty() { continue; }
-        let value: Value = match serde_json::from_str(&line) { Ok(v) => v, Err(_) => continue };
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
         let (role_val, content_val) =
             if value.get("type").and_then(Value::as_str) == Some("message") {
-                let msg = match value.get("message") { Some(m) => m, None => continue };
+                let msg = match value.get("message") {
+                    Some(m) => m,
+                    None => continue,
+                };
                 (msg.get("role"), msg.get("content"))
             } else {
                 (value.get("role"), value.get("content"))
             };
-        let role = match role_val.and_then(Value::as_str) { Some(r) => r.to_string(), None => continue };
+        let role = match role_val.and_then(Value::as_str) {
+            Some(r) => r.to_string(),
+            None => continue,
+        };
         let content = content_val.map(extract_text).unwrap_or_default();
-        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) { continue; }
+        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) {
+            continue;
+        }
         if let Some(snippet) = build_snippet(&content, needle) {
             snippets.push(SearchSnippet { role, snippet });
-            if snippets.len() >= MAX_SNIPPETS { break; }
+            if snippets.len() >= MAX_SNIPPETS {
+                break;
+            }
         }
     }
-    if snippets.is_empty() { return None; }
+    if snippets.is_empty() {
+        return None;
+    }
     Some(SessionSearchHit {
         provider_id: PROVIDER_ID.to_string(),
         session_id: meta.session_id.clone(),
@@ -543,13 +563,17 @@ fn search_session_sqlite(meta: &SessionMeta, needle: &str) -> Option<SessionSear
     let conn = Connection::open_with_flags(
         &db_path,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ).ok()?;
+    )
+    .ok()?;
+    // Fetch all messages for the session without a LIKE prefilter, because
+    // SQLite's LIKE is case-insensitive only for ASCII and would miss Unicode
+    // matches (e.g. "Éclair" vs "éclair"). The Rust to_lowercase().contains()
+    // check below handles full Unicode case-insensitive matching.
     let mut stmt = conn
-        .prepare("SELECT role, content FROM messages WHERE session_id = ?1 AND content LIKE ?2 ORDER BY created_at ASC")
+        .prepare("SELECT role, content FROM messages WHERE session_id = ?1 ORDER BY created_at ASC")
         .ok()?;
-    let like_pattern = format!("%{needle}%");
     let rows = stmt
-        .query_map(rusqlite::params![session_id.as_str(), like_pattern.as_str()], |row| {
+        .query_map(rusqlite::params![session_id.as_str()], |row| {
             let role: String = row.get(0)?;
             let content: String = row.get(1)?;
             Ok((role, content))
@@ -560,13 +584,19 @@ fn search_session_sqlite(meta: &SessionMeta, needle: &str) -> Option<SessionSear
     const MAX_SNIPPETS: usize = 5;
     for row in rows.flatten() {
         let (role, content) = row;
-        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) { continue; }
+        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) {
+            continue;
+        }
         if let Some(snippet) = build_snippet(&content, needle) {
             snippets.push(SearchSnippet { role, snippet });
-            if snippets.len() >= MAX_SNIPPETS { break; }
+            if snippets.len() >= MAX_SNIPPETS {
+                break;
+            }
         }
     }
-    if snippets.is_empty() { return None; }
+    if snippets.is_empty() {
+        return None;
+    }
     Some(SessionSearchHit {
         provider_id: PROVIDER_ID.to_string(),
         session_id: meta.session_id.clone(),

--- a/src-tauri/src/session_manager/providers/openclaw.rs
+++ b/src-tauri/src/session_manager/providers/openclaw.rs
@@ -8,12 +8,12 @@ use serde_json::Value;
 use crate::openclaw_config::get_openclaw_dir;
 use crate::{
     config::write_json_file,
-    session_manager::{SessionMessage, SessionMeta},
+    session_manager::{SessionMessage, SessionMeta, SessionSearchHit, SearchSnippet},
 };
 
 use super::utils::{
-    extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines, truncate_summary,
-    TITLE_MAX_CHARS,
+    build_snippet, extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines,
+    truncate_summary, TITLE_MAX_CHARS,
 };
 
 const PROVIDER_ID: &str = "openclaw";
@@ -120,6 +120,39 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
     }
 
     Ok(messages)
+}
+
+/// Search a single OpenClaw session file for `needle` (case-insensitive).
+pub fn search_session(meta: &SessionMeta, needle: &str) -> Option<SessionSearchHit> {
+    let source_path = meta.source_path.as_deref()?;
+    let path = Path::new(source_path);
+    let file = File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    let lower_needle = needle.to_lowercase();
+    let mut snippets: Vec<SearchSnippet> = Vec::new();
+    const MAX_SNIPPETS: usize = 5;
+
+    for line in reader.lines() {
+        let line = match line { Ok(l) => l, Err(_) => continue };
+        let value: Value = match serde_json::from_str(&line) { Ok(v) => v, Err(_) => continue };
+        if value.get("type").and_then(Value::as_str) != Some("message") { continue; }
+        let message = match value.get("message") { Some(m) => m, None => continue };
+        let raw_role = message.get("role").and_then(Value::as_str).unwrap_or("unknown");
+        let role = match raw_role { "toolResult" => "tool".to_string(), other => other.to_string() };
+        let content = message.get("content").map(extract_text).unwrap_or_default();
+        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) { continue; }
+        if let Some(snippet) = build_snippet(&content, needle) {
+            snippets.push(SearchSnippet { role, snippet });
+            if snippets.len() >= MAX_SNIPPETS { break; }
+        }
+    }
+    if snippets.is_empty() { return None; }
+    Some(SessionSearchHit {
+        provider_id: PROVIDER_ID.to_string(),
+        session_id: meta.session_id.clone(),
+        source_path: source_path.to_string(),
+        snippets,
+    })
 }
 
 pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<bool, String> {

--- a/src-tauri/src/session_manager/providers/openclaw.rs
+++ b/src-tauri/src/session_manager/providers/openclaw.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::openclaw_config::get_openclaw_dir;
 use crate::{
     config::write_json_file,
-    session_manager::{SessionMessage, SessionMeta, SessionSearchHit, SearchSnippet},
+    session_manager::{SearchSnippet, SessionMessage, SessionMeta, SessionSearchHit},
 };
 
 use super::utils::{
@@ -133,20 +133,43 @@ pub fn search_session(meta: &SessionMeta, needle: &str) -> Option<SessionSearchH
     const MAX_SNIPPETS: usize = 5;
 
     for line in reader.lines() {
-        let line = match line { Ok(l) => l, Err(_) => continue };
-        let value: Value = match serde_json::from_str(&line) { Ok(v) => v, Err(_) => continue };
-        if value.get("type").and_then(Value::as_str) != Some("message") { continue; }
-        let message = match value.get("message") { Some(m) => m, None => continue };
-        let raw_role = message.get("role").and_then(Value::as_str).unwrap_or("unknown");
-        let role = match raw_role { "toolResult" => "tool".to_string(), other => other.to_string() };
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if value.get("type").and_then(Value::as_str) != Some("message") {
+            continue;
+        }
+        let message = match value.get("message") {
+            Some(m) => m,
+            None => continue,
+        };
+        let raw_role = message
+            .get("role")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let role = match raw_role {
+            "toolResult" => "tool".to_string(),
+            other => other.to_string(),
+        };
         let content = message.get("content").map(extract_text).unwrap_or_default();
-        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) { continue; }
+        if content.trim().is_empty() || !content.to_lowercase().contains(&lower_needle) {
+            continue;
+        }
         if let Some(snippet) = build_snippet(&content, needle) {
             snippets.push(SearchSnippet { role, snippet });
-            if snippets.len() >= MAX_SNIPPETS { break; }
+            if snippets.len() >= MAX_SNIPPETS {
+                break;
+            }
         }
     }
-    if snippets.is_empty() { return None; }
+    if snippets.is_empty() {
+        return None;
+    }
     Some(SessionSearchHit {
         provider_id: PROVIDER_ID.to_string(),
         session_id: meta.session_id.clone(),

--- a/src-tauri/src/session_manager/providers/opencode.rs
+++ b/src-tauri/src/session_manager/providers/opencode.rs
@@ -3,9 +3,9 @@ use std::path::{Path, PathBuf};
 use rusqlite::Connection;
 use serde_json::Value;
 
-use crate::session_manager::{SessionMessage, SessionMeta};
+use crate::session_manager::{SessionMessage, SessionMeta, SessionSearchHit, SearchSnippet};
 
-use super::utils::{parse_timestamp_to_ms, path_basename, truncate_summary};
+use super::utils::{build_snippet, parse_timestamp_to_ms, path_basename, truncate_summary};
 
 const PROVIDER_ID: &str = "opencode";
 
@@ -311,6 +311,126 @@ pub fn load_messages_sqlite(source: &str) -> Result<Vec<SessionMessage>, String>
     }
 
     Ok(messages)
+}
+
+/// Search OpenCode sessions (file-based or SQLite) for `needle` (case-insensitive).
+pub fn search_sessions(metas: &[&SessionMeta], needle: &str) -> Vec<SessionSearchHit> {
+    metas
+        .iter()
+        .filter_map(|m| {
+            let source = m.source_path.as_deref()?;
+            if source.starts_with("sqlite:") {
+                search_session_sqlite(m, needle)
+            } else {
+                search_session_files(m, needle)
+            }
+        })
+        .collect()
+}
+
+const MAX_SEARCH_SNIPPETS: usize = 5;
+
+fn search_session_files(meta: &SessionMeta, needle: &str) -> Option<SessionSearchHit> {
+    let source_path = meta.source_path.as_deref()?;
+    let msg_dir = Path::new(source_path);
+    if !msg_dir.is_dir() { return None; }
+    let storage = msg_dir.parent().and_then(|p| p.parent())?;
+    let mut msg_files = Vec::new();
+    collect_json_files(msg_dir, &mut msg_files);
+    let lower_needle = needle.to_lowercase();
+    let mut entries: Vec<(i64, String, String)> = Vec::new();
+
+    for msg_path in &msg_files {
+        let data = match std::fs::read_to_string(msg_path) { Ok(d) => d, Err(_) => continue };
+        let value: Value = match serde_json::from_str(&data) { Ok(v) => v, Err(_) => continue };
+        let msg_id = match value.get("id").and_then(Value::as_str) { Some(id) => id.to_string(), None => continue };
+        let role = value.get("role").and_then(Value::as_str).unwrap_or("unknown").to_string();
+        let created_ts = value.get("time").and_then(|t| t.get("created")).and_then(parse_timestamp_to_ms).unwrap_or(0);
+        let part_dir = storage.join("part").join(&msg_id);
+        let text = collect_parts_text(&part_dir);
+        if text.trim().is_empty() || !text.to_lowercase().contains(&lower_needle) { continue; }
+        entries.push((created_ts, role, text));
+    }
+    entries.sort_by_key(|(ts, _, _)| *ts);
+    let mut snippets: Vec<SearchSnippet> = Vec::new();
+    for (_, role, text) in entries {
+        if let Some(snippet) = build_snippet(&text, needle) {
+            snippets.push(SearchSnippet { role, snippet });
+            if snippets.len() >= MAX_SEARCH_SNIPPETS { break; }
+        }
+    }
+    if snippets.is_empty() { return None; }
+    Some(SessionSearchHit {
+        provider_id: PROVIDER_ID.to_string(),
+        session_id: meta.session_id.clone(),
+        source_path: source_path.to_string(),
+        snippets,
+    })
+}
+
+fn search_session_sqlite(meta: &SessionMeta, needle: &str) -> Option<SessionSearchHit> {
+    let source_path = meta.source_path.as_deref()?;
+    let (db_path, session_id) = parse_sqlite_source(source_path)?;
+    let conn = Connection::open_with_flags(
+        &db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ).ok()?;
+    let mut msg_stmt = conn
+        .prepare("SELECT id, time_created, data FROM message WHERE session_id = ?1 ORDER BY time_created ASC")
+        .ok()?;
+    let msg_rows = msg_stmt
+        .query_map([session_id.as_str()], |row| {
+            let id: String = row.get(0)?;
+            let ts: i64 = row.get(1)?;
+            let data: String = row.get(2)?;
+            Ok((id, ts, data))
+        })
+        .ok()?;
+    let mut part_stmt = conn
+        .prepare("SELECT message_id, data FROM part WHERE session_id = ?1 ORDER BY time_created ASC")
+        .ok()?;
+    let part_rows = part_stmt
+        .query_map([session_id.as_str()], |row| {
+            let message_id: String = row.get(0)?;
+            let data: String = row.get(1)?;
+            Ok((message_id, data))
+        })
+        .ok()?;
+    let mut parts_map: std::collections::HashMap<String, Vec<String>> = std::collections::HashMap::new();
+    for part in part_rows.flatten() {
+        let (message_id, data) = part;
+        parts_map.entry(message_id).or_default().push(data);
+    }
+    let lower_needle = needle.to_lowercase();
+    let mut snippets: Vec<SearchSnippet> = Vec::new();
+    for row in msg_rows.flatten() {
+        let (msg_id, _ts, data) = row;
+        let msg_value: Value = match serde_json::from_str(&data) { Ok(v) => v, Err(_) => continue };
+        let role = msg_value.get("role").and_then(Value::as_str).unwrap_or("unknown").to_string();
+        let parts = parts_map.get(&msg_id);
+        let mut text = String::new();
+        if let Some(parts) = parts {
+            for part_data in parts {
+                let part_value: Value = match serde_json::from_str(part_data) { Ok(v) => v, Err(_) => continue };
+                if let Some(t) = extract_part_text(&part_value) {
+                    if !text.is_empty() { text.push('\n'); }
+                    text.push_str(&t);
+                }
+            }
+        }
+        if text.trim().is_empty() || !text.to_lowercase().contains(&lower_needle) { continue; }
+        if let Some(snippet) = build_snippet(&text, needle) {
+            snippets.push(SearchSnippet { role, snippet });
+            if snippets.len() >= MAX_SEARCH_SNIPPETS { break; }
+        }
+    }
+    if snippets.is_empty() { return None; }
+    Some(SessionSearchHit {
+        provider_id: PROVIDER_ID.to_string(),
+        session_id: meta.session_id.clone(),
+        source_path: source_path.to_string(),
+        snippets,
+    })
 }
 
 pub fn delete_session(storage: &Path, path: &Path, session_id: &str) -> Result<bool, String> {

--- a/src-tauri/src/session_manager/providers/opencode.rs
+++ b/src-tauri/src/session_manager/providers/opencode.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use rusqlite::Connection;
 use serde_json::Value;
 
-use crate::session_manager::{SessionMessage, SessionMeta, SessionSearchHit, SearchSnippet};
+use crate::session_manager::{SearchSnippet, SessionMessage, SessionMeta, SessionSearchHit};
 
 use super::utils::{build_snippet, parse_timestamp_to_ms, path_basename, truncate_summary};
 
@@ -333,7 +333,9 @@ const MAX_SEARCH_SNIPPETS: usize = 5;
 fn search_session_files(meta: &SessionMeta, needle: &str) -> Option<SessionSearchHit> {
     let source_path = meta.source_path.as_deref()?;
     let msg_dir = Path::new(source_path);
-    if !msg_dir.is_dir() { return None; }
+    if !msg_dir.is_dir() {
+        return None;
+    }
     let storage = msg_dir.parent().and_then(|p| p.parent())?;
     let mut msg_files = Vec::new();
     collect_json_files(msg_dir, &mut msg_files);
@@ -341,14 +343,33 @@ fn search_session_files(meta: &SessionMeta, needle: &str) -> Option<SessionSearc
     let mut entries: Vec<(i64, String, String)> = Vec::new();
 
     for msg_path in &msg_files {
-        let data = match std::fs::read_to_string(msg_path) { Ok(d) => d, Err(_) => continue };
-        let value: Value = match serde_json::from_str(&data) { Ok(v) => v, Err(_) => continue };
-        let msg_id = match value.get("id").and_then(Value::as_str) { Some(id) => id.to_string(), None => continue };
-        let role = value.get("role").and_then(Value::as_str).unwrap_or("unknown").to_string();
-        let created_ts = value.get("time").and_then(|t| t.get("created")).and_then(parse_timestamp_to_ms).unwrap_or(0);
+        let data = match std::fs::read_to_string(msg_path) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+        let value: Value = match serde_json::from_str(&data) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let msg_id = match value.get("id").and_then(Value::as_str) {
+            Some(id) => id.to_string(),
+            None => continue,
+        };
+        let role = value
+            .get("role")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let created_ts = value
+            .get("time")
+            .and_then(|t| t.get("created"))
+            .and_then(parse_timestamp_to_ms)
+            .unwrap_or(0);
         let part_dir = storage.join("part").join(&msg_id);
         let text = collect_parts_text(&part_dir);
-        if text.trim().is_empty() || !text.to_lowercase().contains(&lower_needle) { continue; }
+        if text.trim().is_empty() || !text.to_lowercase().contains(&lower_needle) {
+            continue;
+        }
         entries.push((created_ts, role, text));
     }
     entries.sort_by_key(|(ts, _, _)| *ts);
@@ -356,10 +377,14 @@ fn search_session_files(meta: &SessionMeta, needle: &str) -> Option<SessionSearc
     for (_, role, text) in entries {
         if let Some(snippet) = build_snippet(&text, needle) {
             snippets.push(SearchSnippet { role, snippet });
-            if snippets.len() >= MAX_SEARCH_SNIPPETS { break; }
+            if snippets.len() >= MAX_SEARCH_SNIPPETS {
+                break;
+            }
         }
     }
-    if snippets.is_empty() { return None; }
+    if snippets.is_empty() {
+        return None;
+    }
     Some(SessionSearchHit {
         provider_id: PROVIDER_ID.to_string(),
         session_id: meta.session_id.clone(),
@@ -374,7 +399,8 @@ fn search_session_sqlite(meta: &SessionMeta, needle: &str) -> Option<SessionSear
     let conn = Connection::open_with_flags(
         &db_path,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ).ok()?;
+    )
+    .ok()?;
     let mut msg_stmt = conn
         .prepare("SELECT id, time_created, data FROM message WHERE session_id = ?1 ORDER BY time_created ASC")
         .ok()?;
@@ -387,7 +413,9 @@ fn search_session_sqlite(meta: &SessionMeta, needle: &str) -> Option<SessionSear
         })
         .ok()?;
     let mut part_stmt = conn
-        .prepare("SELECT message_id, data FROM part WHERE session_id = ?1 ORDER BY time_created ASC")
+        .prepare(
+            "SELECT message_id, data FROM part WHERE session_id = ?1 ORDER BY time_created ASC",
+        )
         .ok()?;
     let part_rows = part_stmt
         .query_map([session_id.as_str()], |row| {
@@ -396,7 +424,8 @@ fn search_session_sqlite(meta: &SessionMeta, needle: &str) -> Option<SessionSear
             Ok((message_id, data))
         })
         .ok()?;
-    let mut parts_map: std::collections::HashMap<String, Vec<String>> = std::collections::HashMap::new();
+    let mut parts_map: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
     for part in part_rows.flatten() {
         let (message_id, data) = part;
         parts_map.entry(message_id).or_default().push(data);
@@ -405,26 +434,44 @@ fn search_session_sqlite(meta: &SessionMeta, needle: &str) -> Option<SessionSear
     let mut snippets: Vec<SearchSnippet> = Vec::new();
     for row in msg_rows.flatten() {
         let (msg_id, _ts, data) = row;
-        let msg_value: Value = match serde_json::from_str(&data) { Ok(v) => v, Err(_) => continue };
-        let role = msg_value.get("role").and_then(Value::as_str).unwrap_or("unknown").to_string();
+        let msg_value: Value = match serde_json::from_str(&data) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let role = msg_value
+            .get("role")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
         let parts = parts_map.get(&msg_id);
         let mut text = String::new();
         if let Some(parts) = parts {
             for part_data in parts {
-                let part_value: Value = match serde_json::from_str(part_data) { Ok(v) => v, Err(_) => continue };
+                let part_value: Value = match serde_json::from_str(part_data) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
                 if let Some(t) = extract_part_text(&part_value) {
-                    if !text.is_empty() { text.push('\n'); }
+                    if !text.is_empty() {
+                        text.push('\n');
+                    }
                     text.push_str(&t);
                 }
             }
         }
-        if text.trim().is_empty() || !text.to_lowercase().contains(&lower_needle) { continue; }
+        if text.trim().is_empty() || !text.to_lowercase().contains(&lower_needle) {
+            continue;
+        }
         if let Some(snippet) = build_snippet(&text, needle) {
             snippets.push(SearchSnippet { role, snippet });
-            if snippets.len() >= MAX_SEARCH_SNIPPETS { break; }
+            if snippets.len() >= MAX_SEARCH_SNIPPETS {
+                break;
+            }
         }
     }
-    if snippets.is_empty() { return None; }
+    if snippets.is_empty() {
+        return None;
+    }
     Some(SessionSearchHit {
         provider_id: PROVIDER_ID.to_string(),
         session_id: meta.session_id.clone(),

--- a/src-tauri/src/session_manager/providers/utils.rs
+++ b/src-tauri/src/session_manager/providers/utils.rs
@@ -220,10 +220,14 @@ pub fn build_snippet(haystack: &str, needle: &str) -> Option<String> {
         let window: String = chars[i..i + needle_len].iter().collect();
         window.to_lowercase() == lower_needle
     })?;
-    let _match_end = (start + needle_len).min(chars.len());
-    let half = SNIPPET_MAX_CHARS.saturating_sub(needle_len) / 2;
+    // Ensure the context window is always wide enough to contain the whole
+    // needle; otherwise a query longer than SNIPPET_MAX_CHARS would produce a
+    // snippet that fails the final `contains` guard and the hit would be
+    // silently dropped even though the content genuinely matches.
+    let window_len = SNIPPET_MAX_CHARS.max(needle_len);
+    let half = window_len.saturating_sub(needle_len) / 2;
     let ctx_start = start.saturating_sub(half);
-    let ctx_end = (ctx_start + SNIPPET_MAX_CHARS).min(chars.len());
+    let ctx_end = (ctx_start + window_len).min(chars.len());
     let mut snippet: String = chars[ctx_start..ctx_end].iter().collect();
     snippet = snippet.trim().to_string();
     if ctx_start > 0 {
@@ -272,6 +276,16 @@ mod tests {
             "这是一段关于浙江移动的对话内容，后面还有很多其他文字用于测试截断逻辑是否正确工作。";
         let s = build_snippet(haystack, "浙江移动").expect("should find CJK");
         assert!(s.contains("浙江移动"));
+    }
+
+    #[test]
+    fn build_snippet_finds_needle_longer_than_max_chars() {
+        // A query longer than SNIPPET_MAX_CHARS must still produce a snippet
+        // that contains the whole match, not silently drop the hit.
+        let needle: String = "a".repeat(SNIPPET_MAX_CHARS + 40);
+        let haystack = format!("prefix {needle} suffix");
+        let s = build_snippet(&haystack, &needle).expect("should find long needle");
+        assert!(s.contains(&needle));
     }
 
     #[test]

--- a/src-tauri/src/session_manager/providers/utils.rs
+++ b/src-tauri/src/session_manager/providers/utils.rs
@@ -216,11 +216,10 @@ pub fn build_snippet(haystack: &str, needle: &str) -> Option<String> {
         return None;
     }
     let lower_needle = needle.to_lowercase();
-    let start = (0..=chars.len().saturating_sub(needle_len))
-        .find(|&i| {
-            let window: String = chars[i..i + needle_len].iter().collect();
-            window.to_lowercase() == lower_needle
-        })?;
+    let start = (0..=chars.len().saturating_sub(needle_len)).find(|&i| {
+        let window: String = chars[i..i + needle_len].iter().collect();
+        window.to_lowercase() == lower_needle
+    })?;
     let _match_end = (start + needle_len).min(chars.len());
     let half = SNIPPET_MAX_CHARS.saturating_sub(needle_len) / 2;
     let ctx_start = start.saturating_sub(half);
@@ -228,7 +227,7 @@ pub fn build_snippet(haystack: &str, needle: &str) -> Option<String> {
     let mut snippet: String = chars[ctx_start..ctx_end].iter().collect();
     snippet = snippet.trim().to_string();
     if ctx_start > 0 {
-        snippet.insert_str(0, "…");
+        snippet.insert(0, '…');
     }
     if ctx_end < chars.len() {
         snippet.push('…');
@@ -269,7 +268,8 @@ mod tests {
 
     #[test]
     fn build_snippet_finds_cjk_substring() {
-        let haystack = "这是一段关于浙江移动的对话内容，后面还有很多其他文字用于测试截断逻辑是否正确工作。";
+        let haystack =
+            "这是一段关于浙江移动的对话内容，后面还有很多其他文字用于测试截断逻辑是否正确工作。";
         let s = build_snippet(haystack, "浙江移动").expect("should find CJK");
         assert!(s.contains("浙江移动"));
     }

--- a/src-tauri/src/session_manager/providers/utils.rs
+++ b/src-tauri/src/session_manager/providers/utils.rs
@@ -199,6 +199,46 @@ pub fn path_basename(value: &str) -> Option<String> {
     Some(last.to_string())
 }
 
+/// Maximum number of characters in a search snippet (context around a match).
+pub const SNIPPET_MAX_CHARS: usize = 160;
+
+/// Build a search snippet around the first occurrence of `needle` in `haystack`.
+/// Returns up to `SNIPPET_MAX_CHARS` chars, centered on the match when possible.
+/// Case-insensitive matching for ASCII; exact for non-ASCII (CJK etc.).
+pub fn build_snippet(haystack: &str, needle: &str) -> Option<String> {
+    if needle.is_empty() {
+        return None;
+    }
+    let chars: Vec<char> = haystack.chars().collect();
+    let needle_chars: Vec<char> = needle.chars().collect();
+    let needle_len = needle_chars.len();
+    if needle_len == 0 || chars.len() < needle_len {
+        return None;
+    }
+    let lower_needle = needle.to_lowercase();
+    let start = (0..=chars.len().saturating_sub(needle_len))
+        .find(|&i| {
+            let window: String = chars[i..i + needle_len].iter().collect();
+            window.to_lowercase() == lower_needle
+        })?;
+    let _match_end = (start + needle_len).min(chars.len());
+    let half = SNIPPET_MAX_CHARS.saturating_sub(needle_len) / 2;
+    let ctx_start = start.saturating_sub(half);
+    let ctx_end = (ctx_start + SNIPPET_MAX_CHARS).min(chars.len());
+    let mut snippet: String = chars[ctx_start..ctx_end].iter().collect();
+    snippet = snippet.trim().to_string();
+    if ctx_start > 0 {
+        snippet.insert_str(0, "…");
+    }
+    if ctx_end < chars.len() {
+        snippet.push('…');
+    }
+    if !snippet.to_lowercase().contains(&lower_needle) {
+        return None;
+    }
+    Some(snippet)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -218,5 +258,29 @@ mod tests {
             parse_timestamp_to_ms(&json!("1970-01-01T00:00:01Z")),
             Some(1_000)
         );
+    }
+
+    #[test]
+    fn build_snippet_finds_ascii_substring_case_insensitively() {
+        let haystack = "The quick BROWN fox jumps over the lazy dog";
+        let s = build_snippet(haystack, "brown").expect("should find 'brown'");
+        assert!(s.to_lowercase().contains("brown"));
+    }
+
+    #[test]
+    fn build_snippet_finds_cjk_substring() {
+        let haystack = "这是一段关于浙江移动的对话内容，后面还有很多其他文字用于测试截断逻辑是否正确工作。";
+        let s = build_snippet(haystack, "浙江移动").expect("should find CJK");
+        assert!(s.contains("浙江移动"));
+    }
+
+    #[test]
+    fn build_snippet_returns_none_for_missing_needle() {
+        assert!(build_snippet("hello world", "missing").is_none());
+    }
+
+    #[test]
+    fn build_snippet_returns_none_for_empty_needle() {
+        assert!(build_snippet("hello", "").is_none());
     }
 }


### PR DESCRIPTION
## Related Issues & PRs

### Upstream (farion1231/cc-switch)
- **Issue #3721** — [希望 Session Manager 支持会话重命名和全文搜索](https://github.com/farion1231/cc-switch/issues/3721) (CLOSED)
  - Requested full-text search across session conversation content, not just metadata (title/summary/paths)
  - Closed because the "rename" part had concerns, but the "full-text search" part is addressed by this PR
- **PR #4976** — [feat(session-search): add full-content deep search across all session messages](https://github.com/farion1231/cc-switch/pull/4976) (OPEN)
  - The equivalent feature for the upstream Tauri desktop app (cc-switch), submitted by the same author

### This Repo (saladday/cc-switch-cli)
- No existing issues or PRs for session full-text search — this is the first implementation for the CLI fork.

---

## Problem

The existing session search only matches session metadata (title, summary, projectDir, sourcePath). Keywords appearing **in the middle of a conversation** (e.g. Chinese terms like "浙江移动") cannot be found, because they are never indexed.

Additionally, the TUI session list only shows sessions for the currently selected provider — there's no way to view all providers' sessions at once.

## Solution

### 1. Full-Content Deep Search (Backend + CLI + TUI)

**Backend (Rust):**
- New `SessionSearchHit` / `SearchSnippet` types in `session_manager::mod`
- `search_sessions_in()` dispatches per-provider in parallel via `thread::scope`
- Each provider (codex/claude/openclaw/gemini) scans JSONL/JSON line-by-line
- Hermes/OpenCode support both JSONL files and SQLite (`LIKE '%kw%'`)
- `build_snippet()` extracts ~160-char context around match, CJK-safe
- 4 new unit tests (ASCII, CJK, missing/empty needle)

**CLI:**
- New `cc-switch sessions search <QUERY>` subcommand (searches all providers by default, no `--all` flag needed)
- Displays results in a table with provider, session, title, and snippet preview
- `--json` output for machine-readable format

**TUI:**
- Press `/` and type to search — **real-time debounce (~400ms)**, no need to press Enter
- Spinner animation (`⠋⠙⠹⠸`) in summary bar while search is running
- Results merge metadata matches + deep content matches
- Asynchronous: search runs in worker thread, UI stays responsive
- Press `Esc` to clear search

<img width="604" height="535" alt="image" src="https://github.com/user-attachments/assets/b6267745-45b8-4863-95e2-653391be5b2d" />

### 2. "All Providers" View in TUI

- Press `a` in the Sessions page to enter "all providers" mode
- Shows sessions from all providers with an extra "Provider" column
- Press `Esc` to exit back to current provider filter
- Original per-provider filtering is preserved (no behavior change when not in "all" mode)
<img width="368" height="388" alt="image" src="https://github.com/user-attachments/assets/9abccd00-3c88-45d8-9a46-ca401e20a655" />

## Architecture

```
TUI filter input → debounce 400ms → async SessionReq::Search
    ↓ (worker thread)
Rust backend: parallel scan per provider
    ├─ File-based: BufReader line-by-line case-insensitive match
    └─ SQLite: SELECT ... WHERE content LIKE '%kw%'
    ↓
SessionMsg::SearchFinished → update results → re-render list
```

## Testing

- ✅ All 52 existing `session_manager` tests pass
- ✅ All 8 TUI sessions tests pass
- ✅ `cargo check` — no errors
- ✅ Manually tested on WSL: searching "浙江移动" finds sessions where the keyword appears in mid-conversation messages
- ✅ CLI: `cc-switch sessions search '浙江移动'` works
- ✅ TUI: real-time search with spinner animation works

## Files Changed (20 files, +920 lines)

**Backend:**
- `session_manager/mod.rs` — search types + parallel dispatch
- `session_manager/providers/utils.rs` — `build_snippet` + tests
- `session_manager/providers/{codex,claude,openclaw,gemini,hermes,opencode}.rs` — per-provider search

**CLI:**
- `cli/commands/sessions.rs` — `search` subcommand

**TUI:**
- `cli/tui/app/{app_state,types,helpers,menu,content_entities}.rs` — search state, debounce, filter integration
- `cli/tui/runtime_systems/{types,workers,handlers}.rs` — async search worker
- `cli/tui/runtime_actions/mod.rs` — `SessionsDeepSearch` action handler
- `cli/tui/ui/sessions.rs` — spinner + all-providers column
- `cli/tui/mod.rs` — debounce timer in main loop
