### PR TITLE
Add Atlas Cloud Codex provider template

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Inspect and control daemon-managed per-app proxy routes for supported apps.
 
 **Features:** independent enable/disable per app, per-app listen ports, daemon-managed workers, current route inspection, dashboard telemetry, token accounting, and foreground serve mode for debugging.
 
-The local proxy can route Claude Code, Codex, and Gemini through CC-Switch, adapt OpenAI Responses API and Chat Completions providers, and connect mainstream OpenAI-compatible models such as DeepSeek, Kimi, Qwen, OpenRouter, xAI, Groq, and Mistral where the target app supports that route.
+The local proxy can route Claude Code, Codex, and Gemini through CC-Switch, adapt OpenAI Responses API and Chat Completions providers, and connect mainstream OpenAI-compatible models and providers such as DeepSeek, Atlas Cloud, Kimi, Qwen, OpenRouter, xAI, Groq, and Mistral where the target app supports that route.
 
 ```bash
 cc-switch proxy show                              # Show proxy configuration, routes, and daemon worker status

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -463,7 +463,7 @@ cc-switch config reset               # 重置为默认配置
 
 **功能：** 每个应用可独立启用/禁用代理、每个应用可配置监听端口、由 daemon 管理 worker、当前路由检查、首页遥测、token 统计，以及用于调试的前台运行模式。
 
-本地代理可将 Claude Code、Codex、Gemini 路由到 CC-Switch，适配 OpenAI Responses API 与 Chat Completions 供应商，并在目标应用支持的路径下接入 DeepSeek、Kimi、Qwen、OpenRouter、xAI、Groq、Mistral 等主流 OpenAI-compatible 模型。
+本地代理可将 Claude Code、Codex、Gemini 路由到 CC-Switch，适配 OpenAI Responses API 与 Chat Completions 供应商，并在目标应用支持的路径下接入 DeepSeek、Atlas Cloud、Kimi、Qwen、OpenRouter、xAI、Groq、Mistral 等主流 OpenAI-compatible 模型与供应商。
 
 ```bash
 cc-switch proxy show                              # 显示代理配置、路由和 daemon worker 状态

