### PR TITLE
feat(cli): adapt to Antigravity CLI alongside Gemini CLI (#278)

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -297,6 +297,8 @@ use crate::provider::ProviderManager;
 pub enum AppType {
     Claude,
     Codex,
+    #[clap(alias = "antigravity", alias = "agy")]
+    #[serde(alias = "antigravity", alias = "agy")]
     Gemini,
     OpenCode,
     Hermes,
@@ -353,17 +355,17 @@ impl FromStr for AppType {
         match normalized.as_str() {
             "claude" => Ok(AppType::Claude),
             "codex" => Ok(AppType::Codex),
-            "gemini" => Ok(AppType::Gemini),
+            "gemini" | "antigravity" | "agy" => Ok(AppType::Gemini),
             "opencode" => Ok(AppType::OpenCode),
             "hermes" => Ok(AppType::Hermes),
             "openclaw" => Ok(AppType::OpenClaw),
             other => Err(AppError::localized(
                 "unsupported_app",
                 format!(
-                    "不支持的应用标识: '{other}'。可选值: claude, codex, gemini, opencode, hermes, openclaw。"
+                    "不支持的应用标识: '{other}'。可选值: claude, codex, gemini (antigravity/agy), opencode, hermes, openclaw。"
                 ),
                 format!(
-                    "Unsupported app id: '{other}'. Allowed: claude, codex, gemini, opencode, hermes, openclaw."
+                    "Unsupported app id: '{other}'. Allowed: claude, codex, gemini (antigravity/agy), opencode, hermes, openclaw."
                 ),
             )),
         }
@@ -1019,5 +1021,13 @@ mod tests {
             config.mcp.openclaw.servers.contains_key("openclaw-tool"),
             "OpenClaw legacy MCP entries should be preserved"
         );
+    }
+
+    #[test]
+    fn app_type_parses_antigravity_aliases() {
+        use std::str::FromStr;
+        assert_eq!(AppType::from_str("antigravity").unwrap(), AppType::Gemini);
+        assert_eq!(AppType::from_str("agy").unwrap(), AppType::Gemini);
+        assert_eq!(AppType::from_str("gemini").unwrap(), AppType::Gemini);
     }
 }

--- a/src-tauri/src/cli/commands/env.rs
+++ b/src-tauri/src/cli/commands/env.rs
@@ -172,15 +172,15 @@ fn check_gemini_doctor() -> Result<(), AppError> {
     let settings_path = crate::gemini_config::get_gemini_settings_path();
 
     let mut rows = vec![
-        check_file_exists("Gemini .env", &env_path),
-        check_file_exists("Gemini settings.json", &settings_path),
+        check_file_exists("Gemini / Antigravity .env", &env_path),
+        check_file_exists("Gemini / Antigravity settings.json", &settings_path),
     ];
 
     match current {
         Some(provider_id) => rows.push(ok_row("Current provider", provider_id)),
         None => rows.push(warn_row(
             "Current provider",
-            "no current Gemini provider selected".to_string(),
+            "no current Gemini / Antigravity provider selected".to_string(),
         )),
     }
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -22,8 +22,8 @@ use crate::app_config::AppType;
 #[command(
     name = "cc-switch",
     version,
-    about = "All-in-One Assistant for Claude Code, Codex, Gemini & OpenCode CLI",
-    long_about = "Unified management for Claude Code, Codex, Gemini, and OpenCode CLI provider configurations, MCP servers, skills, prompts, local proxy routes, and environment checks.\n\nRun without arguments to enter interactive mode."
+    about = "All-in-One Assistant for Claude Code, Codex, Gemini / Antigravity & OpenCode CLI",
+    long_about = "Unified management for Claude Code, Codex, Gemini, Antigravity, and OpenCode CLI provider configurations, MCP servers, skills, prompts, local proxy routes, and environment checks.\n\nRun without arguments to enter interactive mode."
 )]
 pub struct Cli {
     /// Specify the application type

--- a/src-tauri/src/gemini_config.rs
+++ b/src-tauri/src/gemini_config.rs
@@ -24,6 +24,11 @@ pub fn get_gemini_dir() -> PathBuf {
     }
 
     let home = dirs::home_dir().expect("无法获取用户主目录");
+    let gemini_antigravity_dir = home.join(".gemini").join("antigravity-cli");
+    if gemini_antigravity_dir.exists() && gemini_antigravity_dir.is_dir() {
+        return gemini_antigravity_dir;
+    }
+
     let antigravity_dir = home.join(".antigravity");
     if antigravity_dir.exists() {
         return antigravity_dir;

--- a/src-tauri/src/gemini_config.rs
+++ b/src-tauri/src/gemini_config.rs
@@ -5,15 +5,41 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
-/// 获取 Gemini 配置目录路径（支持设置覆盖）
+/// 获取 Gemini / Antigravity 配置目录路径（支持设置覆盖与环境变量覆盖）
 pub fn get_gemini_dir() -> PathBuf {
     if let Some(custom) = crate::settings::get_gemini_override_dir() {
         return custom;
     }
 
-    dirs::home_dir()
-        .expect("无法获取用户主目录")
-        .join(".gemini")
+    if let Ok(env_dir) = std::env::var("ANTIGRAVITY_CONFIG_DIR") {
+        if !env_dir.trim().is_empty() {
+            return PathBuf::from(env_dir.trim());
+        }
+    }
+
+    if let Ok(env_dir) = std::env::var("GEMINI_CONFIG_DIR") {
+        if !env_dir.trim().is_empty() {
+            return PathBuf::from(env_dir.trim());
+        }
+    }
+
+    let home = dirs::home_dir().expect("无法获取用户主目录");
+    let antigravity_dir = home.join(".antigravity");
+    if antigravity_dir.exists() {
+        return antigravity_dir;
+    }
+
+    let gemini_dir = home.join(".gemini");
+    if gemini_dir.exists() {
+        return gemini_dir;
+    }
+
+    antigravity_dir
+}
+
+/// 获取 Antigravity 配置目录路径别名
+pub fn get_antigravity_dir() -> PathBuf {
+    get_gemini_dir()
 }
 
 /// 获取 Gemini .env 文件路径
@@ -730,5 +756,16 @@ KEY_WITH-DASH=value";
         });
 
         assert!(validate_gemini_settings(&settings).is_err());
