### PR TITLE
fix(codex): inject unified session bucket on official live write

### DIFF
--- a/src-tauri/src/services/provider/codex.rs
+++ b/src-tauri/src/services/provider/codex.rs
@@ -510,9 +510,19 @@ impl ProviderService {
                 profile,
             )?;
         let is_official = Self::codex_live_write_category(provider) == Some("official");
-        // Mirror upstream write_codex_live_for_provider: official providers own
-        // auth.json; third-party providers write auth.json unless
-        // preserve_codex_official_auth_on_switch is set (then auth.json is
+        // Align with write_codex_live_for_provider (and upstream farion1231/cc-switch):
+        // when unified Codex session history is enabled, rewrite official live
+        // config through the shared `custom` model_provider bucket so third-party
+        // sessions remain resumeable. Provider DB templates stay clean (stripped
+        // on backfill); only ~/.codex/config.toml is injected.
+        let live_config_text = if is_official && crate::settings::unify_codex_session_history() {
+            crate::codex_config::inject_codex_unified_session_bucket(&prepared_config.config_text)?
+        } else {
+            prepared_config.config_text.clone()
+        };
+
+        // Official providers own auth.json; third-party providers write auth.json
+        // unless preserve_codex_official_auth_on_switch is set (then auth.json is
         // preserved and the API key rides in config.toml's bearer token).
         let should_write_auth = is_official
             || (!force_sync && !crate::settings::preserve_codex_official_auth_on_switch());
@@ -537,12 +547,9 @@ impl ProviderService {
         // When auth.json is preserved (third-party + preserve flag) the API key
         // is injected into config.toml as an experimental_bearer_token instead.
         let config_text = if should_write_auth {
-            prepared_config.config_text.clone()
+            live_config_text
         } else {
-            crate::codex_config::prepare_codex_provider_live_config(
-                &write_auth,
-                &prepared_config.config_text,
-            )?
+            crate::codex_config::prepare_codex_provider_live_config(&write_auth, &live_config_text)?
         };
 
         // auth.json follows Preserve/Write/Delete (no merge): a switch always


### PR DESCRIPTION
## Summary
- `settings codex-history enable` / provider switch reapply go through `prepare_codex_live_write`, which never called `inject_codex_unified_session_bucket`.
- Result: with `unifyCodexSessionHistory=true` and current provider `codex-official`, live `~/.codex/config.toml` stayed without `[model_providers.custom]`, so resuming sessions saved under `model_provider: "custom"` failed with `Model provider \`custom\` not found`.
- Align the live-write path with `write_codex_live_for_provider` and upstream [farion1231/cc-switch](https://github.com/farion1231/cc-switch): inject the shared custom OAuth stub **only into live config** when the provider is official and the unify toggle is on. Stored provider templates remain clean (still stripped on backfill).

## Approach (minimal / non-invasive)
- Do **not** rewrite historical session jsonl by default.
- Do **not** pollute official provider DB `settings_config`.
- Only when writing live `config.toml` for the official provider under the existing unify toggle, inject:

```toml
model_provider = "custom"

[model_providers.custom]
name = "OpenAI"
requires_openai_auth = true
supports_websockets = true
wire_api = "responses"
```

Auth still uses `auth.json` ChatGPT OAuth (`requires_openai_auth = true`).

## farion1231/cc-switch
Checked: that repo's live path is  
`write_live_snapshot` → `write_codex_provider_live_with_catalog` → `write_codex_live_for_provider` → **inject**.  
Backfill still strips the injection from stored official templates. **No equivalent bug there**; no PR needed for the GUI repo.

## Test plan
- [ ] Build CLI and run with `unifyCodexSessionHistory=true`, current provider `codex-official`
- [ ] `cc-switch settings codex-history disable && cc-switch settings codex-history enable` (or re-switch to official)
- [ ] Confirm `~/.codex/config.toml` gains `model_provider = "custom"` and `[model_providers.custom]` stub
- [ ] Resume a session whose `session_meta.payload.model_provider` is `"custom"` — should no longer error
- [ ] Disable unify toggle and re-switch official — stub should be gone; third-party provider switch still writes its own provider id
- [ ] Official provider DB template still has no `model_provider` after switch-away backfill