--- a/src-tauri/src/cli/commands/provider_input.rs
+++ b/src-tauri/src/cli/commands/provider_input.rs
@@ -23,6 +23,7 @@ pub enum ProviderAddTemplate {
     ClaudeOfficial,
     CodexOauth,
     OpenaiOfficial,
+    Atlascloud,
     GoogleOauth,
     Claudeapi,
     Packycode,
@@ -42,6 +43,7 @@ impl ProviderAddTemplate {
             Self::ClaudeOfficial => "claude-official",
             Self::CodexOauth => "codex-oauth",
             Self::OpenaiOfficial => "openai-official",
+            Self::Atlascloud => "atlascloud",
             Self::GoogleOauth => "google-oauth",
             Self::Claudeapi => "claudeapi",
             Self::Packycode => "packycode",
@@ -85,6 +87,18 @@ name = "deepseek"
 base_url = "https://api.deepseek.com"
 wire_api = "responses"
 requires_openai_auth = true"#;
+
+const ATLASCLOUD_CODEX_CONFIG: &str = r#"model_provider = "atlascloud"
+model = "qwen/qwen3.5-flash"
+model_reasoning_effort = "high"
+disable_response_storage = true
+
+[model_providers.atlascloud]
+name = "Atlas Cloud"
+base_url = "https://api.atlascloud.ai/v1"
+wire_api = "responses"
+requires_openai_auth = false
+env_key = "ATLASCLOUD_API_KEY""#;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProviderAddTemplateChoice {
@@ -338,7 +352,7 @@ const PROVIDER_TEMPLATE_CHOICES_CLAUDE: [ProviderAddTemplateChoice; 11] = [
     },
 ];
 
-const PROVIDER_TEMPLATE_CHOICES_CODEX: [ProviderAddTemplateChoice; 10] = [
+const PROVIDER_TEMPLATE_CHOICES_CODEX: [ProviderAddTemplateChoice; 11] = [
     ProviderAddTemplateChoice {
         template: ProviderAddTemplate::Custom,
         label: "Custom",
@@ -374,6 +388,10 @@ const PROVIDER_TEMPLATE_CHOICES_CODEX: [ProviderAddTemplateChoice; 10] = [
     ProviderAddTemplateChoice {
         template: ProviderAddTemplate::Dds,
         label: SPONSOR_PROVIDER_PRESETS[5].chip_label,
+    },
+    ProviderAddTemplateChoice {
+        template: ProviderAddTemplate::Atlascloud,
+        label: "Atlas Cloud",
     },
     ProviderAddTemplateChoice {
         template: ProviderAddTemplate::Deepseek,
@@ -589,6 +607,7 @@ fn template_default_name(template: ProviderAddTemplate) -> Result<&'static str, 
         ProviderAddTemplate::CodexOauth => "Codex",
         ProviderAddTemplate::OpenaiOfficial => "OpenAI Official",
         ProviderAddTemplate::GoogleOauth => "Google OAuth",
+        ProviderAddTemplate::Atlascloud => "Atlas Cloud",
         ProviderAddTemplate::Deepseek => "DeepSeek",
         ProviderAddTemplate::Claudeapi
         | ProviderAddTemplate::Packycode
@@ -610,6 +629,7 @@ fn template_default_website_url(template: ProviderAddTemplate) -> Option<&'stati
         ProviderAddTemplate::CodexOauth => Some("https://openai.com/chatgpt/pricing"),
         ProviderAddTemplate::OpenaiOfficial => Some("https://chatgpt.com/codex"),
         ProviderAddTemplate::GoogleOauth => Some("https://ai.google.dev"),
+        ProviderAddTemplate::Atlascloud => Some("https://www.atlascloud.ai"),
         ProviderAddTemplate::Deepseek => Some("https://platform.deepseek.com"),
         ProviderAddTemplate::Claudeapi
         | ProviderAddTemplate::Packycode
@@ -629,6 +649,7 @@ fn template_default_category(template: ProviderAddTemplate) -> Option<&'static s
         | ProviderAddTemplate::OpenaiOfficial
         | ProviderAddTemplate::GoogleOauth => Some("official"),
         ProviderAddTemplate::Deepseek => Some("cn_official"),
+        ProviderAddTemplate::Atlascloud => Some("aggregator"),
         ProviderAddTemplate::Runapi | ProviderAddTemplate::Qiniu | ProviderAddTemplate::Fenno => {
             Some("aggregator")
         }
@@ -674,6 +695,18 @@ fn template_default_meta(
             }),
             ..Default::default()
         }),
+        ProviderAddTemplate::Atlascloud => Some(ProviderMeta {
+            api_format: Some("openai_chat".to_string()),
+            codex_chat_reasoning: Some(CodexChatReasoningConfig {
+                supports_thinking: Some(false),
+                supports_effort: Some(false),
+                thinking_param: Some("none".to_string()),
+                effort_param: Some("none".to_string()),
+                effort_value_mode: None,
+                output_format: Some("auto".to_string()),
+            }),
+            ..Default::default()
+        }),
         ProviderAddTemplate::GoogleOauth => Some(ProviderMeta {
             partner_promotion_key: Some("google-official".to_string()),
             ..Default::default()
@@ -702,6 +735,7 @@ fn template_default_meta(
 
 fn template_default_icon(template: ProviderAddTemplate) -> Option<&'static str> {
     match template {
+        ProviderAddTemplate::Atlascloud => Some("atlascloud"),
         ProviderAddTemplate::Deepseek => Some("deepseek"),
         ProviderAddTemplate::Runapi => Some("runapi"),
         ProviderAddTemplate::Qiniu => Some("qiniu"),
@@ -721,6 +755,7 @@ fn template_default_icon(template: ProviderAddTemplate) -> Option<&'static str> 
 
 fn template_default_icon_color(template: ProviderAddTemplate) -> Option<&'static str> {
     match template {
+        ProviderAddTemplate::Atlascloud => Some("#2563EB"),
         ProviderAddTemplate::Deepseek => Some("#1E88E5"),
         ProviderAddTemplate::Custom
         | ProviderAddTemplate::ClaudeOfficial
@@ -760,6 +795,7 @@ fn build_provider_template_settings_config(
             }
         })),
         ProviderAddTemplate::OpenaiOfficial => build_codex_official_settings_config(None),
+        ProviderAddTemplate::Atlascloud => Ok(build_codex_atlascloud_settings_config()),
         ProviderAddTemplate::Deepseek => Ok(build_codex_deepseek_settings_config()),
         ProviderAddTemplate::GoogleOauth => Ok(json!({ "env": {} })),
         ProviderAddTemplate::Claudeapi
@@ -776,6 +812,26 @@ fn build_provider_template_settings_config(
         ),
         ProviderAddTemplate::Custom => Err(unsupported_template_error(template)),
     }
+}
+
+fn build_codex_atlascloud_settings_config() -> Value {
+    json!({
+        "config": ATLASCLOUD_CODEX_CONFIG,
+        "modelCatalog": {
+            "models": [
+                {
+                    "model": "qwen/qwen3.5-flash",
+                    "displayName": "Qwen3.5 Flash",
+                    "contextWindow": 1000000,
+                },
+                {
+                    "model": "deepseek-ai/deepseek-v4-pro",
+                    "displayName": "DeepSeek V4 Pro",
+                    "contextWindow": 1000000,
+                },
+            ],
+        },
+    })
 }
 
 fn build_codex_deepseek_settings_config() -> Value {
@@ -1458,6 +1514,7 @@ requires_openai_auth = true
                 "* PackyCode",
                 "* AICodeMirror",
                 "* DDS",
+                "Atlas Cloud",
                 "DeepSeek",
             ]
         );
@@ -1914,6 +1971,85 @@ requires_openai_auth = true
                 .as_ref()
                 .and_then(|meta| meta.partner_promotion_key.as_deref()),
             Some("google-official")
+        );
+    }
+
+    #[test]
+    fn cli_codex_atlascloud_template_matches_openai_compatible_preset_values() {
+        let provider =
+            build_provider_template_seed(&AppType::Codex, ProviderAddTemplate::Atlascloud, &[])
+                .expect("build Atlas Cloud Codex provider");
+
+        assert_eq!(provider.id, "atlas-cloud");
+        assert_eq!(provider.name, "Atlas Cloud");
+        assert_eq!(
+            provider.website_url.as_deref(),
+            Some("https://www.atlascloud.ai")
+        );
+        assert_eq!(provider.category.as_deref(), Some("aggregator"));
+        assert_eq!(provider.icon.as_deref(), Some("atlascloud"));
+        assert_eq!(provider.icon_color.as_deref(), Some("#2563EB"));
+        assert!(
+            provider.settings_config.get("auth").is_none(),
+            "Atlas Cloud preset should use ATLASCLOUD_API_KEY from env, not persist an API key snapshot"
+        );
+
+        let config = provider
+            .settings_config
+            .get("config")
+            .and_then(Value::as_str)
+            .expect("Atlas Cloud Codex config should be TOML string");
+        assert!(config.contains("model_provider = \"atlascloud\""));
+        assert!(config.contains("model = \"qwen/qwen3.5-flash\""));
+        assert!(config.contains("disable_response_storage = true"));
+        assert!(config.contains("[model_providers.atlascloud]"));
+        assert!(config.contains("name = \"Atlas Cloud\""));
+        assert!(config.contains("base_url = \"https://api.atlascloud.ai/v1\""));
+        assert!(config.contains("wire_api = \"responses\""));
+        assert!(config.contains("requires_openai_auth = false"));
+        assert!(config.contains("env_key = \"ATLASCLOUD_API_KEY\""));
+
+        assert_eq!(
+            provider.settings_config["modelCatalog"],
+            json!({
+                "models": [
+                    {
+                        "model": "qwen/qwen3.5-flash",
+                        "displayName": "Qwen3.5 Flash",
+                        "contextWindow": 1000000,
+                    },
+                    {
+                        "model": "deepseek-ai/deepseek-v4-pro",
+                        "displayName": "DeepSeek V4 Pro",
+                        "contextWindow": 1000000,
+                    },
+                ],
+            })
+        );
+
+        let meta = provider
+            .meta
+            .expect("Atlas Cloud metadata should be present");
+        assert_eq!(meta.api_format.as_deref(), Some("openai_chat"));
+        let reasoning = meta
+            .codex_chat_reasoning
+            .expect("Atlas Cloud reasoning metadata should be present");
+        assert_eq!(reasoning.supports_thinking, Some(false));
+        assert_eq!(reasoning.supports_effort, Some(false));
+        assert_eq!(reasoning.thinking_param.as_deref(), Some("none"));
+        assert_eq!(reasoning.effort_param.as_deref(), Some("none"));
+        assert_eq!(reasoning.output_format.as_deref(), Some("auto"));
+        assert!(
+            reasoning.effort_value_mode.is_none(),
+            "Atlas Cloud should not use provider-specific reasoning effort mapping"
+        );
+        assert!(
+            meta.is_partner.is_none(),
+            "Atlas Cloud should not be flagged as a sponsor/partner preset"
+        );
+        assert!(
+            meta.partner_promotion_key.is_none(),
+            "Atlas Cloud should not carry partner promotion metadata"
         );
     }
 

