### PR TITLE
fix: prevent empty tool_call delta from overwriting accumulated call_…

### DIFF
--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -426,10 +426,14 @@ impl ChatToResponsesState {
         {
             let state = self.tools.entry(chat_index).or_default();
             if let Some(id) = id_delta {
-                state.call_id = id;
+                if !id.is_empty() {
+                    state.call_id = id;
+                }
             }
             if let Some(name) = name_delta {
-                state.name = name;
+                if !name.is_empty() {
+                    state.name = name;
+                }
             }
             if !args_delta.is_empty() {
                 state.arguments.push_str(&args_delta);


### PR DESCRIPTION
## Summary

Fix streaming tool call conversion where `call_id` and `name` are overwritten by empty delta chunks.

In `push_tool_call_delta`, both `id`/`call_id` and `name` assignments lacked empty-string protection. When upstream models (e.g. GLM, qwen via DashScope/Aliyun) return empty `id` and `name` in tool_call delta chunks after the first one, the accumulated values are overwritten with empty strings. This causes `response.output_item.done` and `response.completed` to carry empty `call_id` and `name`, leading Codex to reject the tool call with `unsupported call:`.

This PR adds non-empty checks for both `id` and `name` assignments, so that empty deltas are treated as "continue previous value" rather than "clear". Verified locally that streaming tool calls work correctly after the fix.

## Related Issue

Fixes #340

## Screenshots

N/A (no UI changes)

| Before | After |
|--------|-------|
| `call_id` and `name` empty in `output_item.done` | Both fields correctly preserved |

## Checklist

- [x] `cargo clippy` passes
- [x] `cargo test` passes