### PR TITLE
修复自动故障转移中的供应商凭证串号

### DIFF
--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1626,7 +1626,8 @@ impl ProxyService {
             return Ok(existing);
         }
 
-        let (live, sync_live_token_to_current, _) = self
+        // 自动故障转移的 live 配置没有可靠的供应商归属，凭证只能来自 provider 配置。
+        let (live, _, _) = self
             .read_takeover_source_live(app_type, fallback_provider_id)
             .await?;
         let backup = serde_json::to_string(&live)
@@ -1635,14 +1636,11 @@ impl ProxyService {
             .save_live_backup(app_key, &backup)
             .await
             .map_err(|error| format!("save {app_key} live backup failed: {error}"))?;
-        if sync_live_token_to_current {
-            self.sync_live_config_to_current_provider(app_type, &live)
-                .await?;
-        }
 
         Ok(live)
     }
 
+    /// 使用目标 provider 的凭证构建故障转移快照，并仅继承 live 中的非凭证配置。
     fn build_failover_live_snapshot(
         &self,
         app_type: &AppType,
@@ -1651,13 +1649,48 @@ impl ProxyService {
     ) -> Result<Value, String> {
         let provider_snapshot = self.build_live_snapshot_from_provider(app_type, provider)?;
         if matches!(app_type, AppType::Codex) {
-            return Self::prepare_codex_backup_from_existing(
+            let provider_api_key = provider_snapshot
+                .pointer("/auth/OPENAI_API_KEY")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let mut snapshot = Self::prepare_codex_backup_from_existing(
                 provider,
                 provider_snapshot,
                 Some(original_live),
+            )?;
+            Self::apply_codex_provider_api_key_to_failover_snapshot(
+                &mut snapshot,
+                provider_api_key,
             );
+            return Ok(snapshot);
         }
         Self::merge_live_backup_snapshot(app_type, Some(original_live), None, provider_snapshot)
+    }
+
+    /// 保留 Codex OAuth 登录材料，同时确保 API key 只来自目标 provider。
+    fn apply_codex_provider_api_key_to_failover_snapshot(
+        snapshot: &mut Value,
+        provider_api_key: Option<String>,
+    ) {
+        if let Some(provider_api_key) = provider_api_key {
+            let Some(snapshot_obj) = snapshot.as_object_mut() else {
+                return;
+            };
+            let auth = snapshot_obj
+                .entry("auth".to_string())
+                .or_insert_with(|| json!({}));
+            if !auth.is_object() {
+                *auth = json!({});
+            }
+            if let Some(auth_obj) = auth.as_object_mut() {
+                auth_obj.insert("OPENAI_API_KEY".to_string(), json!(provider_api_key));
+            }
+            return;
+        }
+
+        if let Some(auth_obj) = snapshot.get_mut("auth").and_then(Value::as_object_mut) {
+            auth_obj.remove("OPENAI_API_KEY");
+        }
     }
 
     async fn save_failover_live_snapshot(
@@ -1737,11 +1770,19 @@ impl ProxyService {
                 AppType::Codex => {
                     let provider_snapshot =
                         self.build_live_snapshot_from_provider(app_type, provider)?;
+                    let provider_api_key = provider_snapshot
+                        .pointer("/auth/OPENAI_API_KEY")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
                     cached = Self::prepare_codex_backup_from_existing(
                         provider,
                         provider_snapshot,
                         Some(&cached),
                     )?;
+                    Self::apply_codex_provider_api_key_to_failover_snapshot(
+                        &mut cached,
+                        provider_api_key,
+                    );
                 }
                 AppType::Gemini | AppType::OpenCode | AppType::Hermes | AppType::OpenClaw => {}
             }
@@ -3152,6 +3193,20 @@ impl ProxyService {
         app_type: &AppType,
         live_config: &Value,
     ) -> Result<(), String> {
+        let app_key = app_type.as_str();
+        let app_proxy = self
+            .db
+            .get_proxy_config_for_app(app_key)
+            .await
+            .map_err(|error| format!("load proxy config for {app_key} failed: {error}"))?;
+        // 自动故障转移场景下 live 配置不具备可靠的供应商归属，禁止用它反向覆盖凭证。
+        if app_proxy.auto_failover_enabled {
+            log::info!(
+                "skip syncing {app_key} live token because automatic failover credentials are provider-scoped"
+            );
+            return Ok(());
+        }
+
         enum LiveTokenSync {
             Claude(&'static str, String),
             Codex(String),
@@ -6344,6 +6399,140 @@ wire_api = "responses"
         );
     }
 
+    /// 验证多供应商故障转移不会把 live key 覆盖到当前 Codex provider。
+    #[tokio::test]
+    #[serial]
+    async fn codex_failover_queue_does_not_sync_live_token_to_current_provider() {
+        let temp_home = TempDir::new().expect("create temp home");
+        let _env = TestHomeEnvGuard::set(temp_home.path());
+        std::fs::create_dir_all(
+            get_codex_auth_path()
+                .parent()
+                .expect("codex auth parent dir"),
+        )
+        .expect("create ~/.codex");
+        write_json_file(
+            &get_codex_auth_path(),
+            &json!({"OPENAI_API_KEY": "ciii-key"}),
+        )
+        .expect("seed Ciii live auth");
+        write_text_file(
+            &get_codex_config_path(),
+            r#"model_provider = "ciii"
+
+[model_providers.ciii]
+base_url = "https://ciii.example/v1"
+"#,
+        )
+        .expect("seed Ciii live config");
+
+        let db = Arc::new(Database::memory().expect("create database"));
+        let service = ProxyService::new(db.clone());
+        let ciii = Provider::with_id(
+            "ciii".to_string(),
+            "Ciii".to_string(),
+            json!({
+                "auth": {"OPENAI_API_KEY": "ciii-key"},
+                "config": r#"model_provider = "ciii"
+
+[model_providers.ciii]
+base_url = "https://ciii.example/v1"
+"#
+            }),
+            None,
+        );
+        let ylscode = Provider::with_id(
+            "ylscode".to_string(),
+            "ylscode".to_string(),
+            json!({
+                "auth": {"OPENAI_API_KEY": "ylscode-key"},
+                "config": r#"model_provider = "ylscode"
+
+[model_providers.ylscode]
+base_url = "https://ylscode.example/v1"
+"#
+            }),
+            None,
+        );
+        let mut official = Provider::with_id(
+            "official".to_string(),
+            "Official".to_string(),
+            json!({
+                "auth": {"OPENAI_API_KEY": "official-key"},
+                "config": r#"model_provider = "official"
+
+[model_providers.official]
+base_url = "https://api.openai.com/v1"
+"#
+            }),
+            None,
+        );
+        official.category = Some("official".to_string());
+        db.save_provider("codex", &ciii)
+            .expect("save Ciii provider");
+        db.save_provider("codex", &ylscode)
+            .expect("save ylscode provider");
+        db.save_provider("codex", &official)
+            .expect("save official provider");
+        db.set_current_provider("codex", &ylscode.id)
+            .expect("set ylscode current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some(&ylscode.id))
+            .expect("set effective current provider");
+        db.add_to_failover_queue("codex", &ciii.id)
+            .expect("queue Ciii provider");
+        db.add_to_failover_queue("codex", &ylscode.id)
+            .expect("queue ylscode provider");
+        db.add_to_failover_queue("codex", &official.id)
+            .expect("queue official provider");
+
+        service
+            .regenerate_failover_live_snapshots_for_app(&AppType::Codex, Some(&ciii.id))
+            .await
+            .expect("generate provider-scoped failover snapshots");
+        db.set_proxy_flags_sync("codex", true, true)
+            .expect("enable codex automatic failover");
+
+        service
+            .sync_live_config_to_current_provider(
+                &AppType::Codex,
+                &json!({"auth": {"OPENAI_API_KEY": "ciii-key"}}),
+            )
+            .await
+            .expect("skip ambiguous live token sync");
+
+        for (provider_id, expected_key) in [
+            ("ciii", "ciii-key"),
+            ("ylscode", "ylscode-key"),
+            ("official", "official-key"),
+        ] {
+            let unchanged = db
+                .get_provider_by_id(provider_id, "codex")
+                .expect("read Codex provider")
+                .expect("Codex provider exists");
+            assert_eq!(
+                unchanged
+                    .settings_config
+                    .pointer("/auth/OPENAI_API_KEY")
+                    .and_then(Value::as_str),
+                Some(expected_key)
+            );
+
+            let stored_snapshot = db
+                .get_failover_live_snapshot("codex", provider_id)
+                .await
+                .expect("read Codex failover snapshot")
+                .expect("Codex failover snapshot exists");
+            let snapshot: Value = serde_json::from_str(&stored_snapshot.config_json)
+                .expect("parse Codex failover snapshot");
+            assert_eq!(
+                snapshot
+                    .pointer("/auth/OPENAI_API_KEY")
+                    .and_then(Value::as_str),
+                Some(expected_key)
+            );
+        }
+    }
+
     #[tokio::test]
     #[serial]
     async fn enabling_codex_takeover_syncs_live_token_back_to_current_provider() {
@@ -6395,6 +6584,27 @@ base_url = "https://api.openai.com/v1"
             .expect("save codex provider");
         db.set_current_provider("codex", &provider.id)
             .expect("set current codex provider");
+        let queued_provider = Provider::with_id(
+            "queued-codex-provider".to_string(),
+            "Queued Codex Provider".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "queued-provider-token"
+                },
+                "config": r#"model_provider = "queued"
+
+[model_providers.queued]
+base_url = "https://queued.example/v1"
+"#
+            }),
+            None,
+        );
+        db.save_provider("codex", &queued_provider)
+            .expect("save queued codex provider");
+        db.add_to_failover_queue("codex", &provider.id)
+            .expect("queue current codex provider");
+        db.add_to_failover_queue("codex", &queued_provider.id)
+            .expect("queue secondary codex provider");
 
         use_ephemeral_app_proxy_port(db.as_ref(), "codex");
 
@@ -7946,7 +8156,8 @@ base_url = "https://new.example/v1"
         let original_live = json!({
             "auth": {
                 "auth_mode": "chatgpt",
-                "tokens": { "access_token": "official-oauth-token" }
+                "tokens": { "access_token": "official-oauth-token" },
+                "OPENAI_API_KEY": "foreign-live-key"
             },
             "config": stale_config
         });
@@ -7961,6 +8172,16 @@ base_url = "https://new.example/v1"
         assert!(!config.contains("model_provider = \"custom\""));
         assert!(!config.contains("[model_providers.custom]"));
         assert!(config.contains("[mcp_servers.echo]"));
+        assert_eq!(
+            snapshot
+                .pointer("/auth/tokens/access_token")
+                .and_then(Value::as_str),
+            Some("official-oauth-token")
+        );
+        assert!(
+            snapshot.pointer("/auth/OPENAI_API_KEY").is_none(),
+            "official OAuth snapshot must not inherit a live API key"
+        );
     }
 
     #[tokio::test]
@@ -7987,7 +8208,10 @@ base_url = "https://new.example/v1"
         db.save_failover_live_snapshot(
             "codex",
             &provider.id,
-            &serde_json::to_string(&json!({ "auth": {}, "config": stale_config }))
+            &serde_json::to_string(&json!({
+                "auth": {"OPENAI_API_KEY": "foreign-live-key"},
+                "config": stale_config
+            }))
                 .expect("serialize stale snapshot"),
         )
         .await
@@ -8006,6 +8230,10 @@ base_url = "https://new.example/v1"
         assert!(config.contains("model = \"gpt-5.6-sol\""));
         assert!(!config.contains("model = \"gpt-5.4\""));
         assert!(config.contains("[mcp_servers.echo]"));
+        assert!(
+            normalized.pointer("/auth/OPENAI_API_KEY").is_none(),
+            "cached failover snapshot must drop a key absent from provider settings"
+        );
 
         let cached = db
             .get_failover_live_snapshot("codex", &provider.id)
@@ -8021,6 +8249,7 @@ base_url = "https://new.example/v1"
         assert!(!cached_config.contains("model_provider = \"custom\""));
         assert!(cached_config.contains("model = \"gpt-5.6-sol\""));
         assert!(cached_config.contains("[mcp_servers.echo]"));
+        assert!(!cached.config_json.contains("foreign-live-key"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### 问题

自动故障转移准备阶段会读取 live 配置并生成多个供应商快照，但 live 配置本身没有可靠的供应商归属。旧实现会把 live 中的 token 反向同步到 effective current provider，导致供应商 A 的 `OPENAI_API_KEY` 永久覆盖供应商 B 的持久化配置。

Codex 快照合并还可能把 live auth 中的 API key 带入其他供应商的 snapshot；升级前已经缓存的 snapshot 也不会自动修复。

### 修复

- 自动故障转移生成原始 live backup 时不再反向写入 provider 凭证。
- `auto_failover_enabled=true` 时禁止 live token 同步回 current provider。
- Codex failover snapshot 的 `auth.OPENAI_API_KEY` 强制来自目标 provider：
  - 目标 provider 有 key 时覆盖 snapshot 中的 key；
  - 目标 provider 无 key 时删除 snapshot 中遗留的 key。
- 缓存命中时同样执行 key 归一化并持久化修复结果。
- 保留 upstream v5.10.1 的 Codex bearer、OAuth、统一会话、model config 刷新，以及 Claude provider-owned env reconcile 行为。
- 自动故障转移关闭时仍保留原有的 live token -> current provider 同步能力。

### 测试

- live 使用供应商 A key、effective current 为供应商 B 时，两家 provider 配置均不会被改写。
- 每个 failover snapshot 的 key 与目标 provider 一致。
- official OAuth 登录材料会保留，但不会继承 foreign API key。
- 旧缓存 snapshot 会删除不属于目标 provider 的 key，同时继续刷新上游 model/MCP 配置。
- 非自动故障转移且配置多个队列供应商时，手动 takeover 仍会同步 live token。

### 安全说明

PR 和测试仅使用占位 key，不包含真实凭证。

### Problem

Automatic failover reads the live configuration while preparing snapshots for multiple providers, but the live configuration has no reliable provider identity. The previous implementation synchronized the live token back into the effective current provider, allowing provider A's `OPENAI_API_KEY` to permanently overwrite provider B's stored configuration.

Codex snapshot merging could also carry a live API key into another provider's snapshot, and stale cached snapshots were not repaired after upgrade.

### Fix

- Stop synchronizing live credentials while creating the original automatic-failover backup.
- Block live-token-to-current-provider synchronization while `auto_failover_enabled=true`.
- Force each Codex failover snapshot's `auth.OPENAI_API_KEY` to come from its target provider:
  - replace the snapshot key when the provider has one;
  - remove a stale snapshot key when the provider has none.
- Apply the same normalization to cached snapshots and persist repaired cache entries.
- Preserve upstream v5.10.1 behavior for Codex bearer auth, OAuth, unified sessions, model-config refresh, and Claude provider-owned environment reconciliation.
- Preserve the existing live-token synchronization behavior for non-automatic/manual takeover mode.

### Tests

- With provider A's key in live config and provider B as effective current, neither stored provider is overwritten.
- Every failover snapshot keeps the key of its target provider.
- Official OAuth login material is preserved without inheriting a foreign API key.
- Cached snapshots drop foreign keys while continuing to refresh upstream model and MCP configuration.
- Manual takeover still synchronizes the live token when automatic failover is disabled, even with multiple queued providers.

### Security note

The PR and tests use placeholder credentials only. No real key is included.