--- a/src-tauri/src/cli/tui/form/provider_templates.rs
+++ b/src-tauri/src/cli/tui/form/provider_templates.rs
@@ -18,12 +18,25 @@ base_url = "https://api.deepseek.com"
 wire_api = "responses"
 requires_openai_auth = true"#;
 
+const ATLASCLOUD_CODEX_CONFIG: &str = r#"model_provider = "atlascloud"
+model = "qwen/qwen3.5-flash"
+model_reasoning_effort = "high"
+disable_response_storage = true
+
+[model_providers.atlascloud]
+name = "Atlas Cloud"
+base_url = "https://api.atlascloud.ai/v1"
+wire_api = "responses"
+requires_openai_auth = false
+env_key = "ATLASCLOUD_API_KEY""#;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ProviderTemplateId {
     Custom,
     ClaudeOfficial,
     CodexOAuth,
     OpenAiOfficial,
+    AtlasCloud,
     DeepSeek,
     GoogleOAuth,
 }
@@ -262,11 +275,16 @@ static PROVIDER_TEMPLATE_DEFS_CODEX: [ProviderTemplateDef; 2] = [
     },
 ];
 
-static PROVIDER_TEMPLATE_DEFS_CODEX_AFTER_SPONSORS: [ProviderTemplateDef; 1] =
-    [ProviderTemplateDef {
+static PROVIDER_TEMPLATE_DEFS_CODEX_AFTER_SPONSORS: [ProviderTemplateDef; 2] = [
+    ProviderTemplateDef {
+        id: ProviderTemplateId::AtlasCloud,
+        label: "Atlas Cloud",
+    },
+    ProviderTemplateDef {
         id: ProviderTemplateId::DeepSeek,
         label: "DeepSeek",
-    }];
+    },
+];
 
 static PROVIDER_TEMPLATE_DEFS_GEMINI: [ProviderTemplateDef; 2] = [
     ProviderTemplateDef {
@@ -660,6 +678,72 @@ impl ProviderAddFormState {
                     self.codex_requires_openai_auth = true;
                     self.codex_env_key.set("");
                     self.reset_codex_local_routing_state();
+                }
+                ProviderTemplateId::AtlasCloud => {
+                    self.extra = json!({
+                        "category": "aggregator",
+                        "icon": "atlascloud",
+                        "iconColor": "#2563EB",
+                        "meta": {
+                            "apiFormat": "openai_chat",
+                            "codexChatReasoning": {
+                                "supportsThinking": false,
+                                "supportsEffort": false,
+                                "thinkingParam": "none",
+                                "effortParam": "none",
+                                "outputFormat": "auto",
+                            },
+                        },
+                        "settingsConfig": {
+                            "config": ATLASCLOUD_CODEX_CONFIG,
+                            "modelCatalog": {
+                                "models": [
+                                    {
+                                        "model": "qwen/qwen3.5-flash",
+                                        "displayName": "Qwen3.5 Flash",
+                                        "contextWindow": 1000000,
+                                    },
+                                    {
+                                        "model": "deepseek-ai/deepseek-v4-pro",
+                                        "displayName": "DeepSeek V4 Pro",
+                                        "contextWindow": 1000000,
+                                    },
+                                ],
+                            },
+                        },
+                    });
+                    self.name.set("Atlas Cloud");
+                    self.website_url.set("https://www.atlascloud.ai");
+                    self.codex_api_key.set("");
+                    self.codex_base_url.set("https://api.atlascloud.ai/v1");
+                    self.codex_model.set("qwen/qwen3.5-flash");
+                    self.codex_wire_api = CodexWireApi::Responses;
+                    self.codex_requires_openai_auth = false;
+                    self.codex_env_key.set("ATLASCLOUD_API_KEY");
+                    self.claude_api_format = ClaudeApiFormat::OpenAiChat;
+                    self.codex_chat_reasoning = CodexChatReasoningConfig {
+                        supports_thinking: Some(false),
+                        supports_effort: Some(false),
+                        thinking_param: Some("none".to_string()),
+                        effort_param: Some("none".to_string()),
+                        effort_value_mode: None,
+                        output_format: Some("auto".to_string()),
+                    };
+                    self.codex_model_catalog = vec![
+                        CodexModelCatalogRow {
+                            model: "qwen/qwen3.5-flash".to_string(),
+                            display_name: "Qwen3.5 Flash".to_string(),
+                            context_window: "1000000".to_string(),
+                        },
+                        CodexModelCatalogRow {
+                            model: "deepseek-ai/deepseek-v4-pro".to_string(),
+                            display_name: "DeepSeek V4 Pro".to_string(),
+                            context_window: "1000000".to_string(),
+                        },
+                    ];
+                    self.codex_local_routing_field_idx = 0;
+                    self.codex_model_catalog_idx = 0;
+                    self.codex_model_catalog_field = CodexModelCatalogField::Model;
                 }
                 ProviderTemplateId::DeepSeek => {
                     self.extra = json!({

--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -39,6 +39,10 @@ fn deepseek_template_index(app_type: AppType) -> usize {
     template_index_by_label(app_type, "DeepSeek")
 }
 
+fn atlascloud_template_index(app_type: AppType) -> usize {
+    template_index_by_label(app_type, "Atlas Cloud")
+}
+
 fn normalize_template_provider_json(mut value: serde_json::Value) -> serde_json::Value {
     if let Some(obj) = value.as_object_mut() {
         obj.remove("inFailoverQueue");
@@ -127,6 +131,7 @@ fn provider_add_form_template_labels_follow_explicit_support_matrix() {
             "* PackyCode",
             "* AICodeMirror",
             "* DDS",
+            "Atlas Cloud",
             "DeepSeek",
         ]
     );
@@ -258,9 +263,83 @@ fn cli_provider_templates_match_tui_serializer_output() {
         (AppType::OpenCode, ProviderAddTemplate::Fenno, "* FennoAI"),
         (AppType::Hermes, ProviderAddTemplate::Fenno, "* FennoAI"),
         (AppType::OpenClaw, ProviderAddTemplate::Fenno, "* FennoAI"),
+        (
+            AppType::Codex,
+            ProviderAddTemplate::Atlascloud,
+            "Atlas Cloud",
+        ),
     ] {
         assert_cli_template_matches_tui_serializer(app_type, template, label);
     }
+}
+
+#[test]
+fn provider_add_form_codex_atlascloud_template_matches_openai_compatible_preset_values() {
+    let mut form = ProviderAddFormState::new(AppType::Codex);
+
+    form.apply_template(atlascloud_template_index(AppType::Codex), &[]);
+
+    assert_eq!(form.id.value, "atlas-cloud");
+    assert_eq!(form.name.value, "Atlas Cloud");
+    assert_eq!(form.website_url.value, "https://www.atlascloud.ai");
+    assert_eq!(form.codex_base_url.value, "https://api.atlascloud.ai/v1");
+    assert_eq!(form.codex_model.value, "qwen/qwen3.5-flash");
+    assert_eq!(form.codex_wire_api, CodexWireApi::Responses);
+    assert!(!form.codex_requires_openai_auth);
+    assert_eq!(form.codex_env_key.value, "ATLASCLOUD_API_KEY");
+
+    let provider = form.to_provider_json_value();
+    assert_eq!(provider["category"], "aggregator");
+    assert_eq!(provider["icon"], "atlascloud");
+    assert_eq!(provider["iconColor"], "#2563EB");
+    assert_eq!(provider["meta"]["apiFormat"], "openai_chat");
+    assert_eq!(
+        provider["meta"]["codexChatReasoning"],
+        json!({
+            "supportsThinking": false,
+            "supportsEffort": false,
+            "thinkingParam": "none",
+            "effortParam": "none",
+            "outputFormat": "auto",
+        })
+    );
+    assert!(
+        provider["meta"].get("isPartner").is_none(),
+        "Atlas Cloud preset should stay a normal provider template, not a sponsor preset"
+    );
+    assert!(
+        provider["meta"].get("partnerPromotionKey").is_none(),
+        "Atlas Cloud preset should not carry partner promotion metadata"
+    );
+
+    let cfg = provider["settingsConfig"]["config"]
+        .as_str()
+        .expect("settingsConfig.config should be TOML string");
+    assert!(cfg.contains("model_provider = \"atlascloud\""));
+    assert!(cfg.contains("model = \"qwen/qwen3.5-flash\""));
+    assert!(cfg.contains("[model_providers.atlascloud]"));
+    assert!(cfg.contains("name = \"Atlas Cloud\""));
+    assert!(cfg.contains("base_url = \"https://api.atlascloud.ai/v1\""));
+    assert!(cfg.contains("wire_api = \"responses\""));
+    assert!(cfg.contains("requires_openai_auth = false"));
+    assert!(cfg.contains("env_key = \"ATLASCLOUD_API_KEY\""));
+    assert_eq!(
+        provider["settingsConfig"]["modelCatalog"],
+        json!({
+            "models": [
+                {
+                    "model": "qwen/qwen3.5-flash",
+                    "displayName": "Qwen3.5 Flash",
+                    "contextWindow": 1000000,
+                },
+                {
+                    "model": "deepseek-ai/deepseek-v4-pro",
+                    "displayName": "DeepSeek V4 Pro",
+                    "contextWindow": 1000000,
+                },
+            ],
+        })
+    );
 }
 
 #[test]

--- a/src-tauri/src/provider_defaults.rs
+++ b/src-tauri/src/provider_defaults.rs
@@ -58,6 +58,20 @@ pub static DEFAULT_PROVIDER_ICONS: Lazy<HashMap<&'static str, ProviderIcon>> = L
         },
     );
     m.insert(
+        "atlascloud",
+        ProviderIcon {
+            name: "atlascloud",
+            color: "#2563EB",
+        },
+    );
+    m.insert(
+        "atlas cloud",
+        ProviderIcon {
+            name: "atlascloud",
+            color: "#2563EB",
+        },
+    );
+    m.insert(
         "kimi",
         ProviderIcon {
             name: "kimi",
@@ -228,6 +242,15 @@ mod tests {
         let icon = infer_provider_icon("ANTHROPIC");
         assert!(icon.is_some());
         assert_eq!(icon.unwrap().name, "anthropic");
+    }
+
+    #[test]
+    fn test_atlascloud_aliases() {
+        let icon = infer_provider_icon("Atlas Cloud");
+        assert!(icon.is_some());
+        let icon = icon.unwrap();
+        assert_eq!(icon.name, "atlascloud");
+        assert_eq!(icon.color, "#2563EB");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Atlas Cloud as a built-in Codex OpenAI-compatible provider template
- configure the preset with `ATLASCLOUD_API_KEY`, `https://api.atlascloud.ai/v1`, and a live-verified default model catalog
- add matching CLI/TUI serialization tests plus provider icon inference
- update the local proxy provider sentence in the existing English/Chinese docs

## Notes
This keeps Atlas Cloud as a regular provider template. It does not add sponsor, partner, logo, credits, or promotion metadata, and it does not change the existing sponsor sections.

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml atlascloud -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml cli_provider_templates_match_tui_serializer_output -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml provider_add_form_template_labels_follow_explicit_support_matrix -- --nocapture`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- live Atlas Cloud model catalog check confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`
