### PR TITLE
修复半开探测许可泄漏导致故障转移后无法切回

### DIFF
--- a/src-tauri/src/proxy/circuit_breaker.rs
+++ b/src-tauri/src/proxy/circuit_breaker.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::RwLock;
 
@@ -52,13 +52,20 @@ pub struct CircuitBreaker {
     failed_requests: Arc<AtomicU32>,
     last_opened_at: Arc<RwLock<Option<Instant>>>,
     config: Arc<RwLock<CircuitBreakerConfig>>,
-    half_open_requests: Arc<AtomicU32>,
+    half_open_permits: Arc<Mutex<HalfOpenPermitState>>,
+}
+
+#[derive(Default)]
+struct HalfOpenPermitState {
+    generation: u64,
+    in_flight: u32,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct AllowResult {
     pub allowed: bool,
     pub used_half_open_permit: bool,
+    pub(super) half_open_generation: Option<u64>,
 }
 
 impl CircuitBreaker {
@@ -71,7 +78,7 @@ impl CircuitBreaker {
             failed_requests: Arc::new(AtomicU32::new(0)),
             last_opened_at: Arc::new(RwLock::new(None)),
             config: Arc::new(RwLock::new(config)),
-            half_open_requests: Arc::new(AtomicU32::new(0)),
+            half_open_permits: Arc::new(Mutex::new(HalfOpenPermitState::default())),
         }
     }
 
@@ -105,6 +112,7 @@ impl CircuitBreaker {
             CircuitState::Closed => AllowResult {
                 allowed: true,
                 used_half_open_permit: false,
+                half_open_generation: None,
             },
             CircuitState::Open => {
                 let config = self.config.read().await;
@@ -117,11 +125,13 @@ impl CircuitBreaker {
                             CircuitState::Closed => AllowResult {
                                 allowed: true,
                                 used_half_open_permit: false,
+                                half_open_generation: None,
                             },
                             CircuitState::HalfOpen => self.allow_half_open_probe(),
                             CircuitState::Open => AllowResult {
                                 allowed: false,
                                 used_half_open_permit: false,
+                                half_open_generation: None,
                             },
                         };
                     }
@@ -130,6 +140,7 @@ impl CircuitBreaker {
                 AllowResult {
                     allowed: false,
                     used_half_open_permit: false,
+                    half_open_generation: None,
                 }
             }
             CircuitState::HalfOpen => self.allow_half_open_probe(),
@@ -218,38 +229,43 @@ impl CircuitBreaker {
 
     fn allow_half_open_probe(&self) -> AllowResult {
         let max_half_open_requests = 1u32;
-        let current = self.half_open_requests.fetch_add(1, Ordering::SeqCst);
+        let mut permits = self
+            .half_open_permits
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
 
-        if current < max_half_open_requests {
+        if permits.in_flight < max_half_open_requests {
+            permits.in_flight += 1;
             AllowResult {
                 allowed: true,
                 used_half_open_permit: true,
+                half_open_generation: Some(permits.generation),
             }
         } else {
-            self.half_open_requests.fetch_sub(1, Ordering::SeqCst);
             AllowResult {
                 allowed: false,
                 used_half_open_permit: false,
+                half_open_generation: None,
             }
         }
     }
 
     pub fn release_half_open_permit(&self) {
-        let mut current = self.half_open_requests.load(Ordering::SeqCst);
-        loop {
-            if current == 0 {
-                return;
-            }
+        let mut permits = self
+            .half_open_permits
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        permits.in_flight = permits.in_flight.saturating_sub(1);
+    }
 
-            match self.half_open_requests.compare_exchange(
-                current,
-                current - 1,
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            ) {
-                Ok(_) => return,
-                Err(actual) => current = actual,
-            }
+    /// 仅归还指定半开代际的许可，避免旧请求释放新一轮探测名额。
+    pub(super) fn release_half_open_permit_for_generation(&self, generation: u64) {
+        let mut permits = self
+            .half_open_permits
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if permits.generation == generation {
+            permits.in_flight = permits.in_flight.saturating_sub(1);
         }
     }
 
@@ -266,9 +282,14 @@ impl CircuitBreaker {
             return;
         }
 
-        *state = CircuitState::HalfOpen;
+        let mut permits = self
+            .half_open_permits
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        permits.generation = permits.generation.wrapping_add(1);
+        permits.in_flight = 0;
         self.consecutive_successes.store(0, Ordering::SeqCst);
-        self.half_open_requests.store(0, Ordering::SeqCst);
+        *state = CircuitState::HalfOpen;
     }
 
     async fn transition_to_closed(&self) {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -11,7 +11,7 @@ use crate::{app_config::AppType, provider::Provider};
 
 use super::{
     error::ProxyError,
-    provider_router::ProviderRouter,
+    provider_router::{ProviderRequestPermit, ProviderRouter},
     providers::codex_chat_history::CodexChatHistoryStore,
     providers::gemini_shadow::GeminiShadowStore,
     providers::get_adapter,
@@ -269,13 +269,10 @@ impl RequestForwarder {
             }
 
             let permit = if bypass_circuit_breaker {
-                super::circuit_breaker::AllowResult {
-                    allowed: true,
-                    used_half_open_permit: false,
-                }
+                ProviderRequestPermit::bypassed()
             } else {
                 self.router
-                    .allow_provider_request(&provider.id, app_type.as_str())
+                    .acquire_provider_request(&provider.id, app_type.as_str())
                     .await
             };
 
@@ -310,10 +307,10 @@ impl RequestForwarder {
                         if !bypass_circuit_breaker {
                             let _ = self
                                 .router
-                                .record_result(
+                                .record_guarded_result(
+                                    &permit,
                                     &provider.id,
                                     app_type.as_str(),
-                                    permit.used_half_open_permit,
                                     true,
                                     None,
                                 )
@@ -325,16 +322,6 @@ impl RequestForwarder {
 
                     match outcome.attempt_decision {
                         AttemptDecision::NeutralRelease => {
-                            if !bypass_circuit_breaker {
-                                self.router
-                                    .release_permit_neutral(
-                                        &provider.id,
-                                        app_type.as_str(),
-                                        permit.used_half_open_permit,
-                                    )
-                                    .await;
-                            }
-
                             if claude_error_path && !provider_needs_transform {
                                 return Err(ForwardFailure::new(
                                     Some(provider),
@@ -348,10 +335,10 @@ impl RequestForwarder {
                             if !bypass_circuit_breaker {
                                 let _ = self
                                     .router
-                                    .record_result(
+                                    .record_guarded_result(
+                                        &permit,
                                         &provider.id,
                                         app_type.as_str(),
-                                        permit.used_half_open_permit,
                                         false,
                                         Some(format!(
                                             "upstream returned {}",
@@ -390,10 +377,10 @@ impl RequestForwarder {
                             if !bypass_circuit_breaker {
                                 let _ = self
                                     .router
-                                    .record_result(
+                                    .record_guarded_result(
+                                        &permit,
                                         &provider.id,
                                         app_type.as_str(),
-                                        permit.used_half_open_permit,
                                         false,
                                         Some(format!(
                                             "upstream returned {}",
@@ -414,10 +401,10 @@ impl RequestForwarder {
                             if !bypass_circuit_breaker {
                                 let _ = self
                                     .router
-                                    .record_result(
+                                    .record_guarded_result(
+                                        &permit,
                                         &provider.id,
                                         app_type.as_str(),
-                                        permit.used_half_open_permit,
                                         false,
                                         Some(error.to_string()),
                                     )
@@ -426,15 +413,6 @@ impl RequestForwarder {
                             last_error = Some(ForwardFailure::new(Some(provider.clone()), error));
                         }
                         AttemptDecision::NeutralRelease | AttemptDecision::FatalStop => {
-                            if !bypass_circuit_breaker {
-                                self.router
-                                    .release_permit_neutral(
-                                        &provider.id,
-                                        app_type.as_str(),
-                                        permit.used_half_open_permit,
-                                    )
-                                    .await;
-                            }
                             return Err(ForwardFailure::new(Some(provider), error));
                         }
                     }
@@ -514,13 +492,10 @@ impl RequestForwarder {
             }
 
             let permit = if bypass_circuit_breaker {
-                super::circuit_breaker::AllowResult {
-                    allowed: true,
-                    used_half_open_permit: false,
-                }
+                ProviderRequestPermit::bypassed()
             } else {
                 self.router
-                    .allow_provider_request(&provider.id, app_type.as_str())
+                    .acquire_provider_request(&provider.id, app_type.as_str())
                     .await
             };
 
@@ -555,10 +530,10 @@ impl RequestForwarder {
                         if !bypass_circuit_breaker {
                             let _ = self
                                 .router
-                                .record_result(
+                                .record_guarded_result(
+                                    &permit,
                                     &provider.id,
                                     app_type.as_str(),
-                                    permit.used_half_open_permit,
                                     true,
                                     None,
                                 )
@@ -570,16 +545,6 @@ impl RequestForwarder {
 
                     match outcome.attempt_decision {
                         AttemptDecision::NeutralRelease => {
-                            if !bypass_circuit_breaker {
-                                self.router
-                                    .release_permit_neutral(
-                                        &provider.id,
-                                        app_type.as_str(),
-                                        permit.used_half_open_permit,
-                                    )
-                                    .await;
-                            }
-
                             if claude_error_path && !provider_needs_transform {
                                 return Err(ForwardFailure::new(
                                     Some(provider),
@@ -593,10 +558,10 @@ impl RequestForwarder {
                             if !bypass_circuit_breaker {
                                 let _ = self
                                     .router
-                                    .record_result(
+                                    .record_guarded_result(
+                                        &permit,
                                         &provider.id,
                                         app_type.as_str(),
-                                        permit.used_half_open_permit,
                                         false,
                                         Some(format!(
                                             "upstream returned {}",
@@ -635,10 +600,10 @@ impl RequestForwarder {
                             if !bypass_circuit_breaker {
                                 let _ = self
                                     .router
-                                    .record_result(
+                                    .record_guarded_result(
+                                        &permit,
                                         &provider.id,
                                         app_type.as_str(),
-                                        permit.used_half_open_permit,
                                         false,
                                         Some(format!(
                                             "upstream returned {}",
@@ -659,10 +624,10 @@ impl RequestForwarder {
                             if !bypass_circuit_breaker {
                                 let _ = self
                                     .router
-                                    .record_result(
+                                    .record_guarded_result(
+                                        &permit,
                                         &provider.id,
                                         app_type.as_str(),
-                                        permit.used_half_open_permit,
                                         false,
                                         Some(error.to_string()),
                                     )
@@ -671,15 +636,6 @@ impl RequestForwarder {
                             last_error = Some(ForwardFailure::new(Some(provider.clone()), error));
                         }
                         AttemptDecision::NeutralRelease | AttemptDecision::FatalStop => {
-                            if !bypass_circuit_breaker {
-                                self.router
-                                    .release_permit_neutral(
-                                        &provider.id,
-                                        app_type.as_str(),
-                                        permit.used_half_open_permit,
-                                    )
-                                    .await;
-                            }
                             return Err(ForwardFailure::new(Some(provider), error));
                         }
                     }

--- a/src-tauri/src/proxy/forwarder/tests/provider_failover.rs
+++ b/src-tauri/src/proxy/forwarder/tests/provider_failover.rs
@@ -13,6 +13,7 @@ use crate::{
     app_config::AppType,
     provider::{LocalProxyRequestOverrides, ProviderMeta},
     proxy::{
+        circuit_breaker::CircuitBreakerConfig,
         error::ProxyError,
         forwarder::{ForwardOptions, RequestForwarder},
         types::RectifierConfig,
@@ -1412,6 +1413,91 @@ async fn later_half_open_provider_permit_is_not_preclaimed_when_earlier_success_
 
     primary_server.abort();
     half_open_server.abort();
+}
+
+/// 验证 fallback 接管后，高优先级 provider 恢复时下一次请求会切回。
+#[tokio::test]
+async fn recovered_primary_provider_is_selected_after_fallback() {
+    let (primary_url, primary_hits, primary_server) =
+        spawn_mock_upstream(StatusCode::OK, json!({"provider": "primary"})).await;
+    let (fallback_url, fallback_hits, fallback_server) =
+        spawn_mock_upstream(StatusCode::OK, json!({"provider": "fallback"})).await;
+    let primary_provider = claude_provider("p1", &primary_url, None);
+    let fallback_provider = claude_provider("p2", &fallback_url, None);
+    let (db, router) = test_router().await;
+    let forwarder = RequestForwarder::new(router.clone()).expect("create forwarder");
+
+    db.save_provider("claude", &primary_provider)
+        .expect("save primary provider for health tracking");
+    db.save_provider("claude", &fallback_provider)
+        .expect("save fallback provider for health tracking");
+    let mut breaker_config = CircuitBreakerConfig {
+        failure_threshold: 1,
+        success_threshold: 1,
+        timeout_seconds: 3600,
+        ..Default::default()
+    };
+    db.update_circuit_breaker_config(&breaker_config)
+        .await
+        .expect("configure primary circuit breaker");
+    router.update_all_configs(breaker_config.clone()).await;
+    router
+        .record_result(
+            "p1",
+            "claude",
+            false,
+            false,
+            Some("primary outage".to_string()),
+        )
+        .await
+        .expect("open primary breaker");
+
+    let fallback_result = forwarder
+        .forward_buffered_response(
+            &AppType::Claude,
+            "/v1/messages",
+            claude_request_body(),
+            &HeaderMap::new(),
+            vec![primary_provider.clone(), fallback_provider.clone()],
+            ForwardOptions {
+                max_retries: 1,
+                request_timeout: Some(Duration::from_secs(2)),
+                bypass_circuit_breaker: false,
+            },
+            RectifierConfig::default(),
+        )
+        .await
+        .expect("fallback provider should serve during primary outage");
+    assert_eq!(fallback_result.provider.id, "p2");
+
+    breaker_config.timeout_seconds = 0;
+    db.update_circuit_breaker_config(&breaker_config)
+        .await
+        .expect("shorten recovery timeout");
+    router.update_all_configs(breaker_config).await;
+
+    let recovered_result = forwarder
+        .forward_buffered_response(
+            &AppType::Claude,
+            "/v1/messages",
+            claude_request_body(),
+            &HeaderMap::new(),
+            vec![primary_provider, fallback_provider],
+            ForwardOptions {
+                max_retries: 1,
+                request_timeout: Some(Duration::from_secs(2)),
+                bypass_circuit_breaker: false,
+            },
+            RectifierConfig::default(),
+        )
+        .await
+        .expect("recovered primary should serve the next request");
+    assert_eq!(recovered_result.provider.id, "p1");
+    assert_eq!(primary_hits.count.load(Ordering::SeqCst), 1);
+    assert_eq!(fallback_hits.count.load(Ordering::SeqCst), 1);
+
+    primary_server.abort();
+    fallback_server.abort();
 }
 
 #[tokio::test]

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -16,6 +16,40 @@ pub struct ProviderRouter {
     circuit_breakers: Arc<RwLock<HashMap<String, Arc<CircuitBreaker>>>>,
 }
 
+pub(super) struct ProviderRequestPermit {
+    pub(super) allowed: bool,
+    half_open_permit: Option<(Arc<CircuitBreaker>, u64)>,
+}
+
+impl ProviderRequestPermit {
+    /// 创建绕过熔断器时使用的许可，不持有半开探测名额。
+    pub(super) fn bypassed() -> Self {
+        Self {
+            allowed: true,
+            half_open_permit: None,
+        }
+    }
+
+    /// 将熔断器许可包装为可在任务取消时自动释放的守卫。
+    fn guarded(breaker: Arc<CircuitBreaker>, result: AllowResult) -> Self {
+        Self {
+            allowed: result.allowed,
+            half_open_permit: result
+                .half_open_generation
+                .map(|generation| (breaker, generation)),
+        }
+    }
+}
+
+impl Drop for ProviderRequestPermit {
+    /// 在请求完成、取消或 panic 展开时归还半开探测名额。
+    fn drop(&mut self) {
+        if let Some((breaker, generation)) = self.half_open_permit.take() {
+            breaker.release_half_open_permit_for_generation(generation);
+        }
+    }
+}
+
 impl ProviderRouter {
     pub fn new(db: Arc<Database>) -> Self {
         Self {
@@ -89,6 +123,19 @@ impl ProviderRouter {
         breaker.allow_request().await
     }
 
+    /// 获取由生命周期守卫管理的请求许可，避免任务取消后泄漏半开名额。
+    pub(super) async fn acquire_provider_request(
+        &self,
+        provider_id: &str,
+        app_type: &str,
+    ) -> ProviderRequestPermit {
+        let breaker = self
+            .get_or_create_circuit_breaker(&format!("{app_type}:{provider_id}"))
+            .await;
+        let result = breaker.allow_request().await;
+        ProviderRequestPermit::guarded(breaker, result)
+    }
+
     pub async fn record_result(
         &self,
         provider_id: &str,
@@ -124,6 +171,20 @@ impl ProviderRouter {
             )
             .await
             .map_err(|error| ProxyError::DatabaseError(error.to_string()))
+    }
+
+    /// 记录由守卫持有的请求结果，permit 统一在守卫销毁时释放。
+    pub(super) async fn record_guarded_result(
+        &self,
+        permit: &ProviderRequestPermit,
+        provider_id: &str,
+        app_type: &str,
+        success: bool,
+        error_msg: Option<String>,
+    ) -> Result<(), ProxyError> {
+        debug_assert!(permit.allowed);
+        self.record_result(provider_id, app_type, false, success, error_msg)
+            .await
     }
 
     pub async fn reset_circuit_breaker(&self, circuit_key: &str) {

--- a/src-tauri/src/proxy/provider_router/tests.rs
+++ b/src-tauri/src/proxy/provider_router/tests.rs
@@ -4,6 +4,7 @@ use serde_json::json;
 use serial_test::serial;
 use std::{env, sync::Arc};
 use tempfile::TempDir;
+use tokio::sync::oneshot;
 
 struct TempHome {
     #[allow(dead_code)]
@@ -335,6 +336,106 @@ async fn test_release_permit_neutral_frees_half_open_slot() {
     let third = router.allow_provider_request("a", "claude").await;
     assert!(third.allowed);
     assert!(third.used_half_open_permit);
+}
+
+/// 验证请求任务被取消并丢弃许可守卫后，半开探测名额会自动归还。
+#[tokio::test]
+#[serial(home_settings)]
+async fn test_cancelled_guarded_probe_frees_half_open_slot() {
+    let _home = TempHome::new();
+    let db = Arc::new(Database::memory().unwrap());
+
+    db.update_circuit_breaker_config(&CircuitBreakerConfig {
+        failure_threshold: 1,
+        timeout_seconds: 0,
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    let provider_a = Provider::with_id("a".to_string(), "Provider A".to_string(), json!({}), None);
+    db.save_provider("claude", &provider_a).unwrap();
+    db.add_to_failover_queue("claude", "a").unwrap();
+
+    let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+    config.enabled = true;
+    config.auto_failover_enabled = true;
+    db.update_proxy_config_for_app(config).await.unwrap();
+
+    let router = Arc::new(ProviderRouter::new(db.clone()));
+
+    router
+        .record_result("a", "claude", false, false, Some("fail".to_string()))
+        .await
+        .unwrap();
+
+    let task_router = Arc::clone(&router);
+    let (acquired_tx, acquired_rx) = oneshot::channel();
+    let probe_task = tokio::spawn(async move {
+        let permit = task_router.acquire_provider_request("a", "claude").await;
+        assert!(permit.allowed);
+        acquired_tx.send(()).unwrap();
+        std::future::pending::<()>().await;
+        drop(permit);
+    });
+
+    acquired_rx.await.unwrap();
+    assert!(!router.allow_provider_request("a", "claude").await.allowed);
+
+    probe_task.abort();
+    assert!(probe_task.await.unwrap_err().is_cancelled());
+
+    let next = router.acquire_provider_request("a", "claude").await;
+    assert!(next.allowed);
+}
+
+/// 验证旧代际守卫不会释放新一轮半开探测正在使用的名额。
+#[tokio::test]
+#[serial(home_settings)]
+async fn test_stale_guard_does_not_release_new_half_open_generation() {
+    let _home = TempHome::new();
+    let db = Arc::new(Database::memory().unwrap());
+
+    db.update_circuit_breaker_config(&CircuitBreakerConfig {
+        failure_threshold: 1,
+        timeout_seconds: 0,
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    let provider_a = Provider::with_id("a".to_string(), "Provider A".to_string(), json!({}), None);
+    db.save_provider("claude", &provider_a).unwrap();
+    db.add_to_failover_queue("claude", "a").unwrap();
+
+    let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+    config.enabled = true;
+    config.auto_failover_enabled = true;
+    db.update_proxy_config_for_app(config).await.unwrap();
+
+    let router = ProviderRouter::new(db.clone());
+
+    router
+        .record_result("a", "claude", false, false, Some("fail".to_string()))
+        .await
+        .unwrap();
+
+    let stale = router.acquire_provider_request("a", "claude").await;
+    assert!(stale.allowed);
+    router
+        .record_guarded_result(&stale, "a", "claude", false, Some("probe failed".to_string()))
+        .await
+        .unwrap();
+
+    let current = router.acquire_provider_request("a", "claude").await;
+    assert!(current.allowed);
+
+    drop(stale);
+    assert!(!router.allow_provider_request("a", "claude").await.allowed);
+
+    drop(current);
+    let next = router.acquire_provider_request("a", "claude").await;
+    assert!(next.allowed);
 }
 
 #[tokio::test]


### PR DESCRIPTION
### 问题

自动故障转移的高优先级供应商熔断后，会在冷却期结束时进入 HalfOpen 并尝试恢复探测。旧实现通过计数器占用唯一的 HalfOpen 探测许可；如果请求在记录成功或失败之前被取消、提前返回或 panic，许可不会归还。

之后所有请求都无法再次探测已恢复的高优先级供应商，只能持续使用 fallback，看起来就是“故障转移后永远不会切回”。

### 修复

- 使用 `ProviderRequestPermit` 生命周期守卫持有 HalfOpen 探测许可。
- 在 guard `Drop` 时自动释放许可，覆盖正常返回、错误、任务取消和 panic 展开。
- 为 HalfOpen permit 墕加 generation，避免旧请求释放新一轮探测名额。
- 转发器只在实际尝试供应商时获取 permit，避免提前占用后续候选供应商的探测名额。

### 测试

- 任务取消后可以重新获取 HalfOpen permit。
- 旧 generation 的 guard 不会释放新 generation 的 permit。
- 较早供应商成功时不会预占后续 HalfOpen 供应商。
- 高优先级供应商熔断、fallback 接管后，冷却结束且主供应商恢复时，下一次请求会重新选择主供应商。

### 行为说明

当前恢复是请求驱动的：冷却期结束后的下一次业务请求触发 HalfOpen 探测，不新增后台健康检查任务。

### Problem

After a higher-priority provider trips its circuit breaker, it enters HalfOpen after the cooldown period and should be probed again. The previous implementation reserved the single HalfOpen probe slot with a counter. If the request was cancelled, returned early, or panicked before recording success or failure, the slot was never released.

All later requests were then unable to probe the recovered provider and kept using the fallback indefinitely.

### Fix

- Introduce a lifecycle-bound `ProviderRequestPermit` guard for HalfOpen probes.
- Release the permit from `Drop`, covering successful returns, errors, task cancellation, and panic unwinding.
- Track HalfOpen generations so stale requests cannot release a permit from a newer recovery cycle.
- Acquire permits only when a provider is actually attempted, avoiding premature reservation for later candidates.

### Tests

- A cancelled task releases its HalfOpen permit.
- A stale-generation guard cannot release a current-generation permit.
- An earlier successful provider does not pre-acquire a later HalfOpen provider's permit.
- After the primary provider opens and fallback takes over, the recovered primary is selected again on the next request after cooldown.

### Behavioral note

Recovery remains request-driven: the first business request after cooldown triggers the HalfOpen probe. This PR does not introduce a background health-check task.
