### PR TITLE
feat(proxy): inject prompt_cache_key for Codex Chat providers

### DIFF
--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -1955,6 +1955,25 @@ pub mod texts {
         }
     }
 
+    pub fn tui_label_codex_prompt_cache_routing() -> &'static str {
+        if is_chinese() {
+            "提示词缓存路由"
+        } else {
+            "Prompt cache routing"
+        }
+    }
+
+    pub fn tui_codex_prompt_cache_routing_value(mode: &str) -> &'static str {
+        match (is_chinese(), mode) {
+            (true, "enabled") => "开启",
+            (true, "disabled") => "关闭",
+            (true, _) => "自动（推荐）",
+            (false, "enabled") => "Enabled",
+            (false, "disabled") => "Disabled",
+            (false, _) => "Auto (recommended)",
+        }
+    }
+
     pub fn tui_label_codex_model_mapping() -> &'static str {
         if is_chinese() {
             "模型映射"

--- a/src-tauri/src/cli/tui/app/form_handlers/provider.rs
+++ b/src-tauri/src/cli/tui/app/form_handlers/provider.rs
@@ -345,6 +345,16 @@ impl App {
                 };
                 Action::None
             }
+            ProviderAddField::CodexPromptCacheRouting => {
+                if !matches!(key.code, KeyCode::Enter) {
+                    return Action::None;
+                }
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return Action::None;
+                };
+                provider.cycle_codex_prompt_cache_routing();
+                Action::None
+            }
             ProviderAddField::CodexWireApi => {
                 if !matches!(key.code, KeyCode::Enter) {
                     return Action::None;

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -21,7 +21,8 @@ mod tests {
     use crate::cli::tui::data::ProviderRow;
     use crate::cli::tui::form::{
         CodexLocalRoutingField, CodexModelCatalogField, CodexPreviewSection, McpEnvVarRow,
-        McpTransport, ProviderAddFormState, TextInput, UsageQueryField, UsageQueryTemplate,
+        McpTransport, PromptCacheRoutingMode, ProviderAddFormState, TextInput, UsageQueryField,
+        UsageQueryTemplate,
     };
     use crate::cli::tui::runtime_actions::{
         handle_action, run_external_editor_for_prompt_form_content,
@@ -13207,6 +13208,30 @@ mod tests {
     }
 
     #[test]
+    fn provider_codex_prompt_cache_routing_enter_cycles_and_space_is_noop() {
+        let mut app = App::new(Some(AppType::Codex));
+        let mut form = ProviderAddFormState::new(AppType::Codex);
+        form.focus = FormFocus::Fields;
+        form.claude_api_format = super::super::form::ClaudeApiFormat::OpenAiChat;
+        app.form = Some(FormState::ProviderAdd(form));
+        select_provider_field(&mut app, ProviderAddField::CodexPromptCacheRouting);
+
+        app.on_key(key(KeyCode::Char(' ')), &data());
+        let mode = |app: &App| match app.form.as_ref() {
+            Some(FormState::ProviderAdd(form)) => form.codex_prompt_cache_routing,
+            other => panic!("expected ProviderAdd form, got: {other:?}"),
+        };
+        assert_eq!(mode(&app), PromptCacheRoutingMode::Auto);
+
+        app.on_key(key(KeyCode::Enter), &data());
+        assert_eq!(mode(&app), PromptCacheRoutingMode::Enabled);
+        app.on_key(key(KeyCode::Enter), &data());
+        assert_eq!(mode(&app), PromptCacheRoutingMode::Disabled);
+        app.on_key(key(KeyCode::Enter), &data());
+        assert_eq!(mode(&app), PromptCacheRoutingMode::Auto);
+    }
+
+    #[test]
     fn provider_codex_local_routing_model_catalog_edits_inline_and_adds_models() {
         let mut app = App::new(Some(AppType::Codex));
         app.route = Route::Providers;
@@ -14830,6 +14855,24 @@ mod tests {
         assert!(text.contains("Upstream format"), "{text}");
         assert!(text.contains("natively Responses API"), "{text}");
         assert!(!text.contains("上游格式"), "{text}");
+    }
+
+    #[test]
+    fn context_help_codex_prompt_cache_routing_explains_three_modes() {
+        let _lang = use_test_language(Language::English);
+        let mut app = App::new(Some(AppType::Codex));
+        let mut form = ProviderAddFormState::new(AppType::Codex);
+        form.claude_api_format = super::super::form::ClaudeApiFormat::OpenAiChat;
+        app.form = Some(FormState::ProviderAdd(form));
+        select_provider_field(&mut app, ProviderAddField::CodexPromptCacheRouting);
+
+        app.on_key(key(KeyCode::Char('?')), &UiData::default());
+        let text = help_text(&app);
+        assert!(text.contains("Prompt cache routing"), "{text}");
+        assert!(text.contains("known-compatible upstreams"), "{text}");
+        assert!(text.contains("strict gateway"), "{text}");
+        assert!(text.contains("stable client-provided session ID"), "{text}");
+        assert!(!text.contains("提示词缓存路由"), "{text}");
     }
 
     #[test]

--- a/src-tauri/src/cli/tui/form.rs
+++ b/src-tauri/src/cli/tui/form.rs
@@ -166,6 +166,39 @@ impl ClaudeApiFormat {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptCacheRoutingMode {
+    Auto,
+    Enabled,
+    Disabled,
+}
+
+impl PromptCacheRoutingMode {
+    pub fn from_raw(value: &str) -> Self {
+        match value {
+            "enabled" => Self::Enabled,
+            "disabled" => Self::Disabled,
+            _ => Self::Auto,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Enabled => "enabled",
+            Self::Disabled => "disabled",
+        }
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            Self::Auto => Self::Enabled,
+            Self::Enabled => Self::Disabled,
+            Self::Disabled => Self::Auto,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FormFocus {
     Templates,
     Fields,
@@ -227,6 +260,7 @@ pub enum ProviderAddField {
     #[allow(dead_code)]
     CodexModel,
     CodexAdvancedDivider,
+    CodexPromptCacheRouting,
     CodexLocalRouting,
     CodexQuickConfig,
     CodexGoalMode,
@@ -523,6 +557,7 @@ pub struct ProviderAddFormState {
     pub codex_env_key: TextInput,
     pub codex_api_key: TextInput,
     pub codex_chat_reasoning: CodexChatReasoningConfig,
+    pub codex_prompt_cache_routing: PromptCacheRoutingMode,
     pub codex_model_catalog: Vec<CodexModelCatalogRow>,
     /// Independent "需要本地路由映射" toggle (decoupled from the upstream
     /// format, mirroring upstream a4eb5f37). Gates model-mapping / reasoning

--- a/src-tauri/src/cli/tui/form/provider_json.rs
+++ b/src-tauri/src/cli/tui/form/provider_json.rs
@@ -7,8 +7,8 @@ use std::collections::HashSet;
 use super::codex_config::{build_codex_third_party_config_toml, update_codex_config_snippet};
 use super::{
     normalize_local_proxy_header_overrides, parse_codex_model_catalog_context_window,
-    ClaudeApiFormat, GeminiAuthType, ProviderAddFormState, UsageQueryTemplate,
-    OPENCLAW_DEFAULT_API_PROTOCOL, OPENCLAW_DEFAULT_USER_AGENT,
+    ClaudeApiFormat, GeminiAuthType, PromptCacheRoutingMode, ProviderAddFormState,
+    UsageQueryTemplate, OPENCLAW_DEFAULT_API_PROTOCOL, OPENCLAW_DEFAULT_USER_AGENT,
 };
 
 impl ProviderAddFormState {
@@ -580,6 +580,12 @@ impl ProviderAddFormState {
             && !self.is_claude_official_provider();
         let should_write_codex_api_format =
             matches!(self.app_type, AppType::Codex) && !self.is_codex_official_provider();
+        let should_write_prompt_cache_routing = should_write_codex_api_format
+            && self.codex_is_chat_format()
+            && !matches!(
+                self.codex_prompt_cache_routing,
+                PromptCacheRoutingMode::Auto
+            );
         let should_write_claude_api_key_field = matches!(self.app_type, AppType::Claude)
             && !self.is_claude_official_provider()
             && !self.is_claude_codex_oauth_provider()
@@ -597,6 +603,7 @@ impl ProviderAddFormState {
         if !should_write_common_config_meta
             && !should_write_claude_api_format
             && !should_write_codex_api_format
+            && !should_write_prompt_cache_routing
             && !should_write_claude_api_key_field
             && !is_codex_oauth
             && !should_write_local_proxy_settings
@@ -663,6 +670,7 @@ impl ProviderAddFormState {
             if self.is_codex_official_provider() {
                 meta_obj.remove("apiFormat");
                 meta_obj.remove("codexChatReasoning");
+                meta_obj.remove("promptCacheRouting");
             } else {
                 let api_format = match self.claude_api_format {
                     ClaudeApiFormat::OpenAiChat => "openai_chat",
@@ -681,6 +689,15 @@ impl ProviderAddFormState {
                     }
                 } else {
                     meta_obj.remove("codexChatReasoning");
+                }
+
+                if should_write_prompt_cache_routing {
+                    meta_obj.insert(
+                        "promptCacheRouting".to_string(),
+                        json!(self.codex_prompt_cache_routing.as_str()),
+                    );
+                } else {
+                    meta_obj.remove("promptCacheRouting");
                 }
             }
         }

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -15,9 +15,10 @@ use super::provider_state_loading::populate_form_from_provider;
 use super::{
     ClaudeApiFormat, CodexLocalRoutingField, CodexModelCatalogField, CodexModelCatalogRow,
     CodexPreviewSection, CodexWireApi, FormFocus, FormMode, GeminiAuthType, HermesModelField,
-    InlineFieldError, LocalProxySettingsField, ProviderAddField, ProviderAddFormState,
-    ProviderFormPage, ProviderTextField, TextEditSession, TextInput, UsageQueryField,
-    UsageQueryTemplate, HERMES_API_MODES, HERMES_DEFAULT_API_MODE, OPENCLAW_DEFAULT_API_PROTOCOL,
+    InlineFieldError, LocalProxySettingsField, PromptCacheRoutingMode, ProviderAddField,
+    ProviderAddFormState, ProviderFormPage, ProviderTextField, TextEditSession, TextInput,
+    UsageQueryField, UsageQueryTemplate, HERMES_API_MODES, HERMES_DEFAULT_API_MODE,
+    OPENCLAW_DEFAULT_API_PROTOCOL,
 };
 
 fn provider_copy_id(original_id: &str, existing_ids: &[String]) -> String {
@@ -205,6 +206,7 @@ impl ProviderAddFormState {
             codex_env_key: TextInput::new("OPENAI_API_KEY"),
             codex_api_key: TextInput::new(""),
             codex_chat_reasoning: CodexChatReasoningConfig::default(),
+            codex_prompt_cache_routing: PromptCacheRoutingMode::Auto,
             codex_model_catalog: Vec::new(),
             codex_local_routing_enabled: false,
             custom_user_agent: TextInput::new(""),
@@ -431,6 +433,9 @@ impl ProviderAddFormState {
                     // Upstream format is an independent picker; local routing /
                     // model mapping is decoupled from it.
                     fields.push(ProviderAddField::ClaudeApiFormat);
+                    if self.codex_is_chat_format() {
+                        fields.push(ProviderAddField::CodexPromptCacheRouting);
+                    }
                     fields.push(ProviderAddField::CodexLocalRouting);
                     fields.push(ProviderAddField::LocalProxySettings);
                 }
@@ -604,6 +609,7 @@ impl ProviderAddFormState {
             ProviderAddField::HermesRateLimitDelay => Some(&self.hermes_rate_limit_delay),
             ProviderAddField::CodexOAuthAccount
             | ProviderAddField::CodexFastMode
+            | ProviderAddField::CodexPromptCacheRouting
             | ProviderAddField::CodexLocalRouting
             | ProviderAddField::LocalProxySettings
             | ProviderAddField::CodexQuickConfig
@@ -667,6 +673,7 @@ impl ProviderAddFormState {
             ProviderAddField::HermesRateLimitDelay => Some(&mut self.hermes_rate_limit_delay),
             ProviderAddField::CodexOAuthAccount
             | ProviderAddField::CodexFastMode
+            | ProviderAddField::CodexPromptCacheRouting
             | ProviderAddField::CodexLocalRouting
             | ProviderAddField::LocalProxySettings
             | ProviderAddField::CodexQuickConfig
@@ -1306,6 +1313,10 @@ impl ProviderAddFormState {
         self.codex_local_routing_field_idx = self
             .codex_local_routing_field_idx
             .min(len.saturating_sub(1));
+    }
+
+    pub fn cycle_codex_prompt_cache_routing(&mut self) {
+        self.codex_prompt_cache_routing = self.codex_prompt_cache_routing.next();
     }
 
     pub fn toggle_codex_reasoning_thinking(&mut self) {

--- a/src-tauri/src/cli/tui/form/provider_state_loading.rs
+++ b/src-tauri/src/cli/tui/form/provider_state_loading.rs
@@ -4,8 +4,8 @@ use super::{
     claude_disable_auto_upgrade_enabled, claude_hide_attribution_enabled, claude_teammates_enabled,
     claude_tool_search_enabled, detect_balance_provider_for_usage_query,
     detect_coding_plan_provider_for_usage_query, normalize_local_proxy_header_overrides,
-    ClaudeApiFormat, CodexWireApi, ProviderAddFormState, UsageQueryTemplate,
-    OPENCLAW_DEFAULT_API_PROTOCOL,
+    ClaudeApiFormat, CodexWireApi, PromptCacheRoutingMode, ProviderAddFormState,
+    UsageQueryTemplate, OPENCLAW_DEFAULT_API_PROTOCOL,
 };
 use crate::app_config::AppType;
 use crate::provider::Provider;
@@ -236,6 +236,12 @@ fn populate_codex_form(form: &mut ProviderAddFormState, provider: &Provider) {
         .as_ref()
         .and_then(|meta| meta.codex_chat_reasoning.clone())
         .unwrap_or_default();
+    form.codex_prompt_cache_routing = provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.prompt_cache_routing.as_deref())
+        .map(PromptCacheRoutingMode::from_raw)
+        .unwrap_or(PromptCacheRoutingMode::Auto);
     form.codex_model_catalog = provider
         .settings_config
         .get("modelCatalog")

--- a/src-tauri/src/cli/tui/form/provider_templates.rs
+++ b/src-tauri/src/cli/tui/form/provider_templates.rs
@@ -4,7 +4,8 @@ use serde_json::{json, Value};
 
 use super::{
     ClaudeApiFormat, CodexModelCatalogField, CodexModelCatalogRow, CodexWireApi, FormMode,
-    GeminiAuthType, ProviderAddFormState, HERMES_DEFAULT_API_MODE, OPENCLAW_DEFAULT_API_PROTOCOL,
+    GeminiAuthType, PromptCacheRoutingMode, ProviderAddFormState, HERMES_DEFAULT_API_MODE,
+    OPENCLAW_DEFAULT_API_PROTOCOL,
 };
 
 const DEEPSEEK_CODEX_CONFIG: &str = r#"model_provider = "custom"
@@ -487,6 +488,9 @@ impl ProviderAddFormState {
         self.clear_text_edit();
         self.id_is_manual = false;
         self.reset_local_proxy_settings_state();
+        if matches!(self.app_type, AppType::Codex) {
+            self.codex_prompt_cache_routing = PromptCacheRoutingMode::Auto;
+        }
 
         if idx >= builtin_defs.len() && idx < builtin_defs.len() + sponsor_presets.len() {
             let sponsor_idx = idx.saturating_sub(builtin_defs.len());
@@ -549,6 +553,7 @@ impl ProviderAddFormState {
                     self.codex_env_key = defaults.codex_env_key;
                     self.codex_api_key = defaults.codex_api_key;
                     self.codex_chat_reasoning = defaults.codex_chat_reasoning;
+                    self.codex_prompt_cache_routing = defaults.codex_prompt_cache_routing;
                     self.codex_model_catalog = defaults.codex_model_catalog;
                     self.codex_local_routing_enabled = defaults.codex_local_routing_enabled;
                     self.codex_goal_mode = defaults.codex_goal_mode;
@@ -996,6 +1001,7 @@ impl ProviderAddFormState {
     fn reset_codex_local_routing_state(&mut self) {
         self.claude_api_format = ClaudeApiFormat::OpenAiResponses;
         self.codex_chat_reasoning = CodexChatReasoningConfig::default();
+        self.codex_prompt_cache_routing = PromptCacheRoutingMode::Auto;
         self.codex_model_catalog.clear();
         self.codex_local_routing_enabled = false;
         self.codex_local_routing_field_idx = 0;

--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -1896,6 +1896,7 @@ fn provider_add_form_codex_template_switch_clears_local_routing_state() {
     form.claude_api_format = ClaudeApiFormat::OpenAiChat;
     form.codex_chat_reasoning.supports_thinking = Some(true);
     form.codex_chat_reasoning.supports_effort = Some(true);
+    form.codex_prompt_cache_routing = PromptCacheRoutingMode::Disabled;
     form.codex_local_routing_field_idx = 3;
     form.apply_codex_model_catalog_value(json!([
         { "model": "deepseek-chat", "displayName": "DeepSeek Chat" }
@@ -1912,6 +1913,10 @@ fn provider_add_form_codex_template_switch_clears_local_routing_state() {
         vec![CodexLocalRoutingField::Enabled]
     );
     assert_eq!(form.codex_chat_reasoning, Default::default());
+    assert_eq!(
+        form.codex_prompt_cache_routing,
+        PromptCacheRoutingMode::Auto
+    );
     assert!(form.codex_model_catalog.is_empty());
 
     let provider = form.to_provider_json_value();
@@ -1921,6 +1926,7 @@ fn provider_add_form_codex_template_switch_clears_local_routing_state() {
 
     form.claude_api_format = ClaudeApiFormat::OpenAiChat;
     form.codex_chat_reasoning.supports_thinking = Some(true);
+    form.codex_prompt_cache_routing = PromptCacheRoutingMode::Enabled;
     form.apply_codex_model_catalog_value(json!([{ "model": "qwen-coder" }]))
         .expect("catalog should apply");
 
@@ -1929,6 +1935,10 @@ fn provider_add_form_codex_template_switch_clears_local_routing_state() {
     assert!(form.is_codex_official_provider());
     assert!(!form.codex_local_routing_enabled());
     assert_eq!(form.codex_chat_reasoning, Default::default());
+    assert_eq!(
+        form.codex_prompt_cache_routing,
+        PromptCacheRoutingMode::Auto
+    );
     assert!(form.codex_model_catalog.is_empty());
     let official_provider = form.to_provider_json_value();
     assert!(official_provider["meta"].get("apiFormat").is_none());
@@ -2600,6 +2610,101 @@ fn provider_add_form_codex_local_routing_is_off_by_default_and_persisted() {
 
     assert!(!form.codex_local_routing_enabled());
     assert_eq!(provider["meta"]["apiFormat"], "openai_responses");
+}
+
+#[test]
+fn provider_add_form_codex_prompt_cache_routing_is_chat_only() {
+    let mut form = ProviderAddFormState::new(AppType::Codex);
+    form.id.set("custom");
+    form.name.set("Custom");
+
+    assert_eq!(
+        form.codex_prompt_cache_routing,
+        PromptCacheRoutingMode::Auto
+    );
+    assert!(!form
+        .fields()
+        .contains(&ProviderAddField::CodexPromptCacheRouting));
+    assert!(form.to_provider_json_value()["meta"]
+        .get("promptCacheRouting")
+        .is_none());
+
+    form.claude_api_format = ClaudeApiFormat::OpenAiChat;
+    assert!(!form.codex_local_routing_enabled());
+    assert!(form
+        .fields()
+        .contains(&ProviderAddField::CodexPromptCacheRouting));
+
+    form.codex_prompt_cache_routing = PromptCacheRoutingMode::Enabled;
+    let chat = form.to_provider_json_value();
+    assert_eq!(chat["meta"]["promptCacheRouting"], "enabled");
+
+    form.claude_api_format = ClaudeApiFormat::OpenAiResponses;
+    let responses = form.to_provider_json_value();
+    assert!(responses["meta"].get("promptCacheRouting").is_none());
+}
+
+#[test]
+fn provider_add_form_codex_prompt_cache_routing_round_trips_and_normalizes() {
+    let mut provider = Provider::with_id(
+        "custom".to_string(),
+        "Custom".to_string(),
+        json!({ "config": "" }),
+        None,
+    );
+    provider.meta = Some(crate::provider::ProviderMeta {
+        api_format: Some("openai_chat".to_string()),
+        prompt_cache_routing: Some("disabled".to_string()),
+        ..Default::default()
+    });
+
+    let form = ProviderAddFormState::from_provider(AppType::Codex, &provider);
+    assert_eq!(
+        form.codex_prompt_cache_routing,
+        PromptCacheRoutingMode::Disabled
+    );
+    assert_eq!(
+        form.to_provider_json_value()["meta"]["promptCacheRouting"],
+        "disabled"
+    );
+
+    provider
+        .meta
+        .as_mut()
+        .expect("meta should exist")
+        .prompt_cache_routing = Some("unexpected".to_string());
+    let normalized = ProviderAddFormState::from_provider(AppType::Codex, &provider);
+    assert_eq!(
+        normalized.codex_prompt_cache_routing,
+        PromptCacheRoutingMode::Auto
+    );
+    assert!(normalized.to_provider_json_value()["meta"]
+        .get("promptCacheRouting")
+        .is_none());
+}
+
+#[test]
+fn provider_add_form_codex_official_removes_prompt_cache_routing() {
+    let mut provider = Provider::with_id(
+        "official".to_string(),
+        "OpenAI Official".to_string(),
+        json!({ "config": "", "auth": {} }),
+        None,
+    );
+    provider.category = Some("official".to_string());
+    provider.meta = Some(crate::provider::ProviderMeta {
+        api_format: Some("openai_chat".to_string()),
+        prompt_cache_routing: Some("enabled".to_string()),
+        ..Default::default()
+    });
+
+    let form = ProviderAddFormState::from_provider(AppType::Codex, &provider);
+    assert!(!form
+        .fields()
+        .contains(&ProviderAddField::CodexPromptCacheRouting));
+    assert!(form.to_provider_json_value()["meta"]
+        .get("promptCacheRouting")
+        .is_none());
 }
 
 #[test]

--- a/src-tauri/src/cli/tui/help.rs
+++ b/src-tauri/src/cli/tui/help.rs
@@ -541,6 +541,13 @@ fn provider_field_help(app_type: AppType, field: ProviderAddField) -> HelpConten
                 "Default Codex model. Third-party non-GPT models usually need local routing.\nUpstream model mapping generates model_catalog_json so Codex /model can show third-party models. Restart Codex after catalog changes.",
             ),
         ),
+        ProviderAddField::CodexPromptCacheRouting => HelpContent::new(
+            texts::tui_label_codex_prompt_cache_routing(),
+            help_lines(
+                "仅用于 Codex Responses → Chat Completions 转换，和模型映射相互独立。\n自动（推荐）：只向已确认兼容的上游发送 prompt_cache_key；未知或自建网关默认不发送。\n开启：用于其他已确认兼容的网关。\n关闭：始终不发送；严格网关因未知字段返回 HTTP 400 时使用。\n请求自带的 key 优先，否则只使用客户端提供的稳定会话 ID。",
+                "Applies only to Codex Responses → Chat Completions conversion and is independent of model mapping.\nAuto (recommended): sends prompt_cache_key only to known-compatible upstreams; unknown or self-hosted gateways default to off.\nEnabled: use it for another gateway you know is compatible.\nDisabled: never sends it; use this if a strict gateway rejects the unknown field with HTTP 400.\nAn explicit request key wins; otherwise only a stable client-provided session ID is used.",
+            ),
+        ),
         ProviderAddField::CodexLocalRouting => HelpContent::new(
             texts::tui_label_codex_model_mapping(),
             help_lines(

--- a/src-tauri/src/cli/tui/ui/forms/provider.rs
+++ b/src-tauri/src/cli/tui/ui/forms/provider.rs
@@ -1877,6 +1877,9 @@ pub(crate) fn provider_field_label_and_value(
         ProviderAddField::CodexFastMode => texts::tui_label_codex_fast_mode().to_string(),
         ProviderAddField::CodexBaseUrl => texts::tui_label_base_url().to_string(),
         ProviderAddField::CodexModel => texts::model_label().to_string(),
+        ProviderAddField::CodexPromptCacheRouting => {
+            texts::tui_label_codex_prompt_cache_routing().to_string()
+        }
         ProviderAddField::CodexLocalRouting => texts::tui_label_codex_model_mapping().to_string(),
         ProviderAddField::CodexWireApi => {
             strip_trailing_colon(texts::codex_wire_api_label()).to_string()
@@ -1998,6 +2001,10 @@ pub(crate) fn provider_field_label_and_value(
                 "[ ]".to_string()
             }
         }
+        ProviderAddField::CodexPromptCacheRouting => texts::tui_codex_prompt_cache_routing_value(
+            provider.codex_prompt_cache_routing.as_str(),
+        )
+        .to_string(),
         ProviderAddField::CodexLocalRouting => {
             if provider.codex_local_routing_enabled {
                 format!(

--- a/src-tauri/src/cli/tui/ui/forms/shared.rs
+++ b/src-tauri/src/cli/tui/ui/forms/shared.rs
@@ -63,6 +63,7 @@ pub(crate) fn add_form_key_items(
                     ) => texts::tui_key_toggle(),
                     Some(
                         ProviderAddField::GeminiAuthType
+                        | ProviderAddField::CodexPromptCacheRouting
                         | ProviderAddField::OpenClawApiProtocol
                         | ProviderAddField::HermesApiMode,
                     ) => texts::tui_key_select(),

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -420,6 +420,9 @@ pub struct ProviderMeta {
     /// OpenAI 兼容端点使用的 prompt cache key。
     #[serde(rename = "promptCacheKey", skip_serializing_if = "Option::is_none")]
     pub prompt_cache_key: Option<String>,
+    /// Codex Chat provider prompt cache routing mode: "enabled", "disabled", or "auto".
+    #[serde(rename = "promptCacheRouting", skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_routing: Option<String>,
     /// Codex OAuth FAST mode: inject `service_tier = "priority"` for ChatGPT Codex requests.
     #[serde(rename = "codexFastMode", skip_serializing_if = "Option::is_none")]
     pub codex_fast_mode: Option<bool>,

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -420,7 +420,8 @@ pub struct ProviderMeta {
     /// OpenAI 兼容端点使用的 prompt cache key。
     #[serde(rename = "promptCacheKey", skip_serializing_if = "Option::is_none")]
     pub prompt_cache_key: Option<String>,
-    /// Codex Chat provider prompt cache routing mode: "enabled", "disabled", or "auto".
+    /// Session-based prompt-cache routing for Codex Responses -> Chat conversions.
+    /// "auto" enables known-compatible upstreams; "enabled" / "disabled" are overrides.
     #[serde(rename = "promptCacheRouting", skip_serializing_if = "Option::is_none")]
     pub prompt_cache_routing: Option<String>,
     /// Codex OAuth FAST mode: inject `service_tier = "priority"` for ChatGPT Codex requests.

--- a/src-tauri/src/proxy/forwarder/request_builder.rs
+++ b/src-tauri/src/proxy/forwarder/request_builder.rs
@@ -231,6 +231,10 @@ impl RequestForwarder {
         }
 
         let request_body = if codex_responses_to_chat {
+            let explicit_prompt_cache_key = mapped_body
+                .get("prompt_cache_key")
+                .and_then(|value| value.as_str())
+                .map(ToString::to_string);
             upstream_endpoint = rewrite_codex_responses_endpoint_to_chat(endpoint);
             if let Some(history) = self.codex_chat_history.as_ref() {
                 let restored = history.enrich_request(&mut mapped_body).await;
@@ -242,10 +246,18 @@ impl RequestForwarder {
             }
             apply_codex_chat_upstream_model(provider, &mut mapped_body);
             let reasoning_config = resolve_codex_chat_reasoning_config(provider, &mapped_body);
-            transform_codex_chat::responses_to_chat_completions_with_reasoning(
+            let mut chat_body = transform_codex_chat::responses_to_chat_completions_with_reasoning(
                 mapped_body,
                 reasoning_config.as_ref(),
-            )?
+            )?;
+            super::super::providers::inject_codex_chat_prompt_cache_key(
+                provider,
+                &mut chat_body,
+                explicit_prompt_cache_key.as_deref(),
+                self.session_client_provided
+                    .then_some(self.session_id.as_str()),
+            );
+            chat_body
         } else if needs_transform {
             if is_claude_request {
                 super::super::providers::transform_claude_request_for_api_format_with_shadow(

--- a/src-tauri/src/proxy/forwarder/tests/request_building.rs
+++ b/src-tauri/src/proxy/forwarder/tests/request_building.rs
@@ -1709,15 +1709,23 @@ async fn non_managed_upstream_allows_proxy_managed_placeholder_guard() {
 
 #[tokio::test]
 async fn codex_chat_prepare_request_rewrites_responses_to_chat_completions() {
-    let provider = codex_chat_provider("https://example.com/v1", "deepseek-chat");
+    let mut provider = codex_chat_provider("https://example.com/v1", "deepseek-chat");
+    provider
+        .meta
+        .as_mut()
+        .expect("Codex Chat provider should have metadata")
+        .prompt_cache_routing = Some("enabled".to_string());
     let (_db, router) = test_router().await;
-    let forwarder = RequestForwarder::new(router).expect("create forwarder");
+    let forwarder = RequestForwarder::new(router)
+        .expect("create forwarder")
+        .with_session("session-key".to_string(), true);
     let mut headers = HeaderMap::new();
     headers.insert("accept-encoding", HeaderValue::from_static("gzip"));
     let request_body = json!({
         "model": "gpt-5.4",
         "input": "hello",
-        "stream": true
+        "stream": true,
+        "prompt_cache_key": "request-key"
     });
 
     let request = forwarder
@@ -1756,6 +1764,70 @@ async fn codex_chat_prepare_request_rewrites_responses_to_chat_completions() {
     assert_eq!(body["messages"][0]["content"], "hello");
     assert_eq!(body["stream"], true);
     assert_eq!(body["stream_options"]["include_usage"], true);
+    assert_eq!(body["prompt_cache_key"], "request-key");
+}
+
+#[tokio::test]
+async fn codex_chat_prepare_request_uses_only_client_provided_session_for_prompt_cache() {
+    let mut provider = codex_chat_provider("https://example.com/v1", "deepseek-chat");
+    provider
+        .meta
+        .as_mut()
+        .expect("Codex Chat provider should have metadata")
+        .prompt_cache_routing = Some("enabled".to_string());
+    let body = json!({
+        "model": "gpt-5.4",
+        "input": "hello"
+    });
+
+    let (_db, router) = test_router().await;
+    let request = RequestForwarder::new(router)
+        .expect("create forwarder")
+        .with_session("client-session".to_string(), true)
+        .prepare_request(
+            &AppType::Codex,
+            &provider,
+            "/v1/responses",
+            &body,
+            &HeaderMap::new(),
+            ForwardOptions {
+                max_retries: 0,
+                request_timeout: Some(Duration::from_secs(2)),
+                bypass_circuit_breaker: true,
+            },
+        )
+        .await
+        .expect("prepare request with client session")
+        .build()
+        .expect("build request with client session");
+    assert_eq!(
+        request_body_json(&request)["prompt_cache_key"],
+        "client-session"
+    );
+
+    let (_db, router) = test_router().await;
+    let request = RequestForwarder::new(router)
+        .expect("create forwarder")
+        .with_session("generated-session".to_string(), false)
+        .prepare_request(
+            &AppType::Codex,
+            &provider,
+            "/v1/responses",
+            &body,
+            &HeaderMap::new(),
+            ForwardOptions {
+                max_retries: 0,
+                request_timeout: Some(Duration::from_secs(2)),
+                bypass_circuit_breaker: true,
+            },
+        )
+        .await
+        .expect("prepare request with generated session")
+        .build()
+        .expect("build request with generated session");
+    assert!(request_body_json(&request)
+        .get("prompt_cache_key")
+        .is_none());
 }
 
 #[tokio::test]

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -91,8 +91,7 @@ pub fn should_convert_codex_responses_to_chat(provider: &Provider, endpoint: &st
     ) && codex_provider_uses_chat_completions(provider)
 }
 
-
-/// Whether a converted Codex Responses request may send \`prompt_cache_key\` to
+/// Whether a converted Codex Responses request may send `prompt_cache_key` to
 /// its Chat Completions upstream. Unknown OpenAI-compatible gateways default to
 /// false because many reject unsupported request fields with HTTP 400.
 pub fn should_send_codex_chat_prompt_cache_key(provider: &Provider) -> bool {
@@ -131,7 +130,7 @@ pub fn should_send_codex_chat_prompt_cache_key(provider: &Provider) -> bool {
     match url.host_str() {
         Some("api.openai.com") => true,
         Some("api.kimi.com") => {
-            let path = url.path().trim_end_matches("/");
+            let path = url.path().trim_end_matches('/');
             path == "/coding" || path.starts_with("/coding/")
         }
         _ => false,
@@ -691,7 +690,7 @@ experimental_bearer_token = "sk-config-key"
     }
 
     #[test]
-    fn test_codex_provider_uses_chat_completions_from_active_wire_api() {
+    fn prompt_cache_routing_auto_enables_known_upstreams_only() {
         let kimi = create_provider(json!({
             "config": r#"
 model_provider = "custom"
@@ -785,7 +784,7 @@ wire_api = "responses"
     }
 
     #[test]
-    fn test_codex_provider_uses_chat_completions_from_active_wire_api_original() {
+    fn test_codex_provider_uses_chat_completions_from_active_wire_api() {
         let provider = create_provider(json!({
             "config": r#"
 model_provider = "chat_only"

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -91,6 +91,82 @@ pub fn should_convert_codex_responses_to_chat(provider: &Provider, endpoint: &st
     ) && codex_provider_uses_chat_completions(provider)
 }
 
+
+/// Whether a converted Codex Responses request may send \`prompt_cache_key\` to
+/// its Chat Completions upstream. Unknown OpenAI-compatible gateways default to
+/// false because many reject unsupported request fields with HTTP 400.
+pub fn should_send_codex_chat_prompt_cache_key(provider: &Provider) -> bool {
+    match provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.prompt_cache_routing.as_deref())
+        .unwrap_or("auto")
+    {
+        "enabled" => return true,
+        "disabled" => return false,
+        _ => {}
+    }
+
+    let base_url = provider
+        .settings_config
+        .get("base_url")
+        .or_else(|| provider.settings_config.get("baseURL"))
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string)
+        .or_else(|| {
+            provider
+                .settings_config
+                .get("config")
+                .and_then(|value| value.as_str())
+                .and_then(extract_codex_base_url_from_toml)
+        });
+
+    let Some(base_url) = base_url else {
+        return false;
+    };
+    let Ok(url) = url::Url::parse(&base_url) else {
+        return false;
+    };
+
+    match url.host_str() {
+        Some("api.openai.com") => true,
+        Some("api.kimi.com") => {
+            let path = url.path().trim_end_matches("/");
+            path == "/coding" || path.starts_with("/coding/")
+        }
+        _ => false,
+    }
+}
+
+/// Add a stable cache-routing key after Responses -> Chat conversion. An
+/// explicit client key wins; otherwise only a real client-provided session ID
+/// is eligible. Generated per-request UUIDs must never be used here.
+pub fn inject_codex_chat_prompt_cache_key(
+    provider: &Provider,
+    chat_body: &mut JsonValue,
+    explicit_key: Option<&str>,
+    client_session_id: Option<&str>,
+) -> bool {
+    if !should_send_codex_chat_prompt_cache_key(provider) {
+        return false;
+    }
+
+    let key = explicit_key
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .or_else(|| {
+            client_session_id
+                .map(str::trim)
+                .filter(|session_id| !session_id.is_empty())
+        });
+    let Some(key) = key else {
+        return false;
+    };
+
+    chat_body["prompt_cache_key"] = JsonValue::String(key.to_string());
+    true
+}
+
 /// Extract the real upstream model configured for a Codex provider.
 pub fn codex_provider_upstream_model(provider: &Provider) -> Option<String> {
     provider
@@ -616,6 +692,100 @@ experimental_bearer_token = "sk-config-key"
 
     #[test]
     fn test_codex_provider_uses_chat_completions_from_active_wire_api() {
+        let kimi = create_provider(json!({
+            "config": r#"
+model_provider = "custom"
+[model_providers.custom]
+base_url = "https://api.kimi.com/coding/v1"
+wire_api = "responses"
+"#
+        }));
+        let openai = create_provider(json!({
+            "base_url": "https://api.openai.com/v1"
+        }));
+        let unknown = create_provider(json!({
+            "base_url": "https://strict.example.com/v1"
+        }));
+
+        assert!(should_send_codex_chat_prompt_cache_key(&kimi));
+        assert!(should_send_codex_chat_prompt_cache_key(&openai));
+        assert!(!should_send_codex_chat_prompt_cache_key(&unknown));
+    }
+
+    #[test]
+    fn prompt_cache_routing_user_override_wins_over_auto_detection() {
+        let mut kimi = create_provider(json!({
+            "base_url": "https://api.kimi.com/coding/v1"
+        }));
+        kimi.meta = Some(crate::provider::ProviderMeta {
+            prompt_cache_routing: Some("disabled".to_string()),
+            ..Default::default()
+        });
+        assert!(!should_send_codex_chat_prompt_cache_key(&kimi));
+
+        let mut unknown = create_provider(json!({
+            "base_url": "https://strict.example.com/v1"
+        }));
+        unknown.meta = Some(crate::provider::ProviderMeta {
+            prompt_cache_routing: Some("enabled".to_string()),
+            ..Default::default()
+        });
+        assert!(should_send_codex_chat_prompt_cache_key(&unknown));
+    }
+
+    #[test]
+    fn prompt_cache_key_prefers_explicit_key_then_real_session() {
+        let provider = create_provider(json!({
+            "base_url": "https://api.kimi.com/coding/v1"
+        }));
+        let mut explicit_body = json!({ "model": "kimi-for-coding" });
+        assert!(inject_codex_chat_prompt_cache_key(
+            &provider,
+            &mut explicit_body,
+            Some("request-key"),
+            Some("session-key"),
+        ));
+        assert_eq!(explicit_body["prompt_cache_key"], "request-key");
+
+        let mut session_body = json!({ "model": "kimi-for-coding" });
+        assert!(inject_codex_chat_prompt_cache_key(
+            &provider,
+            &mut session_body,
+            None,
+            Some("session-key"),
+        ));
+        assert_eq!(session_body["prompt_cache_key"], "session-key");
+    }
+
+    #[test]
+    fn prompt_cache_key_is_not_injected_without_real_session_or_support() {
+        let kimi = create_provider(json!({
+            "base_url": "https://api.kimi.com/coding/v1"
+        }));
+        let mut no_session_body = json!({ "model": "kimi-for-coding" });
+        assert!(!inject_codex_chat_prompt_cache_key(
+            &kimi,
+            &mut no_session_body,
+            None,
+            None,
+        ));
+        assert!(no_session_body.get("prompt_cache_key").is_none());
+
+        let unknown = create_provider(json!({
+            "base_url": "https://strict.example.com/v1"
+        }));
+        let mut unsupported_body = json!({ "model": "other" });
+        assert!(!inject_codex_chat_prompt_cache_key(
+            &unknown,
+            &mut unsupported_body,
+            Some("request-key"),
+            Some("session-key"),
+        ));
+        assert!(unsupported_body.get("prompt_cache_key").is_none());
+    }
+
+    #[test]
+    fn test_codex_provider_uses_chat_completions_from_active_wire_api_original() {
         let provider = create_provider(json!({
             "config": r#"
 model_provider = "chat_only"

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -37,8 +37,8 @@ pub use codex::CodexAdapter;
 #[allow(unused_imports)]
 pub use codex::{
     apply_codex_chat_upstream_model, codex_provider_catalog_tool_profile,
-    codex_provider_upstream_model, codex_provider_uses_chat_completions, is_origin_only_url,
-    inject_codex_chat_prompt_cache_key, resolve_codex_chat_reasoning_config,
+    codex_provider_upstream_model, codex_provider_uses_chat_completions,
+    inject_codex_chat_prompt_cache_key, is_origin_only_url, resolve_codex_chat_reasoning_config,
     should_convert_codex_responses_to_chat,
 };
 pub use gemini::GeminiAdapter;

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -38,7 +38,8 @@ pub use codex::CodexAdapter;
 pub use codex::{
     apply_codex_chat_upstream_model, codex_provider_catalog_tool_profile,
     codex_provider_upstream_model, codex_provider_uses_chat_completions, is_origin_only_url,
-    resolve_codex_chat_reasoning_config, should_convert_codex_responses_to_chat,
+    inject_codex_chat_prompt_cache_key, resolve_codex_chat_reasoning_config,
+    should_convert_codex_responses_to_chat,
 };
 pub use gemini::GeminiAdapter;
 


### PR DESCRIPTION
## Summary

Port the prompt cache routing feature from the desktop version ([farion1231/cc-switch](https://github.com/farion1231/cc-switch)) into cc-switch-cli.

## Problem

When a Codex provider uses `apiFormat: "openai_chat"`, the local proxy converts Responses API requests to Chat Completions format but never injects `prompt_cache_key`. This means OpenAI-compatible gateways (New API, etc.) cannot route requests to the same upstream channel, losing prompt cache affinity.

The desktop version handles this with `promptCacheRouting` in `ProviderMeta` and `inject_codex_chat_prompt_cache_key()`, but this was missing from the CLI fork.

## Changes

- **`src/provider.rs`**: Add `promptCacheRouting: Option<String>` to `ProviderMeta` (values: `"enabled"`, `"disabled"`, `"auto"`)
- **`src/proxy/providers/codex.rs`**: Port `should_send_codex_chat_prompt_cache_key()` (auto-detects known upstreams: `api.openai.com`, `api.kimi.com/coding`) and `inject_codex_chat_prompt_cache_key()` (injects `prompt_cache_key` into converted Chat body using explicit client key or real session ID)
- **`src/proxy/providers/mod.rs`**: Export the new functions
- **`src/proxy/forwarder/request_builder.rs`**: Call `inject_codex_chat_prompt_cache_key()` after `responses_to_chat_completions_with_reasoning()`
- **4 unit tests** ported from the desktop version

## Verification

Built and deployed on a Debian 12 VPS. Confirmed via `proxy_request_logs` that real Codex CLI requests now show non-zero `cache_read_tokens` from the upstream gateway, proving `prompt_cache_key` injection is working.

## Compatibility

This is a purely additive feature. Providers without `promptCacheRouting` in their meta default to `"auto"`, which only enables cache key injection for known upstreams — exactly matching desktop behavior. No existing functionality is affected.