### PR TITLE
fix(tui): disable mouse capture to restore native text selection

### DIFF
--- a/src-tauri/src/cli/tui/terminal.rs
+++ b/src-tauri/src/cli/tui/terminal.rs
@@ -2,9 +2,7 @@ use std::io::{self, Stdout};
 use std::sync::Arc;
 
 use crossterm::{
-    cursor,
-    event::{DisableMouseCapture, EnableMouseCapture},
-    execute,
+    cursor, execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 #[cfg(test)]
@@ -83,12 +81,7 @@ fn restore_stdout_best_effort(stdout: &mut Stdout) -> Result<(), AppError> {
         record_err(&mut first_err, e);
     }
 
-    if let Err(e) = execute!(
-        stdout,
-        cursor::Show,
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    ) {
+    if let Err(e) = execute!(stdout, cursor::Show, LeaveAlternateScreen) {
         record_err(&mut first_err, e);
     }
 
@@ -111,12 +104,7 @@ impl TuiTerminal {
     pub fn new() -> Result<Self, AppError> {
         let mut stdout = io::stdout();
         enable_raw_mode().map_err(terminal_error)?;
-        if let Err(e) = execute!(
-            stdout,
-            EnterAlternateScreen,
-            EnableMouseCapture,
-            cursor::Hide
-        ) {
+        if let Err(e) = execute!(stdout, EnterAlternateScreen, cursor::Hide) {
             let _ = restore_stdout_best_effort(&mut stdout);
             return Err(terminal_error(e));
         }
@@ -251,12 +239,8 @@ impl TuiTerminal {
 
         match &mut self.terminal {
             TerminalHandle::Stdout(terminal) => {
-                if let Err(e) = execute!(
-                    terminal.backend_mut(),
-                    cursor::Show,
-                    LeaveAlternateScreen,
-                    DisableMouseCapture
-                ) {
+                if let Err(e) = execute!(terminal.backend_mut(), cursor::Show, LeaveAlternateScreen)
+                {
                     record_err(&mut first_err, e);
                 }
                 let _ = terminal.show_cursor();
@@ -296,12 +280,8 @@ impl TuiTerminal {
 
         match &mut self.terminal {
             TerminalHandle::Stdout(terminal) => {
-                if let Err(e) = execute!(
-                    terminal.backend_mut(),
-                    EnterAlternateScreen,
-                    EnableMouseCapture,
-                    cursor::Hide
-                ) {
+                if let Err(e) = execute!(terminal.backend_mut(), EnterAlternateScreen, cursor::Hide)
+                {
                     record_err(&mut first_err, e);
                 }
 


### PR DESCRIPTION
## What

Stop enabling mouse capture when the TUI starts (and when it is reactivated after a handoff). Terminal-native drag-to-select and copy work again while the TUI is running.

## Why

`TuiTerminal::new` and `activate_best_effort` in `src/cli/tui/terminal.rs` run `EnableMouseCapture` alongside `EnterAlternateScreen`. While capture is active the terminal emulator forwards mouse events to the process instead of performing native selection, so users could not select or copy any on-screen text from within the TUI.

The scroll-wheel-to-arrow mapping that previously consumed those events was already removed in ff9dfb2 (`fix(tui): prevent long-list scroll stalls`), so `EnableMouseCapture` now has no consumer yet still blocks selection. This PR drops the capture calls from the terminal enter/restore paths.

Why not keep capture and implement in-app selection instead: an app-drawn selection highlight is just rendered cells, not the terminal's selection, so `Ctrl+C` / `Ctrl+Shift+C` would still copy nothing useful. The app would have to write the clipboard itself (a new dependency or per-OS shell-out, with WSL2 needing `clip.exe`). Terminal-native selection is the only way to get copy via the terminal's existing keybindings without that cost, and it requires capture off.

Closes #347.

## Change

- `src/cli/tui/terminal.rs`: remove the `crossterm::event::{DisableMouseCapture, EnableMouseCapture}` import and the four `EnableMouseCapture` / `DisableMouseCapture` arguments from the `execute!` calls in `new`, `restore_stdout_best_effort`, `restore_best_effort`, and `activate_best_effort`. `EnterAlternateScreen` / `LeaveAlternateScreen`, raw mode, and cursor show/hide are unchanged.

No change to `mod.rs` or `tests.rs` is needed on top of `main`: the `Event::Mouse` arm and the `MouseEventKind` import in `mod.rs` were already removed by ff9dfb2, and `tests.rs` already imports `MouseEventKind` directly.

## Tradeoff

This is the opposite direction from #342, which requests mouse *click* support and needs `EnableMouseCapture` kept. Under crossterm, capture is all-or-nothing: in-app click hit-testing and terminal-native selection cannot coexist. This PR prioritizes copy-paste; if #342 is implemented later it should be opt-in rather than the default, or accept that selection is unavailable while active.

## Testing

```
cd src-tauri && cargo test --lib cli::tui
# 1316 passed; 0 failed
```

`cargo fmt --check` is clean.
