### PR TITLE
Add provider launch command

### DIFF
--- a/src-tauri/src/cli/commands/provider.rs
+++ b/src-tauri/src/cli/commands/provider.rs
@@ -1,7 +1,7 @@
 use clap::{Subcommand, ValueEnum};
-use std::{collections::HashSet, path::PathBuf};
+use std::{collections::HashSet, ffi::OsString, path::PathBuf};
 
-use super::{provider_inspect, provider_usage_query};
+use super::{provider_inspect, provider_usage_query, start};
 use crate::app_config::AppType;
 use crate::cli::commands::provider_input::{
     build_claude_settings_config_from_prompt, build_codex_settings_config_from_prompt,
@@ -37,6 +37,11 @@ const CODEX_API_FORMAT_CHOICES: [&str; 2] = [
     CLAUDE_API_FORMAT_OPENAI_RESPONSES,
     CLAUDE_API_FORMAT_OPENAI_CHAT,
 ];
+const PROVIDER_LAUNCH_AFTER_LONG_HELP: &str = "\
+Examples:
+  cc-switch provider launch demo
+  cc-switch provider launch demo --dry-run
+  cc-switch --app codex provider launch demo -- --model gpt-5.4";
 
 fn is_claude_official_provider(provider: &Provider) -> bool {
     provider
@@ -552,6 +557,18 @@ pub enum ProviderCommand {
         /// Provider ID to switch to
         id: String,
     },
+    /// Launch a temporary agent with a provider without switching the current provider
+    #[command(after_long_help = PROVIDER_LAUNCH_AFTER_LONG_HELP)]
+    Launch {
+        /// Provider selector: exact ID first, then exact Name
+        selector: String,
+        /// Preview the resolved launch without starting the app
+        #[arg(long)]
+        dry_run: bool,
+        /// Native app CLI arguments to pass through after `--`
+        #[arg(last = true, value_name = "NATIVE_ARGS")]
+        native_args: Vec<OsString>,
+    },
     /// Add a new provider (non-interactive; use the TUI for interactive add)
     Add {
         /// Provider template to apply before creation
@@ -690,6 +707,11 @@ pub fn execute(cmd: ProviderCommand, app: Option<AppType>) -> Result<(), AppErro
         ProviderCommand::List => provider_inspect::list_providers(app_type),
         ProviderCommand::Current => provider_inspect::show_current(app_type),
         ProviderCommand::Switch { id } => switch_provider(app_type, &id),
+        ProviderCommand::Launch {
+            selector,
+            dry_run,
+            native_args,
+        } => start::launch_provider(app_type, &selector, dry_run, &native_args),
         ProviderCommand::Add {
             template,
             name,

--- a/src-tauri/src/cli/commands/start.rs
+++ b/src-tauri/src/cli/commands/start.rs
@@ -66,12 +66,35 @@ pub fn execute(cmd: StartCommand) -> Result<(), AppError> {
             selector,
             dry_run,
             native_args,
-        } => start_claude(&selector, dry_run, &native_args),
+        } => launch_provider(AppType::Claude, &selector, dry_run, &native_args),
         StartCommand::Codex {
             selector,
             dry_run,
             native_args,
-        } => start_codex(&selector, dry_run, &native_args),
+        } => launch_provider(AppType::Codex, &selector, dry_run, &native_args),
+    }
+}
+
+pub(crate) fn launch_provider(
+    app_type: AppType,
+    selector: &str,
+    dry_run: bool,
+    native_args: &[OsString],
+) -> Result<(), AppError> {
+    match app_type {
+        AppType::Claude => start_claude(selector, dry_run, native_args),
+        AppType::Codex => start_codex(selector, dry_run, native_args),
+        other => Err(AppError::localized(
+            "cli.start.unsupported_app",
+            format!(
+                "当前暂不支持为 {} 临时启动 agent；目前仅支持 claude 和 codex。",
+                other
+            ),
+            format!(
+                "Temporary agent launch is not supported for {}; currently only claude and codex are supported.",
+                other
+            ),
+        )),
     }
 }
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -952,6 +952,55 @@ mod tests {
     }
 
     #[test]
+    fn parses_provider_launch_subcommand() {
+        let cli = Cli::parse_from([
+            "cc-switch",
+            "--app",
+            "codex",
+            "provider",
+            "launch",
+            "demo",
+            "--dry-run",
+            "--",
+            "--model",
+            "gpt-5.4",
+        ]);
+
+        assert_eq!(cli.app, Some(AppType::Codex));
+        match cli.command {
+            Some(Commands::Provider(super::commands::provider::ProviderCommand::Launch {
+                selector,
+                dry_run,
+                native_args,
+            })) => {
+                assert_eq!(selector, "demo");
+                assert!(dry_run);
+                assert_eq!(
+                    native_args,
+                    vec![OsString::from("--model"), OsString::from("gpt-5.4")]
+                );
+            }
+            _ => panic!("expected provider launch command"),
+        }
+    }
+
+    #[test]
+    fn provider_launch_help_mentions_passthrough_examples() {
+        let mut cmd = Cli::command();
+        let provider = cmd
+            .find_subcommand_mut("provider")
+            .expect("provider subcommand should exist");
+        let launch = provider
+            .find_subcommand_mut("launch")
+            .expect("provider launch subcommand should exist");
+        let help = launch.render_long_help().to_string();
+
+        assert!(help.contains("--dry-run"));
+        assert!(help.contains("Native app CLI arguments to pass through after `--`"));
+        assert!(help.contains("cc-switch --app codex provider launch demo -- --model gpt-5.4"));
+    }
+
+    #[test]
     fn parses_provider_add_template_option() {
         let cli = Cli::parse_from(["cc-switch", "provider", "add", "--template", "codex-oauth"]);
 


### PR DESCRIPTION
Adds `provider launch` as a CLI entry point for temporary Claude/Codex agent launches without switching the current provider.\n\nValidation:\n- `cargo fmt --check`\n- `cargo test provider_launch`\n- `cargo test start_codex_launches_resolved_provider`\n- `cargo test start_claude_launches_resolved_provider`