### PR TITLE
feat(codex): add per-provider option to disable hosted web search

### DIFF
--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -2404,6 +2404,14 @@ pub mod texts {
         }
     }
 
+    pub fn tui_label_codex_disable_web_search() -> &'static str {
+        if is_chinese() {
+            "禁用内置联网搜索"
+        } else {
+            "Disable hosted web search"
+        }
+    }
+
     pub fn tui_label_claude_hide_attribution() -> &'static str {
         if is_chinese() {
             "隐藏 AI 署名"

--- a/src-tauri/src/cli/tui/app/form_handlers/provider.rs
+++ b/src-tauri/src/cli/tui/app/form_handlers/provider.rs
@@ -557,6 +557,13 @@ impl App {
                 provider.toggle_codex_remote_compaction();
                 Action::None
             }
+            ProviderAddField::CodexDisableWebSearch => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+                    return Action::None;
+                };
+                provider.toggle_codex_disable_web_search();
+                Action::None
+            }
             ProviderAddField::ClaudeHideAttribution => {
                 let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
                     return Action::None;

--- a/src-tauri/src/cli/tui/form.rs
+++ b/src-tauri/src/cli/tui/form.rs
@@ -287,6 +287,7 @@ pub enum ProviderAddField {
     CodexQuickConfig,
     CodexGoalMode,
     CodexRemoteCompaction,
+    CodexDisableWebSearch,
     #[allow(dead_code)]
     CodexWireApi,
     #[allow(dead_code)]
@@ -580,6 +581,8 @@ pub struct ProviderAddFormState {
     codex_goal_mode_touched: bool,
     pub codex_remote_compaction: bool,
     codex_remote_compaction_touched: bool,
+    pub codex_disable_web_search: bool,
+    codex_disable_web_search_touched: bool,
     pub codex_quick_config_idx: usize,
     pub codex_oauth_account_id: Option<String>,
     pub codex_fast_mode: bool,

--- a/src-tauri/src/cli/tui/form/provider_json.rs
+++ b/src-tauri/src/cli/tui/form/provider_json.rs
@@ -487,6 +487,16 @@ impl ProviderAddFormState {
             AppType::Codex => {
                 let (config_toml, model_catalog) = self.codex_config_and_model_catalog_for_save();
                 settings_obj.insert("config".to_string(), Value::String(config_toml));
+                if self.codex_disable_web_search_touched {
+                    if self.codex_disable_web_search {
+                        settings_obj.insert(
+                            crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY.to_string(),
+                            json!(true),
+                        );
+                    } else {
+                        settings_obj.remove(crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY);
+                    }
+                }
                 if self.is_codex_official_provider() {
                     let auth_value = settings_obj
                         .entry("auth".to_string())

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -198,6 +198,8 @@ impl ProviderAddFormState {
             codex_goal_mode_touched: false,
             codex_remote_compaction: false,
             codex_remote_compaction_touched: false,
+            codex_disable_web_search: false,
+            codex_disable_web_search_touched: false,
             codex_quick_config_idx: 0,
             codex_oauth_account_id: None,
             codex_fast_mode: false,
@@ -752,6 +754,7 @@ impl ProviderAddFormState {
             | ProviderAddField::CodexQuickConfig
             | ProviderAddField::CodexGoalMode
             | ProviderAddField::CodexRemoteCompaction
+            | ProviderAddField::CodexDisableWebSearch
             | ProviderAddField::CodexWireApi
             | ProviderAddField::CodexRequiresOpenaiAuth
             | ProviderAddField::ClaudeApiFormat
@@ -822,6 +825,7 @@ impl ProviderAddFormState {
             | ProviderAddField::CodexQuickConfig
             | ProviderAddField::CodexGoalMode
             | ProviderAddField::CodexRemoteCompaction
+            | ProviderAddField::CodexDisableWebSearch
             | ProviderAddField::CodexWireApi
             | ProviderAddField::CodexRequiresOpenaiAuth
             | ProviderAddField::ClaudeApiFormat
@@ -1109,14 +1113,23 @@ impl ProviderAddFormState {
         self.codex_remote_compaction_touched = true;
     }
 
+    pub fn toggle_codex_disable_web_search(&mut self) {
+        self.codex_disable_web_search = !self.codex_disable_web_search;
+        self.codex_disable_web_search_touched = true;
+    }
+
     /// The Codex quick toggles, in upstream order. They live on the Codex
     /// "快捷配置菜单" sub-page rather than the main field list. Goal mode is
     /// available for every Codex provider; remote compaction is only meaningful
-    /// for custom providers (upstream `showRemoteCompaction = category != "official"`).
+    /// for custom providers (upstream `showRemoteCompaction = category != "official"`);
+    /// disabling hosted web search applies to native Responses format only.
     pub fn codex_quick_config_fields(&self) -> Vec<ProviderAddField> {
         let mut fields = vec![ProviderAddField::CodexGoalMode];
         if !self.is_codex_official_provider() {
             fields.push(ProviderAddField::CodexRemoteCompaction);
+        }
+        if self.codex_is_native_format() {
+            fields.push(ProviderAddField::CodexDisableWebSearch);
         }
         fields
     }
@@ -1127,6 +1140,7 @@ impl ProviderAddFormState {
             .filter(|field| match field {
                 ProviderAddField::CodexGoalMode => self.codex_goal_mode,
                 ProviderAddField::CodexRemoteCompaction => self.codex_remote_compaction,
+                ProviderAddField::CodexDisableWebSearch => self.codex_disable_web_search,
                 _ => false,
             })
             .count()
@@ -2623,6 +2637,15 @@ impl ProviderAddFormState {
         matches!(self.app_type, AppType::Codex)
             && !self.is_codex_official_provider()
             && matches!(self.claude_api_format, ClaudeApiFormat::OpenAiChat)
+    }
+
+    /// Whether the Codex upstream format is native OpenAI Responses (no proxy
+    /// conversion). Hosted web-search control applies only here: Anthropic
+    /// gateways cannot carry the tool (always disabled) and Chat formats go
+    /// through the proxy which converts it.
+    pub fn codex_is_native_format(&self) -> bool {
+        matches!(self.app_type, AppType::Codex)
+            && matches!(self.claude_api_format, ClaudeApiFormat::OpenAiResponses)
     }
 
     pub fn apply_provider_json_to_fields(&mut self, provider: &Provider) {

--- a/src-tauri/src/cli/tui/form/provider_state_loading.rs
+++ b/src-tauri/src/cli/tui/form/provider_state_loading.rs
@@ -309,6 +309,11 @@ fn populate_codex_form(form: &mut ProviderAddFormState, provider: &Provider) {
     // The routing/mapping toggle has no dedicated stored field: a provider that
     // already carries a catalog is treated as having local routing enabled.
     form.codex_local_routing_enabled = !form.codex_model_catalog.is_empty();
+    form.codex_disable_web_search = provider
+        .settings_config
+        .get(crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY)
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
 }
 
 fn populate_gemini_form(form: &mut ProviderAddFormState, provider: &Provider) {

--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -2215,16 +2215,103 @@ fn provider_add_form_codex_collapses_quick_toggles_into_menu() {
         "the quick-config menu stays above the usage-query section"
     );
 
-    // The two toggles live on the sub-page, not the main field list.
+    // The toggles live on the sub-page, not the main field list.
     assert!(!fields.contains(&ProviderAddField::CodexGoalMode));
     assert!(!fields.contains(&ProviderAddField::CodexRemoteCompaction));
+    assert!(!fields.contains(&ProviderAddField::CodexDisableWebSearch));
+    // The default add-form format is native Responses, so the hosted
+    // web-search toggle is listed.
     assert_eq!(
         form.codex_quick_config_fields(),
         vec![
             ProviderAddField::CodexGoalMode,
             ProviderAddField::CodexRemoteCompaction,
+            ProviderAddField::CodexDisableWebSearch,
         ]
     );
+}
+
+#[test]
+fn provider_add_form_codex_disable_web_search_toggle_persists_and_removes_key() {
+    let mut form = ProviderAddFormState::new(AppType::Codex);
+    form.id.set("myco");
+    form.name.set("My Codex");
+    form.codex_base_url.set("https://api.example.com/v1");
+
+    assert_eq!(form.codex_quick_config_enabled_count(), 0);
+
+    form.toggle_codex_disable_web_search();
+    assert_eq!(form.codex_quick_config_enabled_count(), 1);
+    let provider = form.to_provider_json_value();
+    assert_eq!(
+        provider["settingsConfig"][crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY],
+        json!(true)
+    );
+
+    // Untoggling removes the key instead of persisting false.
+    form.toggle_codex_disable_web_search();
+    let provider = form.to_provider_json_value();
+    assert!(provider["settingsConfig"]
+        .get(crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY)
+        .is_none());
+}
+
+#[test]
+fn provider_add_form_codex_disable_web_search_toggle_skips_untouched_provider() {
+    // Saving without touching the toggle must not add the key.
+    let mut form = ProviderAddFormState::new(AppType::Codex);
+    form.id.set("myco");
+    form.name.set("My Codex");
+    let provider = form.to_provider_json_value();
+    assert!(provider["settingsConfig"]
+        .get(crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY)
+        .is_none());
+}
+
+#[test]
+fn provider_add_form_codex_disable_web_search_gated_to_native_format() {
+    let mut form = ProviderAddFormState::new(AppType::Codex);
+    assert!(form.codex_is_native_format());
+    assert!(form
+        .codex_quick_config_fields()
+        .contains(&ProviderAddField::CodexDisableWebSearch));
+
+    // Chat format: toggle must not be listed (the proxy converts the tool).
+    form.claude_api_format = ClaudeApiFormat::OpenAiChat;
+    assert!(!form
+        .codex_quick_config_fields()
+        .contains(&ProviderAddField::CodexDisableWebSearch));
+
+    // Anthropic format: always disabled, no toggle.
+    form.claude_api_format = ClaudeApiFormat::Anthropic;
+    assert!(!form
+        .codex_quick_config_fields()
+        .contains(&ProviderAddField::CodexDisableWebSearch));
+}
+
+#[test]
+fn provider_add_form_codex_disable_web_search_loads_from_provider() {
+    let provider = Provider::with_id(
+        "myco".to_string(),
+        "My Codex".to_string(),
+        json!({
+            "config": "model = \"gpt-x\"\n",
+            crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY: true,
+        }),
+        None,
+    );
+    let form = ProviderAddFormState::from_provider(AppType::Codex, &provider);
+    assert!(form.codex_disable_web_search);
+
+    // Absent key defaults to enabled web search.
+    let provider = Provider::with_id(
+        "myco".to_string(),
+        "My Codex".to_string(),
+        json!({ "config": "model = \"gpt-x\"\n" }),
+        None,
+    );
+    let form = ProviderAddFormState::from_provider(AppType::Codex, &provider);
+    assert!(!form.codex_disable_web_search);
 }
 
 #[test]
@@ -2484,10 +2571,15 @@ fn provider_add_form_codex_official_offers_goal_mode_only() {
         quick_config_idx == include_common_idx + 1,
         "the quick-config menu should sit directly below the add-common-config toggle"
     );
-    // Upstream shows remote compaction only for non-official providers.
+    // Upstream shows remote compaction only for non-official providers; the
+    // hosted web-search toggle applies to native Responses, so official
+    // providers keep it.
     assert_eq!(
         form.codex_quick_config_fields(),
-        vec![ProviderAddField::CodexGoalMode]
+        vec![
+            ProviderAddField::CodexGoalMode,
+            ProviderAddField::CodexDisableWebSearch,
+        ]
     );
 
     // Goal mode is a top-level [features] setting and still persists for

--- a/src-tauri/src/cli/tui/help.rs
+++ b/src-tauri/src/cli/tui/help.rs
@@ -754,8 +754,8 @@ fn provider_field_help(app_type: AppType, field: ProviderAddField) -> HelpConten
         ProviderAddField::CodexQuickConfig => HelpContent::new(
             texts::tui_label_codex_quick_config(),
             help_lines(
-                "打开 Codex 快捷配置菜单，集中管理启用 Goal mode、启用远程压缩等开关。",
-                "Opens the Codex quick-config menu that groups the Goal-mode and remote-compaction toggles.",
+                "打开 Codex 快捷配置菜单，集中管理启用 Goal mode、启用远程压缩、禁用内置联网搜索等开关。",
+                "Opens the Codex quick-config menu that groups the Goal-mode, remote-compaction, and hosted web-search toggles.",
             ),
         ),
         ProviderAddField::CodexGoalMode => HelpContent::new(
@@ -770,6 +770,13 @@ fn provider_field_help(app_type: AppType, field: ProviderAddField) -> HelpConten
             help_lines(
                 "开启后会将当前 model_providers 条目的 name 写为 OpenAI，使 Codex 尝试使用远程压缩；关闭时恢复原供应商名称。",
                 "When enabled, sets the current model_providers entry's name to \"OpenAI\" so Codex attempts remote compaction; turning it off restores the provider name.",
+            ),
+        ),
+        ProviderAddField::CodexDisableWebSearch => HelpContent::new(
+            texts::tui_label_codex_disable_web_search(),
+            help_lines(
+                "禁用 Codex 的内置联网搜索工具，生成 config.toml 时写入 web_search = \"disabled\"。仅对原生 Responses（openai_responses）格式的供应商生效：Anthropic 网关无法携带该工具（本就禁用），Chat 格式由本地代理转换，此开关不影响两者。关闭时只移除 cc-switch 之前写入的 disabled 值，用户手写的偏好（如 live）会被保留。",
+                "Disables Codex's hosted web-search tool by writing web_search = \"disabled\" into the generated config.toml. Applies only to native Responses (openai_responses) providers: Anthropic gateways cannot carry the tool (always disabled) and Chat formats are converted by the local proxy, so this toggle does not affect them. Turning it off only removes the disabled value previously written by cc-switch, preserving user-owned settings such as live.",
             ),
         ),
         ProviderAddField::ClaudeHideAttribution => HelpContent::new(

--- a/src-tauri/src/cli/tui/ui/forms/provider.rs
+++ b/src-tauri/src/cli/tui/ui/forms/provider.rs
@@ -1888,6 +1888,9 @@ pub(crate) fn provider_field_label_and_value(
         ProviderAddField::CodexRemoteCompaction => {
             texts::tui_label_codex_remote_compaction().to_string()
         }
+        ProviderAddField::CodexDisableWebSearch => {
+            texts::tui_label_codex_disable_web_search().to_string()
+        }
         ProviderAddField::ClaudeHideAttribution => {
             texts::tui_label_claude_hide_attribution().to_string()
         }
@@ -2006,6 +2009,13 @@ pub(crate) fn provider_field_label_and_value(
         }
         ProviderAddField::CodexRemoteCompaction => {
             if provider.codex_remote_compaction {
+                format!("[{}]", texts::tui_marker_active())
+            } else {
+                "[ ]".to_string()
+            }
+        }
+        ProviderAddField::CodexDisableWebSearch => {
+            if provider.codex_disable_web_search {
                 format!("[{}]", texts::tui_marker_active())
             } else {
                 "[ ]".to_string()

--- a/src-tauri/src/cli/tui/ui/forms/shared.rs
+++ b/src-tauri/src/cli/tui/ui/forms/shared.rs
@@ -57,6 +57,7 @@ pub(crate) fn add_form_key_items(
                         | ProviderAddField::ClaudeDisableAutoUpgrade
                         | ProviderAddField::CodexGoalMode
                         | ProviderAddField::CodexRemoteCompaction
+                        | ProviderAddField::CodexDisableWebSearch
                         | ProviderAddField::CodexFastMode
                         | ProviderAddField::OpenClawUserAgent
                         | ProviderAddField::IncludeCommonConfig,

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -45,45 +45,6 @@ impl CodexCatalogToolProfile {
     }
 }
 
-/// Native Responses gateways used by the migrated presets that reject Codex's
-/// hosted web-search tool.
-const CODEX_WEB_SEARCH_REJECT_HOSTS: &[&str] = &["xiaomimimo.com", "minimaxi.com"];
-const CODEX_WEB_SEARCH_REJECT_MODEL_PREFIXES: &[&str] = &["mimo", "minimax"];
-
-fn codex_top_level_model(config_text: &str) -> Option<String> {
-    let doc = config_text.parse::<toml::Value>().ok()?;
-    doc.get("model")
-        .and_then(toml::Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-}
-
-fn codex_native_gateway_rejects_web_search(config_text: &str) -> bool {
-    if let Some(base_url) = extract_codex_base_url(config_text) {
-        let base_url = base_url.to_ascii_lowercase();
-        if CODEX_WEB_SEARCH_REJECT_HOSTS
-            .iter()
-            .any(|host| base_url.contains(host))
-        {
-            return true;
-        }
-    }
-
-    if let Some(model) = codex_top_level_model(config_text) {
-        let model = model.to_ascii_lowercase();
-        let model = model.rsplit('/').next().unwrap_or(model.as_str());
-        if CODEX_WEB_SEARCH_REJECT_MODEL_PREFIXES
-            .iter()
-            .any(|prefix| model.starts_with(prefix))
-        {
-            return true;
-        }
-    }
-
-    false
-}
-
 /// Reserved built-in provider IDs from OpenAI Codex's config/model-provider
 /// catalog. Keep in sync with Codex `RESERVED_MODEL_PROVIDER_IDS` and legacy
 /// removed provider aliases.
@@ -940,7 +901,8 @@ const CODEX_WEB_SEARCH_REJECT_HOSTS: &[&str] = &[
     "minimax.io",     // MiniMax global (api.minimax.io)
     "minimaxi.com",   // MiniMax CN (api.minimaxi.com)
 ];
-const CODEX_WEB_SEARCH_REJECT_MODEL_PREFIXES: &[&str] = &["mimo", "longcat", "minimax"];
+const CODEX_WEB_SEARCH_REJECT_MODEL_PREFIXES: &[&str] =
+    &["mimo", "longcat", "minimax", "qwen3-coder"];
 
 /// Top-level `model` id from a Codex `config.toml`.
 fn codex_top_level_model(config_text: &str) -> Option<String> {
@@ -1808,6 +1770,12 @@ pub fn restore_codex_settings_for_backfill(
     ) {
         settings_obj.insert("modelCatalog".to_string(), model_catalog);
     }
+    if let (Some(settings_obj), Some(option)) = (
+        settings.as_object_mut(),
+        template_settings.get(CODEX_WEB_SEARCH_DISABLE_KEY).cloned(),
+    ) {
+        settings_obj.insert(CODEX_WEB_SEARCH_DISABLE_KEY.to_string(), option);
+    }
     Ok(())
 }
 
@@ -2523,8 +2491,26 @@ base_url = "https://api.deepseek.com"
             );
         }
 
-        // NOT blacklisted → keep Codex default (relays/GPT, DouBao, Qwen, and
-        // any unknown provider incl. an aggregator serving a non-reject model).
+        // Qwen3-Coder is rejected on the model axis (百炼 marks built-in tools
+        // unsupported for the coder series), incl. on the DashScope host and
+        // behind an aggregator "vendor/" prefix (upstream 26f0d221).
+        for (model, host) in [
+            (
+                "qwen3-coder-plus",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+            ("qwen3-coder-plus", "https://api.siliconflow.cn/v1"),
+            ("qwen/qwen3-coder-plus", "https://api.siliconflow.cn/v1"),
+        ] {
+            assert!(
+                codex_native_gateway_rejects_web_search(&cfg(model, host)),
+                "{model} @ {host} should be blacklisted by qwen3-coder brand"
+            );
+        }
+
+        // NOT blacklisted → keep Codex default (relays/GPT, DouBao, general
+        // Qwen models, and any unknown provider incl. an aggregator serving a
+        // non-reject model).
         for (model, host) in [
             ("gpt-5.5", "https://www.packyapi.com/v1"),
             ("gpt-5-codex", "https://aihubmix.com/v1"),
@@ -2533,7 +2519,11 @@ base_url = "https://api.deepseek.com"
                 "https://ark.cn-beijing.volces.com/api/v3",
             ),
             (
-                "qwen3-coder-plus",
+                "qwen-max",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+            (
+                "qwen3-max",
                 "https://dashscope.aliyuncs.com/compatible-mode/v1",
             ),
             ("Pro/moonshotai/Kimi-K2.6", "https://api.siliconflow.cn/v1"),
@@ -2675,9 +2665,9 @@ base_url = "https://api.deepseek.com"
             &settings,
             captured,
             CodexCatalogToolProfile::ProxyChat,
+        )
         .expect("prepare switch");
         assert_eq!(parse_web_search_field(&switched.config_text), None);
->>>>>>> 4436c8d4 (fix(codex): align web_search with upstream blacklist and fix option lifecycle)
     }
 
     #[test]

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -922,9 +922,99 @@ fn set_codex_model_catalog_json_field(
 
 pub(crate) const CODEX_WEB_SEARCH_FIELD: &str = "web_search";
 pub(crate) const CODEX_WEB_SEARCH_DISABLED: &str = "disabled";
-/// Per-provider settings key (in `settingsConfig`) that disables the hosted
-/// web-search tool for native `/responses` providers.
+/// Per-provider settings key (in `settingsConfig`) that forces the hosted
+/// web-search tool off for native `/responses` providers, overriding the
+/// host/model blacklist below.
 pub(crate) const CODEX_WEB_SEARCH_DISABLE_KEY: &str = "disableWebSearch";
+
+/// Native `/responses` gateways whose first-party models do NOT support the
+/// Codex `web_search` hosted tool (aligned with upstream d380b410). A BLACKLIST
+/// (default-on): everything not listed keeps Codex's default, so relays
+/// fronting real GPT and any unknown provider are never touched. Matched by
+/// `base_url` host substring and by the model id's brand prefix (after any
+/// `vendor/` segment), so an aggregator fronting a reject vendor's model is
+/// caught too.
+const CODEX_WEB_SEARCH_REJECT_HOSTS: &[&str] = &[
+    "xiaomimimo.com", // Xiaomi MiMo (api.xiaomimimo.com, token-plan-cn.xiaomimimo.com)
+    "longcat.chat",   // Meituan LongCat (api.longcat.chat)
+    "minimax.io",     // MiniMax global (api.minimax.io)
+    "minimaxi.com",   // MiniMax CN (api.minimaxi.com)
+];
+const CODEX_WEB_SEARCH_REJECT_MODEL_PREFIXES: &[&str] = &["mimo", "longcat", "minimax"];
+
+/// Top-level `model` id from a Codex `config.toml`.
+fn codex_top_level_model(config_text: &str) -> Option<String> {
+    let doc = config_text.parse::<toml::Value>().ok()?;
+    doc.get("model")
+        .and_then(|value| value.as_str())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// Whether a native `/responses` provider's gateway is known to reject the
+/// Codex `web_search` hosted tool — by `base_url` host OR by the active model's
+/// brand (so an aggregator fronting a reject vendor's model is caught too).
+/// Driven by the live `config.toml`, so it applies to existing providers
+/// without a re-save. Users can force-disable via `disableWebSearch` regardless.
+///
+/// Unlike `extract_codex_base_url`, the host check also falls back to the
+/// top-level `base_url` when the active provider section lacks one, mirroring
+/// upstream d380b410 so hand-written legacy flat configs still match.
+pub(crate) fn codex_native_gateway_rejects_web_search(config_text: &str) -> bool {
+    if let Some(base_url) =
+        extract_codex_base_url(config_text).or_else(|| codex_top_level_base_url(config_text))
+    {
+        let base_url = base_url.to_ascii_lowercase();
+        if CODEX_WEB_SEARCH_REJECT_HOSTS
+            .iter()
+            .any(|host| base_url.contains(host))
+        {
+            return true;
+        }
+    }
+    if let Some(model) = codex_top_level_model(config_text) {
+        let model = model.to_ascii_lowercase();
+        // Strip any aggregator "vendor/" prefix, e.g. "MiniMaxAI/MiniMax-M3".
+        let model = model.rsplit('/').next().unwrap_or(model.as_str());
+        if CODEX_WEB_SEARCH_REJECT_MODEL_PREFIXES
+            .iter()
+            .any(|prefix| model.starts_with(prefix))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Top-level `base_url` fallback for the blacklist host check (legacy flat
+/// configs that keep the URL at the root instead of the active provider
+/// section). Kept local to web-search detection: `extract_codex_base_url`
+/// deliberately does not fall back when `model_provider` is present.
+fn codex_top_level_base_url(config_text: &str) -> Option<String> {
+    config_text
+        .parse::<toml::Value>()
+        .ok()?
+        .get("base_url")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|base_url| !base_url.is_empty())
+        .map(str::to_string)
+}
+
+/// Copy provider-owned catalog-generation options (e.g. `disableWebSearch`)
+/// into a rebuilt Codex settings snapshot. Live-file rebuilds (backfill,
+/// temporary-launch capture) project only `{auth, config}`, so callers must
+/// re-apply these explicitly or the option is lost across a switch cycle.
+pub fn merge_codex_provider_catalog_options(
+    settings: &mut Value,
+    provider: &crate::provider::Provider,
+) {
+    if let Some(root) = settings.as_object_mut() {
+        if let Some(option) = provider.settings_config.get(CODEX_WEB_SEARCH_DISABLE_KEY) {
+            root.insert(CODEX_WEB_SEARCH_DISABLE_KEY.to_string(), option.clone());
+        }
+    }
+}
 
 /// Disable the hosted web-search tool for protocol paths that cannot carry it.
 /// Only remove values previously written by cc-switch, preserving user-owned
@@ -953,25 +1043,30 @@ pub struct PreparedCodexConfigText {
     pub model_catalog: Option<Value>,
 }
 
-pub fn prepare_codex_config_text_with_model_catalog_payload(
+fn prepare_codex_config_text_with_model_catalog_payload_impl(
     settings: &Value,
     config_text: &str,
     profile: CodexCatalogToolProfile,
+    manage_web_search: bool,
+    web_search_reject_override: Option<bool>,
 ) -> Result<PreparedCodexConfigText, AppError> {
     let catalog_path = get_codex_model_catalog_path();
 
-    if let Some(catalog) = codex_model_catalog_from_settings(settings, config_text, profile)? {
-        let config_text = set_codex_model_catalog_json_field(config_text, Some(&catalog_path))?;
-        // Anthropic gateways cannot carry the hosted web-search tool at all, so
-        // it is always disabled there. Native `/responses` providers disable it
-        // when their gateway is known to reject the tool (host/model blacklist)
-        // OR the per-provider `disableWebSearch` option forces it off. Chat
-        // profiles go through the proxy which converts the tool, so neither
-        // applies.
-        let disable_web_search = match profile {
+    // Anthropic gateways cannot carry the hosted web-search tool at all, so it
+    // is always disabled there. Native `/responses` providers disable it when
+    // their gateway is known to reject the tool (host/model blacklist) OR the
+    // per-provider `disableWebSearch` option forces it off. Chat profiles go
+    // through the proxy which converts the tool, so neither applies.
+    let disable_web_search = manage_web_search
+        && match profile {
             CodexCatalogToolProfile::Anthropic => true,
             CodexCatalogToolProfile::NativeResponses => {
-                codex_native_gateway_rejects_web_search(&config_text)
+                // The caller may supply the blacklist verdict explicitly when
+                // `config_text` no longer reflects the real gateway (proxy
+                // takeover rewrites base_url to the local proxy).
+                let rejects = web_search_reject_override
+                    .unwrap_or_else(|| codex_native_gateway_rejects_web_search(config_text));
+                rejects
                     || settings
                         .get(CODEX_WEB_SEARCH_DISABLE_KEY)
                         .and_then(Value::as_bool)
@@ -979,18 +1074,82 @@ pub fn prepare_codex_config_text_with_model_catalog_payload(
             }
             CodexCatalogToolProfile::ProxyChat => false,
         };
-        let config_text = set_codex_web_search_field(&config_text, disable_web_search)?;
+
+    if let Some(catalog) = codex_model_catalog_from_settings(settings, config_text, profile)? {
+        let config_text = set_codex_model_catalog_json_field(config_text, Some(&catalog_path))?;
+        let config_text = if manage_web_search {
+            set_codex_web_search_field(&config_text, disable_web_search)?
+        } else {
+            config_text
+        };
         Ok(PreparedCodexConfigText {
             config_text,
             model_catalog: Some(catalog),
         })
     } else {
         let config_text = set_codex_model_catalog_json_field(config_text, None)?;
+        let config_text = if manage_web_search {
+            set_codex_web_search_field(&config_text, disable_web_search)?
+        } else {
+            config_text
+        };
         Ok(PreparedCodexConfigText {
-            config_text: set_codex_web_search_field(&config_text, disable_web_search)?,
+            config_text,
             model_catalog: None,
         })
     }
+}
+
+pub fn prepare_codex_config_text_with_model_catalog_payload(
+    settings: &Value,
+    config_text: &str,
+    profile: CodexCatalogToolProfile,
+) -> Result<PreparedCodexConfigText, AppError> {
+    prepare_codex_config_text_with_model_catalog_payload_impl(
+        settings,
+        config_text,
+        profile,
+        true,
+        None,
+    )
+}
+
+/// Like `prepare_codex_config_text_with_model_catalog_payload`, but the caller
+/// supplies the blacklist verdict explicitly. Used by proxy-takeover writes,
+/// where `config_text`'s base_url was rewritten to the local proxy and no
+/// longer identifies the real gateway; the verdict is evaluated against the
+/// provider's stored (pre-rewrite) config instead.
+pub fn prepare_codex_config_text_with_model_catalog_payload_with_reject_verdict(
+    settings: &Value,
+    config_text: &str,
+    profile: CodexCatalogToolProfile,
+    web_search_reject_override: bool,
+) -> Result<PreparedCodexConfigText, AppError> {
+    prepare_codex_config_text_with_model_catalog_payload_impl(
+        settings,
+        config_text,
+        profile,
+        true,
+        Some(web_search_reject_override),
+    )
+}
+
+/// Verbatim-restore variant: the captured config text's `web_search` state is
+/// authoritative, so the field is neither written nor cleaned even when the
+/// restore profile differs (e.g. a native provider's snapshot restored through
+/// the provider-less ProxyChat fallback).
+pub fn prepare_codex_verbatim_config_text_with_model_catalog_payload(
+    settings: &Value,
+    config_text: &str,
+    profile: CodexCatalogToolProfile,
+) -> Result<PreparedCodexConfigText, AppError> {
+    prepare_codex_config_text_with_model_catalog_payload_impl(
+        settings,
+        config_text,
+        profile,
+        false,
+        None,
+    )
 }
 
 pub fn write_prepared_codex_model_catalog(
@@ -1013,17 +1172,22 @@ pub fn prepare_codex_config_text_with_model_catalog(
     Ok(prepared.config_text)
 }
 
-/// Project an inline provider model catalog when one is present.
-///
-/// Settings without `modelCatalog` may already carry a live
-/// `model_catalog_json` pointer, so their config text is preserved unchanged.
-pub fn prepare_codex_live_config_text_with_optional_catalog(
+/// Project an inline provider model catalog when one is present, preserving
+/// the captured text's `web_search` state (see
+/// `prepare_codex_verbatim_config_text_with_model_catalog_payload`).
+pub fn prepare_codex_live_config_text_with_optional_catalog_verbatim(
     settings: &Value,
     config_text: &str,
     profile: CodexCatalogToolProfile,
 ) -> Result<String, AppError> {
     if settings.get("modelCatalog").is_some() {
-        prepare_codex_config_text_with_model_catalog(settings, config_text, profile)
+        let prepared = prepare_codex_verbatim_config_text_with_model_catalog_payload(
+            settings,
+            config_text,
+            profile,
+        )?;
+        write_prepared_codex_model_catalog(&prepared)?;
+        Ok(prepared.config_text)
     } else {
         Ok(config_text.to_string())
     }
@@ -2323,6 +2487,197 @@ base_url = "https://api.deepseek.com"
         .expect("prepare capable-gateway config");
         let parsed: toml::Value = toml::from_str(&prepared.config_text).unwrap();
         assert!(parsed.get("web_search").is_none());
+    }
+
+    #[test]
+    fn web_search_blacklist_disables_only_known_reject_gateways() {
+        let cfg = |model: &str, base_url: &str| {
+            format!(
+                "model_provider = \"custom\"\nmodel = \"{model}\"\n\n[model_providers.custom]\nname = \"x\"\nbase_url = \"{base_url}\"\nwire_api = \"responses\"\n"
+            )
+        };
+
+        // Blacklisted by host (first-party reject gateways) → disable.
+        for (model, host) in [
+            ("mimo-v2.5-pro", "https://api.xiaomimimo.com/v1"),
+            ("mimo-v2.5", "https://token-plan-cn.xiaomimimo.com/v1"),
+            ("LongCat-2.0-Preview", "https://api.longcat.chat/openai/v1"),
+            ("MiniMax-M3", "https://api.minimax.io/v1"),
+            ("MiniMax-M3", "https://api.minimaxi.com/v1"),
+        ] {
+            assert!(
+                codex_native_gateway_rejects_web_search(&cfg(model, host)),
+                "{host} should be blacklisted"
+            );
+        }
+
+        // Blacklisted by MODEL brand even on an aggregator host → disable.
+        for (model, host) in [
+            ("MiniMax-M3", "https://api.siliconflow.cn/v1"),
+            ("MiniMaxAI/MiniMax-M3", "https://api.siliconflow.cn/v1"),
+            ("mimo-v2.5-pro", "https://some-aggregator.example/v1"),
+        ] {
+            assert!(
+                codex_native_gateway_rejects_web_search(&cfg(model, host)),
+                "{model} @ {host} should be blacklisted by model brand"
+            );
+        }
+
+        // NOT blacklisted → keep Codex default (relays/GPT, DouBao, Qwen, and
+        // any unknown provider incl. an aggregator serving a non-reject model).
+        for (model, host) in [
+            ("gpt-5.5", "https://www.packyapi.com/v1"),
+            ("gpt-5-codex", "https://aihubmix.com/v1"),
+            (
+                "doubao-seed-2-1-pro",
+                "https://ark.cn-beijing.volces.com/api/v3",
+            ),
+            (
+                "qwen3-coder-plus",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+            ("Pro/moonshotai/Kimi-K2.6", "https://api.siliconflow.cn/v1"),
+        ] {
+            assert!(
+                !codex_native_gateway_rejects_web_search(&cfg(model, host)),
+                "{model} @ {host} should NOT be blacklisted"
+            );
+        }
+    }
+
+    #[test]
+    fn blacklist_host_check_falls_back_to_top_level_base_url() {
+        // Legacy hand-written flat config: model_provider present but the
+        // active section lacks base_url; the URL lives at the top level.
+        // Upstream's extraction falls back, so the blacklist must too.
+        let config = "model_provider = \"custom\"\nmodel = \"custom-brand\"\nbase_url = \"https://api.minimaxi.com/v1\"\n";
+        assert!(
+            codex_native_gateway_rejects_web_search(config),
+            "top-level base_url must satisfy the host blacklist"
+        );
+    }
+
+    #[test]
+    fn reject_verdict_override_keeps_disabled_after_base_url_rewrite() {
+        // Simulates proxy takeover: the live text's base_url was rewritten to
+        // the local proxy, but the stored provider config names a blacklisted
+        // gateway. The explicit verdict must keep web_search = "disabled".
+        let rewritten = "model_provider = \"custom\"\nmodel = \"custom-brand\"\n\n[model_providers.custom]\nbase_url = \"http://127.0.0.1:15721/v1\"\n";
+        let stored = "model_provider = \"custom\"\nmodel = \"custom-brand\"\n\n[model_providers.custom]\nbase_url = \"https://api.minimaxi.com/v1\"\n";
+        let settings =
+            json!({ "modelCatalog": { "models": [json!({ "model": "custom-brand" })] } });
+
+        // Without the verdict, the rewritten proxy host misses the blacklist
+        // and the sentinel would be cleaned.
+        let naive = prepare_codex_config_text_with_model_catalog_payload(
+            &settings,
+            rewritten,
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("prepare rewritten config");
+        assert_eq!(parse_web_search_field(&naive.config_text), None);
+
+        // With the verdict from the stored config, "disabled" stays.
+        let verdict = crate::codex_config::codex_native_gateway_rejects_web_search(stored);
+        assert!(verdict);
+        let prepared = prepare_codex_config_text_with_model_catalog_payload_with_reject_verdict(
+            &settings,
+            rewritten,
+            CodexCatalogToolProfile::NativeResponses,
+            verdict,
+        )
+        .expect("prepare takeover config");
+        assert_eq!(
+            parse_web_search_field(&prepared.config_text).as_deref(),
+            Some(CODEX_WEB_SEARCH_DISABLED)
+        );
+    }
+
+    #[test]
+    fn native_reject_gateway_writes_disabled_without_user_option() {
+        // A blacklisted native gateway is disabled by default: no option key
+        // needed (aligned with upstream, unlike the toggle which is an
+        // optional force-disable override).
+        let config =
+            "model = \"mimo-v2.5-pro\"\n\n[model_providers.custom]\nbase_url = \"https://api.xiaomimimo.com/v1\"\n";
+        let native = prepare_codex_config_text_with_model_catalog_payload(
+            &json!({}),
+            config,
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("prepare native config");
+        assert_eq!(
+            parse_web_search_field(&native.config_text).as_deref(),
+            Some(CODEX_WEB_SEARCH_DISABLED)
+        );
+    }
+
+    #[test]
+    fn switch_away_and_back_cycles_web_search_field() {
+        // Switch to a blacklisted native provider → disabled written.
+        let native_cfg =
+            "model = \"mimo-v2.5-pro\"\n\n[model_providers.custom]\nbase_url = \"https://api.xiaomimimo.com/v1\"\n";
+        let native = prepare_codex_config_text_with_model_catalog_payload(
+            &json!({}),
+            native_cfg,
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("prepare native config");
+        assert_eq!(
+            parse_web_search_field(&native.config_text).as_deref(),
+            Some(CODEX_WEB_SEARCH_DISABLED)
+        );
+
+        // Switch away to a chat provider → cc-switch's sentinel removed.
+        let chat = prepare_codex_config_text_with_model_catalog_payload(
+            &json!({}),
+            &native.config_text,
+            CodexCatalogToolProfile::ProxyChat,
+        )
+        .expect("prepare chat config");
+        assert_eq!(parse_web_search_field(&chat.config_text), None);
+
+        // Switch back → disabled written again.
+        let back = prepare_codex_config_text_with_model_catalog_payload(
+            &json!({}),
+            &chat.config_text,
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("prepare native config again");
+        assert_eq!(
+            parse_web_search_field(&back.config_text).as_deref(),
+            Some(CODEX_WEB_SEARCH_DISABLED)
+        );
+    }
+
+    #[test]
+    fn verbatim_restore_preserves_disabled_field_across_proxy_chat_profile() {
+        // A native provider's captured live config carries the sentinel; the
+        // provider-less restore path uses the ProxyChat fallback profile and
+        // must NOT strip it.
+        let captured = "model = \"mimo-v2.5-pro\"\nweb_search = \"disabled\"\n\n[model_providers.custom]\nbase_url = \"https://api.xiaomimimo.com/v1\"\n";
+        let settings =
+            json!({ "modelCatalog": { "models": [json!({ "model": "mimo-v2.5-pro" })] } });
+
+        let verbatim = prepare_codex_verbatim_config_text_with_model_catalog_payload(
+            &settings,
+            captured,
+            CodexCatalogToolProfile::ProxyChat,
+        )
+        .expect("prepare verbatim restore");
+        assert_eq!(
+            parse_web_search_field(&verbatim.config_text).as_deref(),
+            Some(CODEX_WEB_SEARCH_DISABLED)
+        );
+
+        // The non-verbatim path keeps cleaning (switch semantics).
+        let switched = prepare_codex_config_text_with_model_catalog_payload(
+            &settings,
+            captured,
+            CodexCatalogToolProfile::ProxyChat,
+        .expect("prepare switch");
+        assert_eq!(parse_web_search_field(&switched.config_text), None);
+>>>>>>> 4436c8d4 (fix(codex): align web_search with upstream blacklist and fix option lifecycle)
     }
 
     #[test]

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -922,6 +922,9 @@ fn set_codex_model_catalog_json_field(
 
 pub(crate) const CODEX_WEB_SEARCH_FIELD: &str = "web_search";
 pub(crate) const CODEX_WEB_SEARCH_DISABLED: &str = "disabled";
+/// Per-provider settings key (in `settingsConfig`) that disables the hosted
+/// web-search tool for native `/responses` providers.
+pub(crate) const CODEX_WEB_SEARCH_DISABLE_KEY: &str = "disableWebSearch";
 
 /// Disable the hosted web-search tool for protocol paths that cannot carry it.
 /// Only remove values previously written by cc-switch, preserving user-owned
@@ -959,10 +962,20 @@ pub fn prepare_codex_config_text_with_model_catalog_payload(
 
     if let Some(catalog) = codex_model_catalog_from_settings(settings, config_text, profile)? {
         let config_text = set_codex_model_catalog_json_field(config_text, Some(&catalog_path))?;
+        // Anthropic gateways cannot carry the hosted web-search tool at all, so
+        // it is always disabled there. Native `/responses` providers disable it
+        // when their gateway is known to reject the tool (host/model blacklist)
+        // OR the per-provider `disableWebSearch` option forces it off. Chat
+        // profiles go through the proxy which converts the tool, so neither
+        // applies.
         let disable_web_search = match profile {
             CodexCatalogToolProfile::Anthropic => true,
             CodexCatalogToolProfile::NativeResponses => {
                 codex_native_gateway_rejects_web_search(&config_text)
+                    || settings
+                        .get(CODEX_WEB_SEARCH_DISABLE_KEY)
+                        .and_then(Value::as_bool)
+                        == Some(true)
             }
             CodexCatalogToolProfile::ProxyChat => false,
         };
@@ -974,10 +987,7 @@ pub fn prepare_codex_config_text_with_model_catalog_payload(
     } else {
         let config_text = set_codex_model_catalog_json_field(config_text, None)?;
         Ok(PreparedCodexConfigText {
-            config_text: set_codex_web_search_field(
-                &config_text,
-                profile == CodexCatalogToolProfile::Anthropic,
-            )?,
+            config_text: set_codex_web_search_field(&config_text, disable_web_search)?,
             model_catalog: None,
         })
     }
@@ -2180,6 +2190,95 @@ mod tests {
         let parsed: toml::Value =
             toml::from_str(&proxy.config_text).expect("parse proxy-chat config");
         assert!(parsed.get("web_search").is_none());
+    }
+
+    fn parse_web_search_field(config_text: &str) -> Option<String> {
+        toml::from_str::<toml::Value>(config_text)
+            .ok()
+            .and_then(|parsed| {
+                parsed
+                    .get("web_search")
+                    .and_then(toml::Value::as_str)
+                    .map(str::to_string)
+            })
+    }
+
+    #[test]
+    fn native_responses_disable_web_search_option_writes_disabled_field() {
+        let config = "model = \"gpt-5.6\"\n";
+        let settings = json!({ CODEX_WEB_SEARCH_DISABLE_KEY: true });
+
+        let native = prepare_codex_config_text_with_model_catalog_payload(
+            &settings,
+            config,
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("prepare native config");
+        assert_eq!(
+            parse_web_search_field(&native.config_text).as_deref(),
+            Some(CODEX_WEB_SEARCH_DISABLED)
+        );
+    }
+
+    #[test]
+    fn native_responses_without_option_keeps_web_search_field_absent() {
+        let config = "model = \"gpt-5.6\"\n";
+        let settings = json!({});
+
+        let native = prepare_codex_config_text_with_model_catalog_payload(
+            &settings,
+            config,
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("prepare native config");
+        assert_eq!(parse_web_search_field(&native.config_text), None);
+
+        // Explicit false behaves like absent.
+        let off = prepare_codex_config_text_with_model_catalog_payload(
+            &json!({ CODEX_WEB_SEARCH_DISABLE_KEY: false }),
+            config,
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("prepare native config");
+        assert_eq!(parse_web_search_field(&off.config_text), None);
+    }
+
+    #[test]
+    fn native_responses_option_off_removes_previous_disabled_value() {
+        let config = "model = \"gpt-5.6\"\nweb_search = \"disabled\"\n";
+        let off = prepare_codex_config_text_with_model_catalog_payload(
+            &json!({ CODEX_WEB_SEARCH_DISABLE_KEY: false }),
+            config,
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("prepare native config");
+        assert_eq!(parse_web_search_field(&off.config_text), None);
+
+        // User-owned values survive the cleanup.
+        let live = prepare_codex_config_text_with_model_catalog_payload(
+            &json!({ CODEX_WEB_SEARCH_DISABLE_KEY: false }),
+            "model = \"gpt-5.6\"\nweb_search = \"live\"\n",
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("prepare native config");
+        assert_eq!(
+            parse_web_search_field(&live.config_text).as_deref(),
+            Some("live")
+        );
+    }
+
+    #[test]
+    fn proxy_chat_profile_ignores_disable_web_search_option() {
+        let config = "model = \"gpt-5.6\"\n";
+        let settings = json!({ CODEX_WEB_SEARCH_DISABLE_KEY: true });
+
+        let proxy = prepare_codex_config_text_with_model_catalog_payload(
+            &settings,
+            config,
+            CodexCatalogToolProfile::ProxyChat,
+        )
+        .expect("prepare proxy-chat config");
+        assert_eq!(parse_web_search_field(&proxy.config_text), None);
     }
 
     #[test]

--- a/src-tauri/src/services/provider/codex.rs
+++ b/src-tauri/src/services/provider/codex.rs
@@ -49,6 +49,13 @@ impl ProviderService {
         raw_settings.insert("auth".to_string(), auth);
         raw_settings.insert("config".to_string(), Value::String(cfg_text_for_storage));
         let mut settings_to_store = Value::Object(raw_settings);
+        // The rebuild projects only {auth, config}; carry provider-owned
+        // catalog options (e.g. disableWebSearch) so they survive the switch
+        // cycle.
+        crate::codex_config::merge_codex_provider_catalog_options(
+            &mut settings_to_store,
+            &provider,
+        );
         if Self::codex_live_write_category(&provider) == Some("official") {
             crate::codex_config::strip_codex_unified_session_bucket_from_settings(
                 &mut settings_to_store,
@@ -451,6 +458,11 @@ impl ProviderService {
                     &mut settings_for_storage,
                 )?;
             }
+            // Carry provider-owned catalog options across the live rebuild.
+            crate::codex_config::merge_codex_provider_catalog_options(
+                &mut settings_for_storage,
+                &snapshot_provider,
+            );
             snapshot_provider.settings_config = settings_for_storage;
             snapshot_provider = Self::migrate_provider_snapshot_for_storage(
                 &AppType::Codex,
@@ -473,7 +485,13 @@ impl ProviderService {
             if let Some(auth) = capture_auth {
                 raw_settings.insert("auth".to_string(), auth);
             }
-            snapshot_provider.settings_config = Value::Object(raw_settings);
+            let mut settings_for_storage = Value::Object(raw_settings);
+            // Carry provider-owned catalog options across the live rebuild.
+            crate::codex_config::merge_codex_provider_catalog_options(
+                &mut settings_for_storage,
+                &snapshot_provider,
+            );
+            snapshot_provider.settings_config = settings_for_storage;
         };
         if let Some(manager) = config.get_manager_mut(&AppType::Codex) {
             if let Some(current) = manager.providers.get_mut(current_id) {

--- a/src-tauri/src/services/provider/tests.rs
+++ b/src-tauri/src/services/provider/tests.rs
@@ -333,6 +333,99 @@ fn capture_codex_temp_launch_snapshot_persists_auth_and_config() {
 }
 
 #[test]
+fn capture_codex_temp_launch_snapshot_preserves_disable_web_search_option() {
+    let mut config = MultiAppConfig::default();
+    config.ensure_app(&AppType::Codex);
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "official".to_string();
+        let mut settings = codex_settings("model_reasoning_effort = \"medium\"\n");
+        settings.as_object_mut().expect("settings object").insert(
+            crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY.to_string(),
+            json!(true),
+        );
+        manager.providers.insert(
+            "official".to_string(),
+            Provider::with_id(
+                "official".to_string(),
+                "OpenAI Official".to_string(),
+                settings,
+                None,
+            ),
+        );
+    }
+    let state = state_from_config(config);
+    let temp = TempDir::new().expect("create temp codex home");
+    std::fs::write(temp.path().join("config.toml"), "model = \"gpt-5.6\"\n").expect("write config");
+
+    ProviderService::capture_codex_temp_launch_snapshot(&state, "official", temp.path())
+        .expect("capture temp launch snapshot");
+
+    let providers = ProviderService::list(&state, AppType::Codex).expect("list providers");
+    let provider = providers.get("official").expect("provider should remain");
+    assert_eq!(
+        provider
+            .settings_config
+            .get(crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY),
+        Some(&json!(true)),
+        "the live rebuild must carry provider-owned catalog options"
+    );
+}
+
+#[test]
+fn backfill_codex_current_preserves_disable_web_search_option() {
+    let temp = TempDir::new().expect("create temp codex home");
+    let _guard = TestEnvGuard::isolated(temp.path());
+    let codex_home = temp.path().join(".codex");
+    std::fs::create_dir_all(&codex_home).expect("create codex home");
+    std::fs::write(codex_home.join("config.toml"), "model = \"gpt-5.6\"\n").expect("write config");
+
+    let mut config = MultiAppConfig::default();
+    config.ensure_app(&AppType::Codex);
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "current".to_string();
+        let mut settings = codex_settings("model = \"gpt-5.6\"\n");
+        settings.as_object_mut().expect("settings object").insert(
+            crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY.to_string(),
+            json!(true),
+        );
+        manager.providers.insert(
+            "current".to_string(),
+            Provider::with_id("current".to_string(), "Current".to_string(), settings, None),
+        );
+        manager.providers.insert(
+            "next".to_string(),
+            Provider::with_id(
+                "next".to_string(),
+                "Next".to_string(),
+                codex_settings("model = \"gpt-x\"\n"),
+                None,
+            ),
+        );
+    }
+
+    ProviderService::backfill_codex_current(&mut config, "next", Some("current"))
+        .expect("backfill current provider");
+
+    let provider = config
+        .get_manager(&AppType::Codex)
+        .and_then(|manager| manager.providers.get("current"))
+        .expect("provider should remain");
+    assert_eq!(
+        provider
+            .settings_config
+            .get(crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY),
+        Some(&json!(true)),
+        "backfill must carry provider-owned catalog options"
+    );
+}
+
+#[test]
 fn capture_codex_temp_launch_snapshot_clears_auth_when_auth_file_is_missing() {
     let mut config = MultiAppConfig::default();
     config.ensure_app(&AppType::Codex);

--- a/src-tauri/src/services/provider/tests.rs
+++ b/src-tauri/src/services/provider/tests.rs
@@ -375,6 +375,75 @@ fn capture_codex_temp_launch_snapshot_preserves_disable_web_search_option() {
 }
 
 #[test]
+fn switch_codex_cycle_preserves_disable_web_search_option_on_active_provider() {
+    let temp_home = TempDir::new().expect("create temp home");
+    let _env = TestEnvGuard::isolated(temp_home.path());
+    std::fs::create_dir_all(crate::codex_config::get_codex_config_dir())
+        .expect("create ~/.codex (initialized)");
+
+    let mut config = MultiAppConfig::default();
+    config.ensure_app(&AppType::Codex);
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "p1".to_string();
+        manager.providers.insert(
+            "p1".to_string(),
+            Provider::with_id(
+                "p1".to_string(),
+                "Provider One".to_string(),
+                json!({
+                    "auth": { "OPENAI_API_KEY": "sk-one" },
+                    // Non-blacklisted host: the disable must come solely from
+                    // the stored option, proving it survives the switch cycle.
+                    "config": "model_provider = \"custom\"\nmodel = \"gpt-4o\"\n\n[model_providers.custom]\nbase_url = \"https://api.one.example/v1\"\nwire_api = \"responses\"\n",
+                    crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY: true,
+                }),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "p2".to_string(),
+            Provider::with_id(
+                "p2".to_string(),
+                "Provider Two".to_string(),
+                json!({
+                    "auth": { "OPENAI_API_KEY": "sk-two" },
+                    "config": "model_provider = \"custom\"\nmodel = \"gpt-4o\"\n\n[model_providers.custom]\nbase_url = \"https://api.two.example/v1\"\nwire_api = \"responses\"\n",
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = state_from_config(config);
+
+    // Seed p1 live, switch away, switch back: a real ProviderService::switch
+    // cycle that exercises backfill capture + refresh_provider_snapshot.
+    ProviderService::switch(&state, AppType::Codex, "p1").expect("seed p1 live");
+    ProviderService::switch(&state, AppType::Codex, "p2").expect("switch to p2");
+    ProviderService::switch(&state, AppType::Codex, "p1").expect("switch back to p1");
+
+    // The refreshed snapshot of the newly active provider must keep the option.
+    let providers = ProviderService::list(&state, AppType::Codex).expect("list providers");
+    let p1 = providers.get("p1").expect("p1 exists");
+    assert_eq!(
+        p1.settings_config
+            .get(crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY),
+        Some(&json!(true)),
+        "refresh_provider_snapshot must preserve disableWebSearch"
+    );
+
+    let live_text =
+        std::fs::read_to_string(get_codex_config_path()).expect("read live config.toml");
+    assert!(
+        live_text.contains("web_search = \"disabled\""),
+        "live config must disable web_search via the preserved option"
+    );
+}
+
+#[test]
 fn backfill_codex_current_preserves_disable_web_search_option() {
     let temp = TempDir::new().expect("create temp codex home");
     let _guard = TestEnvGuard::isolated(temp.path());

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3680,23 +3680,6 @@ impl ProxyService {
         self.write_codex_live_verbatim(config)
     }
 
-    /// Merge per-provider catalog-generation options that the effective live
-    /// snapshot (for Codex only `{auth, config}`) would otherwise drop, so the
-    /// generated config honors e.g. `disableWebSearch`.
-    fn merge_codex_provider_catalog_options(settings: &mut Value, provider: &Provider) {
-        if let Some(root) = settings.as_object_mut() {
-            if let Some(option) = provider
-                .settings_config
-                .get(crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY)
-            {
-                root.insert(
-                    crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY.to_string(),
-                    option.clone(),
-                );
-            }
-        }
-    }
-
     fn write_codex_live_for_provider(
         &self,
         config: &Value,
@@ -3749,7 +3732,7 @@ impl ProxyService {
                 );
             }
         }
-        Self::merge_codex_provider_catalog_options(&mut settings, provider);
+        crate::codex_config::merge_codex_provider_catalog_options(&mut settings, provider);
 
         let profile = crate::proxy::providers::codex_provider_catalog_tool_profile(provider);
         crate::codex_config::write_codex_provider_live_with_catalog(
@@ -3792,7 +3775,7 @@ impl ProxyService {
                 }
             }
             if let Some(provider) = provider {
-                Self::merge_codex_provider_catalog_options(&mut settings, provider);
+                crate::codex_config::merge_codex_provider_catalog_options(&mut settings, provider);
             }
 
             let config_text = config
@@ -3802,13 +3785,36 @@ impl ProxyService {
             let profile = provider
                 .map(crate::proxy::providers::codex_provider_catalog_tool_profile)
                 .unwrap_or(crate::codex_config::CodexCatalogToolProfile::ProxyChat);
-            let prepared_config =
-                crate::codex_config::prepare_codex_live_config_text_with_optional_catalog(
+            // rewrite_live_for_proxy already replaced the live base_url with
+            // the local proxy address, so the web_search blacklist verdict
+            // must come from the provider's stored (pre-rewrite) config;
+            // otherwise host-blacklisted gateways lose their
+            // web_search = "disabled" during takeover and get rejected 400s.
+            let web_search_reject_override = provider
+                .and_then(|provider| {
+                    provider
+                        .settings_config
+                        .get("config")
+                        .and_then(Value::as_str)
+                        .map(crate::codex_config::codex_native_gateway_rejects_web_search)
+                })
+                .unwrap_or_else(|| {
+                    crate::codex_config::codex_native_gateway_rejects_web_search(config_text)
+                });
+            let prepared_config = if settings.get("modelCatalog").is_some() {
+                let prepared = crate::codex_config::prepare_codex_config_text_with_model_catalog_payload_with_reject_verdict(
                     &settings,
                     config_text,
                     profile,
+                    web_search_reject_override,
                 )
                 .map_err(|error| format!("write Codex live config failed: {error}"))?;
+                crate::codex_config::write_prepared_codex_model_catalog(&prepared)
+                    .map_err(|error| format!("write Codex live config failed: {error}"))?;
+                prepared.config_text
+            } else {
+                config_text.to_string()
+            };
             let live_config =
                 crate::codex_config::prepare_codex_provider_live_config(auth, &prepared_config)
                     .map_err(|error| format!("write Codex live config failed: {error}"))?;
@@ -3846,7 +3852,7 @@ impl ProxyService {
                 );
             }
         }
-        Self::merge_codex_provider_catalog_options(&mut settings, provider);
+        crate::codex_config::merge_codex_provider_catalog_options(&mut settings, provider);
 
         let profile = crate::proxy::providers::codex_provider_catalog_tool_profile(provider);
         crate::codex_config::write_codex_provider_live_config_only_with_catalog(
@@ -3864,10 +3870,12 @@ impl ProxyService {
 
         // A saved live snapshot may carry an inline model catalog, so prepare
         // the config once for every restore branch before deciding whether
-        // auth.json also needs to be written.
+        // auth.json also needs to be written. The captured text's web_search
+        // state is authoritative: a native provider's `web_search = "disabled"`
+        // must survive the provider-less ProxyChat fallback profile here.
         let prepared_config = config_text
             .map(|config_text| {
-                crate::codex_config::prepare_codex_live_config_text_with_optional_catalog(
+                crate::codex_config::prepare_codex_live_config_text_with_optional_catalog_verbatim(
                     config,
                     config_text,
                     crate::codex_config::CodexCatalogToolProfile::ProxyChat,

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3680,6 +3680,23 @@ impl ProxyService {
         self.write_codex_live_verbatim(config)
     }
 
+    /// Merge per-provider catalog-generation options that the effective live
+    /// snapshot (for Codex only `{auth, config}`) would otherwise drop, so the
+    /// generated config honors e.g. `disableWebSearch`.
+    fn merge_codex_provider_catalog_options(settings: &mut Value, provider: &Provider) {
+        if let Some(root) = settings.as_object_mut() {
+            if let Some(option) = provider
+                .settings_config
+                .get(crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY)
+            {
+                root.insert(
+                    crate::codex_config::CODEX_WEB_SEARCH_DISABLE_KEY.to_string(),
+                    option.clone(),
+                );
+            }
+        }
+    }
+
     fn write_codex_live_for_provider(
         &self,
         config: &Value,
@@ -3732,6 +3749,7 @@ impl ProxyService {
                 );
             }
         }
+        Self::merge_codex_provider_catalog_options(&mut settings, provider);
 
         let profile = crate::proxy::providers::codex_provider_catalog_tool_profile(provider);
         crate::codex_config::write_codex_provider_live_with_catalog(
@@ -3772,6 +3790,9 @@ impl ProxyService {
                             .unwrap_or_else(|| json!({ "models": [] })),
                     );
                 }
+            }
+            if let Some(provider) = provider {
+                Self::merge_codex_provider_catalog_options(&mut settings, provider);
             }
 
             let config_text = config
@@ -3825,6 +3846,7 @@ impl ProxyService {
                 );
             }
         }
+        Self::merge_codex_provider_catalog_options(&mut settings, provider);
 
         let profile = crate::proxy::providers::codex_provider_catalog_tool_profile(provider);
         crate::codex_config::write_codex_provider_live_config_only_with_catalog(

--- a/src-tauri/tests/proxy_takeover.rs
+++ b/src-tauri/tests/proxy_takeover.rs
@@ -1014,6 +1014,79 @@ async fn disabling_one_managed_app_restores_only_that_app_while_shared_runtime_k
     );
 }
 
+#[tokio::test]
+#[serial]
+async fn codex_takeover_keeps_web_search_disabled_for_blacklisted_gateway() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let home = ensure_test_home();
+    let _test_process_cleanup = TestProcessCleanup::new(home);
+
+    // A native /responses gateway on the web_search reject blacklist (host
+    // match only; the model brand is intentionally not a reject prefix).
+    let provider_config =
+        "model_provider = \"custom\"\nmodel = \"custom-brand\"\n\n[model_providers.custom]\nbase_url = \"https://api.minimaxi.com/v1\"\nwire_api = \"responses\"\n";
+    let mut provider = Provider::with_id(
+        "p1".to_string(),
+        "MiniMax".to_string(),
+        json!({
+            "auth": { "OPENAI_API_KEY": "sk-minimax" },
+            "config": provider_config,
+        }),
+        None,
+    );
+    provider.meta = Some(ProviderMeta {
+        ..Default::default()
+    });
+
+    let seeded = AppState::try_new().expect("create app state");
+    seeded
+        .db
+        .save_provider("codex", &provider)
+        .expect("save codex provider");
+    seeded
+        .db
+        .set_current_provider("codex", "p1")
+        .expect("set current codex provider");
+
+    // The live config already carries cc-switch's web_search sentinel from a
+    // previous switch; takeover must preserve it, not clean it.
+    seed_codex_live(
+        &json!({ "OPENAI_API_KEY": "sk-minimax" }),
+        "model_provider = \"custom\"\nmodel = \"custom-brand\"\nweb_search = \"disabled\"\n\n[model_providers.custom]\nbase_url = \"https://api.minimaxi.com/v1\"\nwire_api = \"responses\"\n",
+    );
+
+    let mut codex_port = find_free_port();
+    set_app_proxy_port(&seeded.db, "codex", codex_port).await;
+    seeded
+        .proxy_service
+        .set_managed_session_for_app("codex", true)
+        .await
+        .expect("start managed proxy for codex");
+    let _cleanup = ManagedSessionCleanup::new(load_runtime_session_pid(&seeded, "codex"));
+
+    let taken_over =
+        std::fs::read_to_string(get_codex_config_path()).expect("read taken-over codex config");
+    assert!(
+        taken_over.contains("127.0.0.1") && taken_over.contains("/v1"),
+        "Codex should route through the local proxy during takeover"
+    );
+    assert!(
+        taken_over.contains("web_search = \"disabled\""),
+        "takeover must keep web_search = \"disabled\" for the blacklisted gateway: {taken_over}"
+    );
+    assert!(
+        !taken_over.contains("api.minimaxi.com"),
+        "the original gateway host is rewritten away, so only the stored-config verdict can keep the sentinel"
+    );
+
+    seeded
+        .proxy_service
+        .set_managed_session_for_app("codex", false)
+        .await
+        .expect("disable managed proxy for codex");
+}
+
 #[cfg(unix)]
 #[test]
 #[serial]


### PR DESCRIPTION
## 动机

Codex 供应商走原生 `/responses`（NativeResponses）格式直连网关时，部分网关不支持 hosted web-search 工具；此前 cc-switch 只能通过 model catalog 的 `supports_search_tool: false` 隐式抑制工具声明，无法在 config.toml 顶层显式禁用。本 PR 为这类供应商提供「禁用内置联网搜索」开关，控制 `web_search` 字段的生成。

## 行为变化

- 表单新增开关（Codex 快捷配置菜单），仅对原生 Responses（`openai_responses`）格式的供应商显示；官方 OAuth 供应商同样可见
- 开关开启时，生成 live config.toml 写入 `web_search = "disabled"`
- 关闭/未设置：不写入；仅清理 cc-switch 之前写入的恰好为 `"disabled"` 的值，用户手写的 `"live"` 等偏好保留
- Anthropic 格式维持现状（恒禁用，Messages 桥无法携带该工具）；Chat 格式不受影响（本地代理负责转换）
- 选项持久化于 `settingsConfig.disableWebSearch`（布尔），随 provider 经 SQLite / 导入导出 / WebDAV 同步往返，无需数据库迁移

## 实现要点

- 写时生成：`prepare_codex_config_text_with_model_catalog_payload` 根据 profile + 选项推导 disable 条件，覆盖切换、同步、takeover、failover、恢复全部 live 写入入口
- 代理快照合并：`build_effective_live_snapshot` 对 Codex 只投影 `{auth, config}`，新增 `merge_codex_provider_catalog_options` 在 proxy 侧三处写路径补齐选项
- 表单遵循既有 touched 模式，未触碰开关的保存不产生任何键写入

## 测试

- 新增 8 个单测（codex_config 生成 4 个 + 表单 4 个），更新 3 处既有断言
- `cargo test --lib web_search`（9 个）、`--lib provider_add_form_codex`（43 个）全绿
- `cargo fmt --check` 通过；改动文件无新增 clippy 警告
- 两路独立盲审无 findings
- 注：全量 lib 测试的 16 个失败（theme 15 + proxy catalog 1）与两个 settings 集成目标编译失败均为 HEAD 预先存在的问题（stash 对比验证），与本 PR 无关