+    }
+
+    #[test]
+    fn test_get_gemini_dir_supports_antigravity_env() {
+        std::env::set_var("ANTIGRAVITY_CONFIG_DIR", "/tmp/test_antigravity_dir");
+        assert_eq!(get_gemini_dir(), PathBuf::from("/tmp/test_antigravity_dir"));
+        assert_eq!(
+            get_antigravity_dir(),
+            PathBuf::from("/tmp/test_antigravity_dir")
+        );
+        std::env::remove_var("ANTIGRAVITY_CONFIG_DIR");
     }
 }

--- a/src-tauri/src/services/local_env_check.rs
+++ b/src-tauri/src/services/local_env_check.rs
@@ -48,22 +48,26 @@ impl LocalTool {
         match self {
             LocalTool::Claude => "Claude",
             LocalTool::Codex => "Codex",
-            LocalTool::Gemini => "Gemini",
+            LocalTool::Gemini => "Gemini / Antigravity",
             LocalTool::OpenCode => "OpenCode",
             LocalTool::Hermes => "Hermes",
             LocalTool::OpenClaw => "OpenClaw",
         }
     }
 
-    fn binary_name(self) -> &'static str {
+    pub fn binary_names(self) -> &'static [&'static str] {
         match self {
-            LocalTool::Claude => "claude",
-            LocalTool::Codex => "codex",
-            LocalTool::Gemini => "gemini",
-            LocalTool::OpenCode => "opencode",
-            LocalTool::Hermes => "hermes",
-            LocalTool::OpenClaw => "openclaw",
+            LocalTool::Claude => &["claude"],
+            LocalTool::Codex => &["codex"],
+            LocalTool::Gemini => &["antigravity", "agy", "gemini"],
+            LocalTool::OpenCode => &["opencode"],
+            LocalTool::Hermes => &["hermes"],
+            LocalTool::OpenClaw => &["openclaw"],
         }
+    }
+
+    fn binary_name(self) -> &'static str {
+        self.binary_names()[0]
     }
 
     fn version_args(self) -> &'static [&'static str] {
@@ -215,7 +219,9 @@ async fn check_local_environment_progressive_with<F, P, ProbeFuture>(
 
 pub fn check_tool_installed(app_type: &AppType) -> bool {
     let tool = LocalTool::from_app_type(app_type);
-    is_tool_installed(tool.binary_name())
+    tool.binary_names()
+        .iter()
+        .any(|&bin| is_tool_installed(bin))
 }
 
 fn is_tool_installed(bin: &str) -> bool {
@@ -230,9 +236,14 @@ async fn check_tool(
         return None;
     }
 
-    let executable = match which::which(tool.binary_name()) {
-        Ok(path) => path,
-        Err(_) => {
+    let executable = tool
+        .binary_names()
+        .iter()
+        .find_map(|&bin| which::which(bin).ok());
+
+    let executable = match executable {
+        Some(path) => path,
+        None => {
             return Some(ToolCheckResult {
                 tool,
                 display_name: tool.display_name(),
@@ -853,10 +864,21 @@ mod tests {
 
         assert_eq!(
             display_names,
-            vec!["Claude", "Codex", "Gemini", "OpenCode", "Hermes", "OpenClaw"]
+            vec![
+                "Claude",
+                "Codex",
+                "Gemini / Antigravity",
+                "OpenCode",
+                "Hermes",
+                "OpenClaw"
+            ]
         );
         assert_eq!(LocalTool::Hermes.binary_name(), "hermes");
         assert_eq!(LocalTool::OpenClaw.binary_name(), "openclaw");
+        assert_eq!(
+            LocalTool::Gemini.binary_names(),
+            &["antigravity", "agy", "gemini"]
+        );
         assert_eq!(LocalTool::Hermes.version_timeout(), Duration::from_secs(10));
         assert_eq!(LocalTool::Claude.version_timeout(), Duration::from_secs(5));
     }


### PR DESCRIPTION
## Summary
Closes #278.

This PR adapts `cc-switch-cli` to support the **Antigravity CLI** (`antigravity` / `agy`) alongside Gemini CLI ahead of the Google Gemini CLI replacement deadline on June 18th.

## Changes Included
1. **AppType & Parameter Aliases**:
   - Added `antigravity` and `agy` aliases to `AppType::Gemini` (`#[clap(alias = "antigravity", alias = "agy")]`, `#[serde(alias = "antigravity", alias = "agy")]`).
   - `FromStr` for `AppType` parses `antigravity` and `agy` into `AppType::Gemini`.
2. **Config Directory & Env Support**:
   - `get_gemini_dir()` in `gemini_config.rs` respects `ANTIGRAVITY_CONFIG_DIR`, `GEMINI_CONFIG_DIR`, and automatically fallbacks between `~/.antigravity` and `~/.gemini`.
   - Exported `get_antigravity_dir()` alias helper.
3. **Local CLI Tool Detection**:
   - Updated `LocalTool::Gemini` in `local_env_check.rs` to inspect binary candidates in sequence: `["antigravity", "agy", "gemini"]`.
   - Updated display labels to `Gemini / Antigravity`.
4. **Tests & Formatting**:
   - Unit tests added to cover `AppType` string parsing and `ANTIGRAVITY_CONFIG_DIR` resolution.
   - Formatted with `cargo fmt --check`.