### PR TITLE
feat(skills): configurable SSOT storage location (cc-switch | unified), align with upstream GUI

### DIFF
--- a/src-tauri/src/cli/commands/skills.rs
+++ b/src-tauri/src/cli/commands/skills.rs
@@ -629,22 +629,34 @@ fn sync_method(method: Option<SyncMethod>) -> Result<(), AppError> {
 fn storage_location(location: Option<SkillStorageLocation>) -> Result<(), AppError> {
     match location {
         Some(target) => {
+            let current = crate::settings::get_skill_storage_location();
+            if current == target {
+                println!("Skill 存储位置已是当前值，无需迁移。");
+                return Ok(());
+            }
             let result = SkillService::migrate_storage(target)?;
             let label = match target {
                 SkillStorageLocation::CcSwitch => "cc-switch (~/.cc-switch/skills)",
                 SkillStorageLocation::Unified => "unified (~/.agents/skills)",
             };
-            println!(
-                "{}",
-                success(&format!(
-                    "Skill 存储位置已切换为 {label}: {} 迁移, {} 跳过, {} 错误",
-                    result.migrated_count,
-                    result.skipped_count,
-                    result.errors.len()
-                ))
-            );
-            for e in &result.errors {
-                eprintln!("  - {e}");
+            if result.errors.is_empty() {
+                println!(
+                    "{}",
+                    success(&format!(
+                        "Skill 存储位置已切换为 {label}: {} 迁移, {} 跳过",
+                        result.migrated_count, result.skipped_count
+                    ))
+                );
+            } else {
+                eprintln!(
+                    "Skill 存储位置切换为 {label} 但部分失败: {} 失败, {} 跳过",
+                    result.errors.len(),
+                    result.skipped_count
+                );
+                for e in &result.errors {
+                    eprintln!("  - {e}");
+                }
+                eprintln!("备份位于 {{config_dir}}/skill-backups/，可手工恢复。");
             }
         }
         None => {

--- a/src-tauri/src/cli/commands/skills.rs
+++ b/src-tauri/src/cli/commands/skills.rs
@@ -7,7 +7,7 @@ use crate::cli::commands::app_targets::{
 };
 use crate::cli::ui::{create_table, highlight, info, success};
 use crate::error::AppError;
-use crate::services::skill::{ImportSkillSelection, SkillRepo, SyncMethod};
+use crate::services::skill::{ImportSkillSelection, SkillRepo, SkillStorageLocation, SyncMethod};
 use crate::services::SkillService;
 
 #[derive(Subcommand)]
@@ -110,6 +110,12 @@ pub enum SkillsCommand {
         #[arg(value_enum)]
         method: Option<SyncMethod>,
     },
+    /// Get or set the skills SSOT storage location (cc-switch|unified)
+    StorageLocation {
+        /// Optional location to set (omit to show current). Setting triggers migration.
+        #[arg(value_enum)]
+        location: Option<SkillStorageLocation>,
+    },
     /// Manage skill repositories
     #[command(subcommand)]
     Repos(SkillReposCommand),
@@ -164,6 +170,7 @@ pub fn execute(cmd: SkillsCommand, app: Option<AppType>) -> Result<(), AppError>
         SkillsCommand::ImportFromApps { apps, directories } => import_from_apps(apps, directories),
         SkillsCommand::Info { spec } => show_skill_info(&spec),
         SkillsCommand::SyncMethod { method } => sync_method(method),
+        SkillsCommand::StorageLocation { location } => storage_location(location),
         SkillsCommand::Repos(repos_cmd) => execute_repos(repos_cmd),
     }
 }
@@ -614,6 +621,41 @@ fn sync_method(method: Option<SyncMethod>) -> Result<(), AppError> {
             let method = SkillService::get_sync_method()?;
             println!("{}", highlight("Skill Sync Method"));
             println!("{method:?}");
+        }
+    }
+    Ok(())
+}
+
+fn storage_location(location: Option<SkillStorageLocation>) -> Result<(), AppError> {
+    match location {
+        Some(target) => {
+            let result = SkillService::migrate_storage(target)?;
+            let label = match target {
+                SkillStorageLocation::CcSwitch => "cc-switch (~/.cc-switch/skills)",
+                SkillStorageLocation::Unified => "unified (~/.agents/skills)",
+            };
+            println!(
+                "{}",
+                success(&format!(
+                    "Skill 存储位置已切换为 {label}: {} 迁移, {} 跳过, {} 错误",
+                    result.migrated_count,
+                    result.skipped_count,
+                    result.errors.len()
+                ))
+            );
+            for e in &result.errors {
+                eprintln!("  - {e}");
+            }
+        }
+        None => {
+            let current = crate::settings::get_skill_storage_location();
+            println!(
+                "{}",
+                match current {
+                    SkillStorageLocation::CcSwitch => "cc-switch",
+                    SkillStorageLocation::Unified => "unified",
+                }
+            );
         }
     }
     Ok(())

--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -5644,17 +5644,36 @@ pub mod texts {
 
     pub fn tui_settings_skills_storage_location_label() -> &'static str {
         if is_chinese() {
-            "存储位置"
+            "技能存储位置"
         } else {
-            "Storage location"
+            "Skill storage location"
         }
     }
 
     pub fn tui_skills_storage_location_title() -> &'static str {
         if is_chinese() {
-            "选择存储位置"
+            "选择技能存储位置"
         } else {
-            "Select Storage Location"
+            "Select Skill Storage Location"
+        }
+    }
+
+    /// 迁移确认弹窗消息（维护者要求：迁移前需用户确认）。
+    pub fn tui_confirm_skills_migrate_storage(
+        location: crate::services::skill::SkillStorageLocation,
+    ) -> String {
+        let target = match location {
+            crate::services::skill::SkillStorageLocation::CcSwitch => {
+                "cc-switch (~/.cc-switch/skills)"
+            }
+            crate::services::skill::SkillStorageLocation::Unified => "unified (~/.agents/skills)",
+        };
+        if is_chinese() {
+            format!("将迁移全部已管理技能到 {target}，并同步各应用目录。迁移前会自动备份，继续吗？")
+        } else {
+            format!(
+                "This will migrate all managed skills to {target} and re-sync app directories. A backup is created first. Continue?"
+            )
         }
     }
 

--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -5642,6 +5642,43 @@ pub mod texts {
         }
     }
 
+    pub fn tui_settings_skills_storage_location_label() -> &'static str {
+        if is_chinese() {
+            "存储位置"
+        } else {
+            "Storage location"
+        }
+    }
+
+    pub fn tui_skills_storage_location_title() -> &'static str {
+        if is_chinese() {
+            "选择存储位置"
+        } else {
+            "Select Storage Location"
+        }
+    }
+
+    pub fn tui_skills_storage_location_name(
+        location: crate::services::skill::SkillStorageLocation,
+    ) -> &'static str {
+        match location {
+            crate::services::skill::SkillStorageLocation::CcSwitch => {
+                if is_chinese() {
+                    "cc-switch (~/.cc-switch/skills)"
+                } else {
+                    "cc-switch (~/.cc-switch/skills)"
+                }
+            }
+            crate::services::skill::SkillStorageLocation::Unified => {
+                if is_chinese() {
+                    "unified (~/.agents/skills)"
+                } else {
+                    "unified (~/.agents/skills)"
+                }
+            }
+        }
+    }
+
     pub fn tui_skills_installed_summary(installed: usize, enabled: usize, app: &str) -> String {
         if is_chinese() {
             format!("已安装: {installed}   当前应用({app})已启用: {enabled}")
@@ -8561,6 +8598,14 @@ pub mod texts {
             format!("同步方式已设置为: {method}")
         } else {
             format!("Sync method set to: {method}")
+        }
+    }
+
+    pub fn tui_toast_skills_storage_location_set(location: &str) -> String {
+        if is_chinese() {
+            format!("存储位置已切换为: {location}")
+        } else {
+            format!("Storage location set to: {location}")
         }
     }
 

--- a/src-tauri/src/cli/tui/app.rs
+++ b/src-tauri/src/cli/tui/app.rs
@@ -7,7 +7,7 @@ use crate::app_config::AppType;
 use crate::cli::i18n::current_language;
 use crate::cli::i18n::texts;
 use crate::cli::i18n::Language;
-use crate::services::skill::SyncMethod;
+use crate::services::skill::{SkillStorageLocation, SyncMethod};
 
 use super::data::UiData;
 use super::form::{

--- a/src-tauri/src/cli/tui/app/app_state.rs
+++ b/src-tauri/src/cli/tui/app/app_state.rs
@@ -66,6 +66,9 @@ pub enum Action {
     SkillsSetSyncMethod {
         method: SyncMethod,
     },
+    SkillsSetStorageLocation {
+        location: SkillStorageLocation,
+    },
     SkillsDiscover {
         query: String,
         source: SkillsDiscoverSource,
@@ -497,6 +500,7 @@ pub enum SettingsItem {
     PreferredEditor,
     VisibleAppsMode,
     VisibleApps,
+    SkillsStorageLocation,
     OpenClawConfigDir,
     ManagedAccounts,
     SkipClaudeOnboarding,
@@ -508,7 +512,7 @@ pub enum SettingsItem {
 }
 
 impl SettingsItem {
-    pub const ALL: [SettingsItem; 14] = [
+    pub const ALL: [SettingsItem; 15] = [
         SettingsItem::ManagedAccounts,
         SettingsItem::Language,
         SettingsItem::Theme,
@@ -516,6 +520,7 @@ impl SettingsItem {
         SettingsItem::PreferredEditor,
         SettingsItem::VisibleAppsMode,
         SettingsItem::VisibleApps,
+        SettingsItem::SkillsStorageLocation,
         SettingsItem::OpenClawConfigDir,
         SettingsItem::SkipClaudeOnboarding,
         SettingsItem::ClaudePluginIntegration,

--- a/src-tauri/src/cli/tui/app/content_config.rs
+++ b/src-tauri/src/cli/tui/app/content_config.rs
@@ -929,6 +929,14 @@ impl App {
                     };
                     Action::None
                 }
+                Some(SettingsItem::SkillsStorageLocation) => {
+                    self.overlay = Overlay::SkillsStorageLocationPicker {
+                        selected: storage_location_picker_index(
+                            crate::settings::get_skill_storage_location(),
+                        ),
+                    };
+                    Action::None
+                }
                 Some(SettingsItem::OpenClawConfigDir) => {
                     let buffer = crate::settings::get_settings()
                         .openclaw_config_dir

--- a/src-tauri/src/cli/tui/app/helpers.rs
+++ b/src-tauri/src/cli/tui/app/helpers.rs
@@ -1802,6 +1802,20 @@ pub(crate) fn sync_method_for_picker_index(index: usize) -> SyncMethod {
     }
 }
 
+pub(crate) fn storage_location_picker_index(location: SkillStorageLocation) -> usize {
+    match location {
+        SkillStorageLocation::CcSwitch => 0,
+        SkillStorageLocation::Unified => 1,
+    }
+}
+
+pub(crate) fn storage_location_for_picker_index(index: usize) -> SkillStorageLocation {
+    match index {
+        1 => SkillStorageLocation::Unified,
+        _ => SkillStorageLocation::CcSwitch,
+    }
+}
+
 pub(crate) fn openclaw_tools_profile_picker_index(profile: Option<&str>) -> Option<usize> {
     OPENCLAW_TOOLS_PROFILE_PICKER_VALUES
         .iter()

--- a/src-tauri/src/cli/tui/app/overlay_handlers/dialogs.rs
+++ b/src-tauri/src/cli/tui/app/overlay_handlers/dialogs.rs
@@ -114,6 +114,11 @@ impl App {
                     ConfirmAction::SkillsUninstall { directory } => Action::SkillsUninstall {
                         directory: directory.clone(),
                     },
+                    ConfirmAction::SkillsMigrateStorage { location } => {
+                        Action::SkillsSetStorageLocation {
+                            location: *location,
+                        }
+                    }
                     ConfirmAction::SkillsRepoRemove { owner, name } => Action::SkillsRepoRemove {
                         owner: owner.clone(),
                         name: name.clone(),

--- a/src-tauri/src/cli/tui/app/overlay_handlers/pickers.rs
+++ b/src-tauri/src/cli/tui/app/overlay_handlers/pickers.rs
@@ -310,12 +310,13 @@ impl App {
             KeyCode::Enter => {
                 let location = storage_location_for_picker_index(*selected);
                 let unchanged = location == data.skills.storage_location;
-                self.overlay = Overlay::None;
                 if unchanged {
-                    Action::None
-                } else {
-                    Action::SkillsSetStorageLocation { location }
+                    self.overlay = Overlay::None;
+                    return Some(Action::None);
                 }
+                // 迁移会移动技能文件：先弹确认（维护者要求），确认后再发 Action。
+                self.overlay = Overlay::confirm_skills_migrate_storage(location);
+                Action::None
             }
             _ => Action::None,
         })

--- a/src-tauri/src/cli/tui/app/overlay_handlers/pickers.rs
+++ b/src-tauri/src/cli/tui/app/overlay_handlers/pickers.rs
@@ -85,6 +85,9 @@ impl App {
         if let Some(action) = self.handle_sync_method_picker_key(key, data) {
             return Some(action);
         }
+        if let Some(action) = self.handle_storage_location_picker_key(key, data) {
+            return Some(action);
+        }
         if let Some(action) = self.handle_claude_api_format_picker_key(key, data) {
             return Some(action);
         }
@@ -276,6 +279,42 @@ impl App {
                     Action::None
                 } else {
                     Action::SkillsSetSyncMethod { method }
+                }
+            }
+            _ => Action::None,
+        })
+    }
+
+    fn handle_storage_location_picker_key(
+        &mut self,
+        key: KeyEvent,
+        data: &UiData,
+    ) -> Option<Action> {
+        let Overlay::SkillsStorageLocationPicker { selected } = &mut self.overlay else {
+            return None;
+        };
+
+        Some(match key.code {
+            KeyCode::Esc => {
+                self.close_overlay();
+                Action::None
+            }
+            KeyCode::Up => {
+                *selected = selected.saturating_sub(1);
+                Action::None
+            }
+            KeyCode::Down => {
+                *selected = (*selected + 1).min(1);
+                Action::None
+            }
+            KeyCode::Enter => {
+                let location = storage_location_for_picker_index(*selected);
+                let unchanged = location == data.skills.storage_location;
+                self.overlay = Overlay::None;
+                if unchanged {
+                    Action::None
+                } else {
+                    Action::SkillsSetStorageLocation { location }
                 }
             }
             _ => Action::None,

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -10736,6 +10736,30 @@ mod tests {
     }
 
     #[test]
+    fn settings_skills_storage_location_item_opens_picker_overlay() {
+        let temp_home = TempDir::new().expect("create temp home");
+        let _env = TestEnvGuard::isolated(temp_home.path());
+
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Settings;
+        app.focus = Focus::Content;
+        app.settings_idx = SettingsItem::ALL
+            .iter()
+            .position(|item| matches!(item, SettingsItem::SkillsStorageLocation))
+            .expect("SkillsStorageLocation missing from SettingsItem::ALL");
+
+        let action = app.on_key(key(KeyCode::Enter), &UiData::default());
+        assert!(matches!(action, Action::None));
+        assert!(matches!(
+            &app.overlay,
+            Overlay::SkillsStorageLocationPicker { selected }
+                if *selected == storage_location_picker_index(
+                    crate::settings::get_skill_storage_location()
+                )
+        ));
+    }
+
+    #[test]
     #[serial(home_settings)]
     fn visible_apps_picker_rejects_zero_selection_without_closing() {
         let temp_home = TempDir::new().expect("create temp home");

--- a/src-tauri/src/cli/tui/app/types.rs
+++ b/src-tauri/src/cli/tui/app/types.rs
@@ -4693,6 +4693,9 @@ pub enum Overlay {
     SkillsSyncMethodPicker {
         selected: usize,
     },
+    SkillsStorageLocationPicker {
+        selected: usize,
+    },
     McpKeyValuePicker {
         kind: crate::cli::tui::form::McpKeyValueKind,
         selected: usize,
@@ -4858,6 +4861,7 @@ impl Overlay {
                 | Overlay::SkillsAppsPicker { .. }
                 | Overlay::SkillsImportPicker { .. }
                 | Overlay::SkillsSyncMethodPicker { .. }
+                | Overlay::SkillsStorageLocationPicker { .. }
                 | Overlay::McpKeyValuePicker { .. }
                 | Overlay::McpTypePicker { .. }
                 | Overlay::SpeedtestResult { .. }
@@ -4900,6 +4904,7 @@ impl Overlay {
             | Overlay::SkillsAppsPicker { .. }
             | Overlay::SkillsImportPicker { .. }
             | Overlay::SkillsSyncMethodPicker { .. }
+            | Overlay::SkillsStorageLocationPicker { .. }
             | Overlay::McpKeyValuePicker { .. }
             | Overlay::McpTypePicker { .. }
             | Overlay::Loading { .. }

--- a/src-tauri/src/cli/tui/app/types.rs
+++ b/src-tauri/src/cli/tui/app/types.rs
@@ -4343,6 +4343,9 @@ pub enum ConfirmAction {
     SkillsUninstall {
         directory: String,
     },
+    SkillsMigrateStorage {
+        location: crate::services::skill::SkillStorageLocation,
+    },
     SkillsRepoRemove {
         owner: String,
         name: String,
@@ -4832,6 +4835,17 @@ pub(crate) fn model_fetch_filter(models: &[String], query: &str) -> ModelFetchFi
 }
 
 impl Overlay {
+    /// 迁移 SSOT 前的确认弹窗（维护者要求：迁移会移动技能文件，需用户确认）。
+    pub fn confirm_skills_migrate_storage(
+        location: crate::services::skill::SkillStorageLocation,
+    ) -> Self {
+        Overlay::Confirm(ConfirmOverlay {
+            title: crate::cli::i18n::texts::tui_confirm_title().to_string(),
+            message: crate::cli::i18n::texts::tui_confirm_skills_migrate_storage(location),
+            action: ConfirmAction::SkillsMigrateStorage { location },
+        })
+    }
+
     pub fn is_active(&self) -> bool {
         !matches!(self, Overlay::None)
     }

--- a/src-tauri/src/cli/tui/data.rs
+++ b/src-tauri/src/cli/tui/data.rs
@@ -318,6 +318,7 @@ pub struct SkillsSnapshot {
     pub installed: Vec<crate::services::skill::InstalledSkill>,
     pub repos: Vec<crate::services::skill::SkillRepo>,
     pub sync_method: crate::services::skill::SyncMethod,
+    pub storage_location: crate::services::skill::SkillStorageLocation,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -3636,6 +3637,7 @@ fn load_skills_snapshot() -> Result<SkillsSnapshot, AppError> {
         installed: SkillService::list_installed()?,
         repos: SkillService::list_repos()?,
         sync_method: SkillService::get_sync_method()?,
+        storage_location: crate::settings::get_skill_storage_location(),
     })
 }
 
@@ -3651,6 +3653,7 @@ fn load_skills_snapshot_from_state(state: &AppState) -> Result<SkillsSnapshot, A
         installed,
         repos: state.db.get_skill_repos()?,
         sync_method: SkillService::get_sync_method()?,
+        storage_location: crate::settings::get_skill_storage_location(),
     })
 }
 

--- a/src-tauri/src/cli/tui/mod.rs
+++ b/src-tauri/src/cli/tui/mod.rs
@@ -2292,6 +2292,7 @@ fn cache_invalidation_for_action(action: &Action) -> CacheInvalidation {
         | Action::SkillsUninstall { .. }
         | Action::SkillsSync { .. }
         | Action::SkillsSetSyncMethod { .. }
+        | Action::SkillsSetStorageLocation { .. }
         | Action::SkillsRepoAdd { .. }
         | Action::SkillsRepoRemove { .. }
         | Action::SkillsRepoToggleEnabled { .. }

--- a/src-tauri/src/cli/tui/runtime_actions/mod.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/mod.rs
@@ -848,6 +848,9 @@ pub(crate) fn handle_action(
         Action::SkillsUninstall { directory } => skills::uninstall(&mut ctx, directory),
         Action::SkillsSync { app: scope } => skills::sync(&mut ctx, scope),
         Action::SkillsSetSyncMethod { method } => skills::set_sync_method(&mut ctx, method),
+        Action::SkillsSetStorageLocation { location } => {
+            skills::set_storage_location(&mut ctx, location)
+        }
         Action::SkillsDiscover {
             query,
             source,

--- a/src-tauri/src/cli/tui/runtime_actions/skills.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/skills.rs
@@ -2,7 +2,7 @@ use crate::app_config::{AppType, SkillApps};
 use crate::cli::i18n::texts;
 use crate::error::AppError;
 use crate::services::{
-    skill::{ImportSkillSelection, SyncMethod},
+    skill::{ImportSkillSelection, SkillStorageLocation, SyncMethod},
     SkillService,
 };
 
@@ -159,6 +159,21 @@ pub(super) fn set_sync_method(
     *ctx.data = super::super::data::UiData::load(&ctx.app.app_type)?;
     ctx.app.push_toast(
         texts::tui_toast_skills_sync_method_set(texts::tui_skills_sync_method_name(method)),
+        ToastKind::Success,
+    );
+    Ok(())
+}
+
+pub(super) fn set_storage_location(
+    ctx: &mut RuntimeActionContext<'_>,
+    location: SkillStorageLocation,
+) -> Result<(), AppError> {
+    SkillService::migrate_storage(location)?;
+    *ctx.data = super::super::data::UiData::load(&ctx.app.app_type)?;
+    ctx.app.push_toast(
+        texts::tui_toast_skills_storage_location_set(texts::tui_skills_storage_location_name(
+            location,
+        )),
         ToastKind::Success,
     );
     Ok(())

--- a/src-tauri/src/cli/tui/runtime_actions/skills.rs
+++ b/src-tauri/src/cli/tui/runtime_actions/skills.rs
@@ -168,14 +168,33 @@ pub(super) fn set_storage_location(
     ctx: &mut RuntimeActionContext<'_>,
     location: SkillStorageLocation,
 ) -> Result<(), AppError> {
-    SkillService::migrate_storage(location)?;
+    let result = SkillService::migrate_storage(location)?;
     *ctx.data = super::super::data::UiData::load(&ctx.app.app_type)?;
-    ctx.app.push_toast(
-        texts::tui_toast_skills_storage_location_set(texts::tui_skills_storage_location_name(
-            location,
-        )),
-        ToastKind::Success,
-    );
+    let name = texts::tui_skills_storage_location_name(location);
+    if result.errors.is_empty() {
+        let msg = if result.skipped_count > 0 {
+            format!(
+                "{}（{} 个跳过）",
+                texts::tui_toast_skills_storage_location_set(&name),
+                result.skipped_count
+            )
+        } else {
+            texts::tui_toast_skills_storage_location_set(&name)
+        };
+        ctx.app.push_toast(msg, ToastKind::Success);
+    } else {
+        let first = result.errors.first().cloned().unwrap_or_default();
+        ctx.app.push_toast(
+            format!(
+                "{}：{} 个失败（{} 个跳过），已尝试清理半成品。首条错误: {}",
+                texts::tui_toast_skills_storage_location_set(&name),
+                result.errors.len(),
+                result.skipped_count,
+                first
+            ),
+            ToastKind::Warning,
+        );
+    }
     Ok(())
 }
 

--- a/src-tauri/src/cli/tui/ui/config.rs
+++ b/src-tauri/src/cli/tui/ui/config.rs
@@ -20,6 +20,7 @@ fn settings_section(item: SettingsItem) -> SettingsSection {
         | SettingsItem::PreferredEditor => SettingsSection::General,
         SettingsItem::VisibleAppsMode
         | SettingsItem::VisibleApps
+        | SettingsItem::SkillsStorageLocation
         | SettingsItem::OpenClawConfigDir => SettingsSection::Applications,
         SettingsItem::SkipClaudeOnboarding
         | SettingsItem::ClaudePluginIntegration
@@ -3476,6 +3477,10 @@ pub(super) fn render_settings(
             super::app::SettingsItem::VisibleApps => (
                 texts::tui_settings_visible_apps_label().to_string(),
                 visible_apps_summary(&visible_apps),
+            ),
+            super::app::SettingsItem::SkillsStorageLocation => (
+                texts::tui_settings_skills_storage_location_label().to_string(),
+                texts::tui_skills_storage_location_name(data.skills.storage_location).to_string(),
             ),
             super::app::SettingsItem::OpenClawConfigDir => (
                 texts::tui_settings_openclaw_config_dir_label().to_string(),

--- a/src-tauri/src/cli/tui/ui/overlay/pickers.rs
+++ b/src-tauri/src/cli/tui/ui/overlay/pickers.rs
@@ -2418,6 +2418,58 @@ pub(super) fn render_skills_sync_method_picker_overlay(
     frame.render_stateful_widget(list, body_area, &mut state);
 }
 
+pub(super) fn render_skills_storage_location_picker_overlay(
+    frame: &mut Frame<'_>,
+    data: &UiData,
+    content_area: Rect,
+    theme: &theme::Theme,
+    selected: usize,
+) {
+    let locations = [
+        crate::services::skill::SkillStorageLocation::CcSwitch,
+        crate::services::skill::SkillStorageLocation::Unified,
+    ];
+
+    let body_area = overlay_frame(
+        frame,
+        content_area,
+        theme,
+        texts::tui_skills_storage_location_title(),
+        &[
+            ("←→", texts::tui_key_select()),
+            ("Enter", texts::tui_key_apply()),
+            ("Esc", texts::tui_key_cancel()),
+        ],
+        OverlaySize::FitRows {
+            width: OVERLAY_FIXED_LG.0,
+            body_rows: locations.len() as u16,
+        },
+        overlay_border_style(theme, false),
+    );
+
+    let current = data.skills.storage_location;
+
+    let items = locations.into_iter().map(|location| {
+        let marker = if location == current {
+            texts::tui_marker_active()
+        } else {
+            texts::tui_marker_inactive()
+        };
+        ListItem::new(Line::from(Span::raw(format!(
+            "{marker}  {}",
+            texts::tui_skills_storage_location_name(location)
+        ))))
+    });
+
+    let list = List::new(items)
+        .highlight_style(selection_style(theme))
+        .highlight_symbol(highlight_symbol(theme));
+
+    let mut state = ListState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(list, body_area, &mut state);
+}
+
 #[expect(
     clippy::too_many_arguments,
     reason = "app picker renderer receives list state and display labels"

--- a/src-tauri/src/cli/tui/ui/overlay/render.rs
+++ b/src-tauri/src/cli/tui/ui/overlay/render.rs
@@ -263,6 +263,15 @@ pub(crate) fn render_overlay(
                 *selected,
             )
         }
+        Overlay::SkillsStorageLocationPicker { selected } => {
+            super::pickers::render_skills_storage_location_picker_overlay(
+                frame,
+                data,
+                content_area,
+                theme,
+                *selected,
+            )
+        }
         Overlay::McpKeyValuePicker { kind, selected } => {
             super::mcp_key_value::render_mcp_key_value_picker_overlay(
                 frame,

--- a/src-tauri/src/cli/tui/ui/tests.rs
+++ b/src-tauri/src/cli/tui/ui/tests.rs
@@ -4378,6 +4378,32 @@ fn settings_page_shows_visible_apps_row_value() {
 
 #[test]
 #[serial(home_settings)]
+fn settings_page_shows_skills_storage_location_row_value() {
+    let _lock = lock_env();
+    let _no_color = EnvGuard::remove("NO_COLOR");
+    let temp_home = TempDir::new().expect("create temp home");
+    let _home = SettingsEnvGuard::set_home(temp_home.path());
+
+    let mut app = App::new(Some(AppType::Claude));
+    app.route = Route::Settings;
+    app.focus = Focus::Content;
+
+    let all = all_text(&render(&app, &minimal_data(&app.app_type)));
+
+    assert!(
+        all.contains(texts::tui_settings_skills_storage_location_label()),
+        "{all}"
+    );
+    assert!(
+        all.contains(texts::tui_skills_storage_location_name(
+            crate::settings::get_skill_storage_location()
+        )),
+        "{all}"
+    );
+}
+
+#[test]
+#[serial(home_settings)]
 fn settings_page_shows_visible_apps_mode_row_value() {
     let _lock = lock_env();
     let _no_color = EnvGuard::remove("NO_COLOR");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,7 @@ pub use mcp::{
 };
 pub use provider::{Provider, ProviderMeta, UsageScript};
 pub use proxy::{ProxyConfig, ProxyServerInfo, ProxyStatus};
+pub use services::skill::SkillStorageLocation;
 pub use services::{
     reapply_current_codex_official_live, AuthService, ConfigService, CredentialStatus,
     EndpointLatency, ExtraUsage, HealthStatus, ImportSkillSelection, ManagedAuthAccount,
@@ -78,10 +79,10 @@ pub use services::{
     SyncDecision, WebDavSyncService, WebDavSyncSummary,
 };
 pub use settings::{
-    get_enable_claude_plugin_integration, get_s3_sync_settings, get_skip_claude_onboarding,
-    get_webdav_sync_settings, set_enable_claude_plugin_integration, set_s3_sync_settings,
-    set_skip_claude_onboarding, set_webdav_sync_settings, update_s3_sync_status, update_settings,
-    update_webdav_sync_status, webdav_jianguoyun_preset, AppSettings, S3SyncSettings,
-    WebDavSyncSettings, WebDavSyncStatus,
+    get_enable_claude_plugin_integration, get_s3_sync_settings, get_skill_storage_location,
+    get_skip_claude_onboarding, get_webdav_sync_settings, set_enable_claude_plugin_integration,
+    set_s3_sync_settings, set_skill_storage_location, set_skip_claude_onboarding,
+    set_webdav_sync_settings, update_s3_sync_status, update_settings, update_webdav_sync_status,
+    webdav_jianguoyun_preset, AppSettings, S3SyncSettings, WebDavSyncSettings, WebDavSyncStatus,
 };
 pub use store::AppState;

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -131,6 +131,14 @@ pub enum SkillStorageLocation {
     Unified,
 }
 
+/// 结果 of a skills SSOT storage migration (`migrate_storage`).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MigrationResult {
+    pub migrated_count: usize,
+    pub skipped_count: usize,
+    pub errors: Vec<String>,
+}
+
 /// Explicit app matrix submitted when importing unmanaged skills.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -621,6 +629,124 @@ impl SkillService {
         };
         create_managed_config_dir_all(&dir)?;
         Ok(dir)
+    }
+
+    /// Migrate the skills SSOT directory between storage locations.
+    ///
+    /// Walks the current SSOT directory itself (each subdirectory is one skill),
+    /// moves every skill into the target location, backs the source up first,
+    /// persists the new `skill_storage_location`, then refreshes app dirs.
+    pub fn migrate_storage(target: SkillStorageLocation) -> Result<MigrationResult, AppError> {
+        let current = crate::settings::get_skill_storage_location();
+        if current == target {
+            return Ok(MigrationResult::default());
+        }
+
+        let old_dir = Self::get_ssot_dir()?;
+        let new_dir = match target {
+            SkillStorageLocation::CcSwitch => get_app_config_dir().join("skills"),
+            SkillStorageLocation::Unified => crate::config::home_dir()
+                .unwrap_or_else(|| get_app_config_dir())
+                .join(".agents")
+                .join("skills"),
+        };
+        fs::create_dir_all(&new_dir).map_err(|e| AppError::io(&new_dir, e))?;
+        Self::validate_skill_storage_destination(&new_dir)?;
+
+        // 步骤 0【迁移前备份】: 目录复制（简单可靠），后续可精化为 zip 归档。
+        let backup_dir = get_app_config_dir().join("skill-backups");
+        let has_skills = old_dir.is_dir()
+            && fs::read_dir(&old_dir)
+                .map(|mut entries| entries.next().is_some())
+                .unwrap_or(false);
+        if has_skills {
+            fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+            let stamp = Utc::now().format("%Y%m%d%H%M%S");
+            let snapshot = backup_dir.join(format!("skills-{stamp}"));
+            Self::copy_dir_recursive(&old_dir, &snapshot)?;
+        }
+
+        let mut result = MigrationResult::default();
+        let mut migrated_dirs: Vec<String> = Vec::new();
+        if old_dir.is_dir() {
+            for entry in fs::read_dir(&old_dir).map_err(|e| AppError::io(&old_dir, e))? {
+                let entry = entry.map_err(|e| AppError::io(&old_dir, e))?;
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+
+                let directory = entry.file_name().to_string_lossy().to_string();
+                if directory.starts_with('.') {
+                    continue;
+                }
+
+                let src = old_dir.join(&directory);
+                let dst = new_dir.join(&directory);
+                if !src.exists() {
+                    result.skipped_count += 1;
+                    continue;
+                }
+                if dst.exists() {
+                    result.skipped_count += 1;
+                    continue;
+                }
+
+                match fs::rename(&src, &dst) {
+                    Ok(()) => {
+                        migrated_dirs.push(directory);
+                        result.migrated_count += 1;
+                    }
+                    Err(_) => match Self::copy_dir_recursive(&src, &dst) {
+                        Ok(()) => {
+                            let _ = fs::remove_dir_all(&src);
+                            migrated_dirs.push(directory);
+                            result.migrated_count += 1;
+                        }
+                        Err(e) => result.errors.push(format!("{directory}: {e}")),
+                    },
+                }
+            }
+        }
+
+        crate::settings::set_skill_storage_location(target)?;
+
+        // 刷新 app 目录（best effort：失败仅告警，不影响迁移结果）。
+        let method = crate::settings::get_skill_sync_method();
+        for directory in &migrated_dirs {
+            for app in Self::supported_skill_apps().filter(Self::app_supports_skills) {
+                if let Err(e) = Self::sync_to_app_dir(directory, &app, method) {
+                    log::warn!("迁移后同步 Skill {directory} 到 {app:?} 失败: {e}");
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Reject migration targets that alias an app's skills directory
+    /// (the CLI has no `paths_alias`, so canonicalized paths are compared).
+    fn validate_skill_storage_destination(dest: &Path) -> Result<(), AppError> {
+        for app in Self::skill_source_apps() {
+            if !Self::app_supports_skills(&app) {
+                continue;
+            }
+            let app_dir = match Self::get_app_skills_dir(&app) {
+                Ok(dir) => dir,
+                Err(_) => continue,
+            };
+            if let (Ok(dest_canon), Ok(app_canon)) = (dest.canonicalize(), app_dir.canonicalize()) {
+                if dest_canon == app_canon {
+                    return Err(AppError::Message(format!(
+                        "迁移目标 {} 与 {} 的 skills 目录别名（{}），拒绝迁移",
+                        dest.display(),
+                        app.as_str(),
+                        app_canon.display()
+                    )));
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn get_app_skills_dir(app: &AppType) -> Result<PathBuf, AppError> {
@@ -2683,6 +2809,103 @@ mod tests {
         assert_eq!(
             SkillService::repos_fingerprint(&repos),
             "a/repo@dev|b/repo@main"
+        );
+    }
+
+    #[test]
+    fn migrate_storage_noop_when_same_target() {
+        let home = tempfile::tempdir().expect("create isolated home");
+        let _env = crate::test_support::TestEnvGuard::isolated(home.path());
+        crate::settings::set_skill_storage_location(SkillStorageLocation::CcSwitch)
+            .expect("set cc_switch storage");
+
+        let result = SkillService::migrate_storage(SkillStorageLocation::CcSwitch)
+            .expect("noop migration must succeed");
+        assert_eq!(result.migrated_count, 0, "noop must not migrate anything");
+        assert_eq!(result.skipped_count, 0, "noop must not skip anything");
+        assert!(
+            result.errors.is_empty(),
+            "noop must not record errors: {:?}",
+            result.errors
+        );
+        assert_eq!(
+            crate::settings::get_skill_storage_location(),
+            SkillStorageLocation::CcSwitch
+        );
+    }
+
+    #[test]
+    fn migrate_storage_moves_skills_and_updates_setting() {
+        let home = tempfile::tempdir().expect("create isolated home");
+        let _env = crate::test_support::TestEnvGuard::isolated(home.path());
+        crate::settings::set_skill_storage_location(SkillStorageLocation::CcSwitch)
+            .expect("set cc_switch storage");
+
+        let old_dir = SkillService::get_ssot_dir().expect("resolve cc_switch SSOT");
+        let skill_dir = old_dir.join("test-skill");
+        fs::create_dir_all(&skill_dir).expect("create test skill directory");
+        fs::write(skill_dir.join("SKILL.md"), "# Test Skill").expect("write test skill manifest");
+
+        let result = SkillService::migrate_storage(SkillStorageLocation::Unified)
+            .expect("migrate to unified storage must succeed");
+        assert_eq!(result.migrated_count, 1, "one skill must migrate");
+        assert!(
+            result.errors.is_empty(),
+            "migration must not record errors: {:?}",
+            result.errors
+        );
+
+        let new_dir = SkillService::get_ssot_dir().expect("resolve unified SSOT");
+        assert!(
+            new_dir.join("test-skill").join("SKILL.md").exists(),
+            "skill must exist in the new SSOT: {:?}",
+            new_dir
+        );
+        assert!(
+            !skill_dir.exists(),
+            "old skill directory must be gone: {:?}",
+            skill_dir
+        );
+        assert_eq!(
+            crate::settings::get_skill_storage_location(),
+            SkillStorageLocation::Unified
+        );
+    }
+
+    #[test]
+    fn migrate_storage_creates_backup_first() {
+        let home = tempfile::tempdir().expect("create isolated home");
+        let _env = crate::test_support::TestEnvGuard::isolated(home.path());
+        crate::settings::set_skill_storage_location(SkillStorageLocation::CcSwitch)
+            .expect("set cc_switch storage");
+
+        let old_dir = SkillService::get_ssot_dir().expect("resolve cc_switch SSOT");
+        let skill_dir = old_dir.join("test-skill");
+        fs::create_dir_all(&skill_dir).expect("create test skill directory");
+        fs::write(skill_dir.join("SKILL.md"), "# Test Skill").expect("write test skill manifest");
+
+        SkillService::migrate_storage(SkillStorageLocation::Unified)
+            .expect("migrate to unified storage must succeed");
+
+        let backup_root = get_app_config_dir().join("skill-backups");
+        assert!(
+            backup_root.is_dir(),
+            "backup root must exist: {:?}",
+            backup_root
+        );
+        let snapshots: Vec<_> = fs::read_dir(&backup_root)
+            .expect("read backup root")
+            .filter_map(Result::ok)
+            .collect();
+        assert!(
+            !snapshots.is_empty(),
+            "backup must contain at least one snapshot"
+        );
+        let snapshot = snapshots[0].path();
+        assert!(
+            snapshot.join("test-skill").join("SKILL.md").exists(),
+            "backup snapshot must contain the migrated skill: {:?}",
+            snapshot
         );
     }
 }

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -120,6 +120,17 @@ pub enum SyncMethod {
     Copy,
 }
 
+/// Skill SSOT 存储位置（上游 GUI 对齐）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, clap::ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillStorageLocation {
+    /// CC Switch 管理目录 (~/.cc-switch/skills/)
+    #[default]
+    CcSwitch,
+    /// Agent Skills 统一标准目录 (~/.agents/skills/)
+    Unified,
+}
+
 /// Explicit app matrix submitted when importing unmanaged skills.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -672,66 +672,79 @@ impl SkillService {
 
         let mut result = MigrationResult::default();
         let mut migrated_dirs: Vec<String> = Vec::new();
-        if old_dir.is_dir() {
-            for entry in fs::read_dir(&old_dir).map_err(|e| AppError::io(&old_dir, e))? {
-                let entry = entry.map_err(|e| AppError::io(&old_dir, e))?;
-                let path = entry.path();
-                if !path.is_dir() {
-                    continue;
-                }
 
-                let directory = entry.file_name().to_string_lossy().to_string();
-                if directory.starts_with('.') {
-                    continue;
-                }
+        // 只迁移 DB 管理的技能（对齐上游：仅迁移 db 管理集，不搬未管理目录）。
+        let index = Self::load_index()?;
+        let managed: Vec<String> = index.skills.keys().cloned().collect();
 
-                let src = old_dir.join(&directory);
-                let dst = new_dir.join(&directory);
-                if !src.exists() {
-                    result.skipped_count += 1;
+        for directory in managed {
+            // 脏目录名防穿越（DB 行可能被同步导入污染）。
+            let directory = match Self::require_valid_directory(&directory) {
+                Ok(d) => d,
+                Err(err) => {
+                    result.errors.push(format!("{directory}: {err}"));
                     continue;
                 }
-                if dst.exists() {
-                    result.skipped_count += 1;
-                    continue;
-                }
+            };
 
-                match fs::rename(&src, &dst) {
+            let src = old_dir.join(&directory);
+            let dst = new_dir.join(&directory);
+            if !src.exists() {
+                result.skipped_count += 1;
+                continue;
+            }
+
+            if dst.exists() {
+                // 目标已含同名技能：不覆盖文件，但 symlink 可能仍指向旧存储，
+                // 必须强制刷新到新位置（blocker 3）。
+                result.skipped_count += 1;
+                migrated_dirs.push(directory);
+                continue;
+            }
+
+            match fs::rename(&src, &dst) {
+                Ok(()) => {
+                    migrated_dirs.push(directory);
+                    result.migrated_count += 1;
+                }
+                Err(_) => match Self::copy_dir_recursive(&src, &dst) {
                     Ok(()) => {
+                        if let Err(e) = fs::remove_dir_all(&src) {
+                            // 源未删干净：新旧各有一份，提示用户手动清理。
+                            result.errors.push(format!(
+                                "{directory}: 源目录清理失败（已复制，旧目录保留）: {e}"
+                            ));
+                        }
                         migrated_dirs.push(directory);
                         result.migrated_count += 1;
                     }
-                    Err(_) => match Self::copy_dir_recursive(&src, &dst) {
-                        Ok(()) => {
-                            if let Err(e) = fs::remove_dir_all(&src) {
-                                // 源未删干净：新旧各有一份，提示用户手动清理。
-                                result.errors.push(format!(
-                                    "{directory}: 源目录清理失败（已复制，旧目录保留）: {e}"
-                                ));
-                            }
-                            migrated_dirs.push(directory);
-                            result.migrated_count += 1;
-                        }
-                        Err(e) => {
-                            // 复制失败可能留下半成品目标目录：清理它，避免后续
-                            // sync_to_app_dir 用残缺副本覆盖 app 完整副本。
-                            let clean_msg = match fs::remove_dir_all(&dst) {
-                                Ok(()) => String::new(),
-                                Err(ce) => format!("；清理半成品目标目录失败: {ce}"),
-                            };
-                            result.errors.push(format!("{directory}: {e}{clean_msg}"));
-                        }
-                    },
-                }
+                    Err(e) => {
+                        // 复制失败可能留下半成品目标目录：清理它，避免后续
+                        // sync_to_app_dir 用残缺副本覆盖 app 完整副本。
+                        let clean_msg = match fs::remove_dir_all(&dst) {
+                            Ok(()) => String::new(),
+                            Err(ce) => format!("；清理半成品目标目录失败: {ce}"),
+                        };
+                        result.errors.push(format!("{directory}: {e}{clean_msg}"));
+                    }
+                },
             }
         }
 
         crate::settings::set_skill_storage_location(target)?;
 
-        // 刷新 app 目录（best effort：失败仅告警，不影响迁移结果）。
+        // 刷新 app 目录（best effort）：只同步该 skill 已启用的 app（blocker 1），
+        // 尊重配置的 app 选择而非全量同步。
         let method = crate::settings::get_skill_sync_method();
         for directory in &migrated_dirs {
-            for app in Self::supported_skill_apps().filter(Self::app_supports_skills) {
+            let apps_for_skill: Vec<AppType> = match index.skills.get(directory) {
+                Some(record) => Self::supported_skill_apps()
+                    .filter(Self::app_supports_skills)
+                    .filter(|app| record.apps.is_enabled_for(app))
+                    .collect(),
+                None => Vec::new(),
+            };
+            for app in apps_for_skill {
                 if let Err(e) = Self::sync_to_app_dir(directory, &app, method) {
                     log::warn!("迁移后同步 Skill {directory} 到 {app:?} 失败: {e}");
                 }
@@ -739,6 +752,23 @@ impl SkillService {
         }
 
         Ok(result)
+    }
+
+    /// 拒绝含路径穿越/多段/绝对路径的目录名（对齐上游 require_valid_directory 语义）。
+    fn require_valid_directory(directory: &str) -> Result<String, AppError> {
+        let p = Path::new(directory);
+        let mut components = p.components();
+        let valid = directory.starts_with('.') == false
+            && p.is_absolute() == false
+            && matches!(components.next(), Some(std::path::Component::Normal(_)))
+            && components.next().is_none();
+        if valid {
+            Ok(directory.to_string())
+        } else {
+            Err(AppError::Message(format!(
+                "Invalid skill directory (possible path traversal): {directory:?}"
+            )))
+        }
     }
 
     /// Reject migration targets that alias an app's skills directory
@@ -2863,6 +2893,24 @@ mod tests {
         fs::create_dir_all(&skill_dir).expect("create test skill directory");
         fs::write(skill_dir.join("SKILL.md"), "# Test Skill").expect("write test skill manifest");
 
+        // 注入 DB 管理记录（迁移只移动 DB 管理的技能）。
+        let db = Database::init().expect("init db");
+        let skill = crate::app_config::InstalledSkill {
+            id: "local:test-skill".to_string(),
+            name: "Test Skill".to_string(),
+            description: None,
+            directory: "test-skill".to_string(),
+            repo_owner: None,
+            repo_name: None,
+            repo_branch: None,
+            readme_url: None,
+            apps: crate::app_config::SkillApps::only(&AppType::Claude),
+            installed_at: 0,
+            content_hash: None,
+            updated_at: 0,
+        };
+        db.save_skill(&skill).expect("save managed skill");
+
         let result = SkillService::migrate_storage(SkillStorageLocation::Unified)
             .expect("migrate to unified storage must succeed");
         assert_eq!(result.migrated_count, 1, "one skill must migrate");
@@ -2966,6 +3014,35 @@ mod tests {
             crate::settings::get_skill_storage_location(),
             SkillStorageLocation::CcSwitch,
             "location must not switch when migration fails early"
+        );
+    }
+
+    /// Blocker 2 回归：未管理的目录（无 DB 记录）不得被迁移移动。
+    #[test]
+    fn migrate_storage_skips_unmanaged_dirs() {
+        let home = tempfile::tempdir().expect("create isolated home");
+        let _env = crate::test_support::TestEnvGuard::isolated(home.path());
+        crate::settings::set_skill_storage_location(SkillStorageLocation::CcSwitch)
+            .expect("set cc_switch storage");
+
+        let old_dir = SkillService::get_ssot_dir().expect("resolve cc_switch SSOT");
+        // 未管理的目录：只建目录，不注入 DB 记录。
+        let unmanaged = old_dir.join("unmanaged-dir");
+        fs::create_dir_all(&unmanaged).expect("create unmanaged dir");
+        fs::write(unmanaged.join("SKILL.md"), "# Unmanaged").expect("write unmanaged manifest");
+
+        let result = SkillService::migrate_storage(SkillStorageLocation::Unified)
+            .expect("migrate must succeed");
+        assert_eq!(result.migrated_count, 0, "no managed skills to migrate");
+        assert!(
+            unmanaged.exists(),
+            "unmanaged directory must stay in old SSOT: {:?}",
+            old_dir
+        );
+        let new_dir = SkillService::get_ssot_dir().expect("resolve unified SSOT");
+        assert!(
+            !new_dir.join("unmanaged-dir").exists(),
+            "unmanaged directory must not be moved to new SSOT"
         );
     }
 }

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -611,7 +611,14 @@ impl SkillService {
     // ---------------------------------------------------------------------
 
     pub fn get_ssot_dir() -> Result<PathBuf, AppError> {
-        let dir = get_app_config_dir().join("skills");
+        let location = crate::settings::get_skill_storage_location();
+        let dir = match location {
+            SkillStorageLocation::CcSwitch => get_app_config_dir().join("skills"),
+            SkillStorageLocation::Unified => crate::config::home_dir()
+                .unwrap_or_else(|| get_app_config_dir())
+                .join(".agents")
+                .join("skills"),
+        };
         create_managed_config_dir_all(&dir)?;
         Ok(dir)
     }
@@ -2466,6 +2473,28 @@ mod tests {
         assert_eq!(
             SkillService::branch_candidates("HEAD", Some("trunk".to_string()), false),
             vec!["trunk", "main", "master"]
+        );
+    }
+
+    #[test]
+    fn get_ssot_dir_switches_on_location() {
+        let home = tempfile::tempdir().expect("create isolated home");
+        let _env = crate::test_support::TestEnvGuard::isolated(home.path());
+
+        crate::settings::set_skill_storage_location(SkillStorageLocation::CcSwitch)
+            .expect("set cc_switch storage");
+        let cc_dir = SkillService::get_ssot_dir().expect("resolve cc_switch SSOT");
+        assert!(
+            cc_dir.ends_with(".cc-switch/skills"),
+            "cc_switch mode: {cc_dir:?}"
+        );
+
+        crate::settings::set_skill_storage_location(SkillStorageLocation::Unified)
+            .expect("set unified storage");
+        let agents_dir = SkillService::get_ssot_dir().expect("resolve unified SSOT");
+        assert!(
+            agents_dir.ends_with(".agents/skills"),
+            "unified mode: {agents_dir:?}"
         );
     }
 

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -126,6 +126,7 @@ pub enum SyncMethod {
 pub enum SkillStorageLocation {
     /// CC Switch 管理目录 (~/.cc-switch/skills/)
     #[default]
+    #[value(alias = "cc_switch")]
     CcSwitch,
     /// Agent Skills 统一标准目录 (~/.agents/skills/)
     Unified,
@@ -618,15 +619,23 @@ impl SkillService {
     // Paths
     // ---------------------------------------------------------------------
 
-    pub fn get_ssot_dir() -> Result<PathBuf, AppError> {
-        let location = crate::settings::get_skill_storage_location();
-        let dir = match location {
+    /// 解析指定存储位置对应的 SSOT 目录路径（不创建目录）。
+    ///
+    /// `get_ssot_dir()` 与 `migrate_storage()` 共用此函数，保证两处路径解析一致；
+    /// unified 模式的目标在 `~/.agents/skills`（不在受管 config root 下），
+    /// 因此 `create_managed_config_dir_all` 会自然退化为普通 `create_dir_all`。
+    fn ssot_dir_for(location: SkillStorageLocation) -> PathBuf {
+        match location {
             SkillStorageLocation::CcSwitch => get_app_config_dir().join("skills"),
             SkillStorageLocation::Unified => crate::config::home_dir()
                 .unwrap_or_else(|| get_app_config_dir())
                 .join(".agents")
                 .join("skills"),
-        };
+        }
+    }
+
+    pub fn get_ssot_dir() -> Result<PathBuf, AppError> {
+        let dir = Self::ssot_dir_for(crate::settings::get_skill_storage_location());
         create_managed_config_dir_all(&dir)?;
         Ok(dir)
     }
@@ -643,14 +652,9 @@ impl SkillService {
         }
 
         let old_dir = Self::get_ssot_dir()?;
-        let new_dir = match target {
-            SkillStorageLocation::CcSwitch => get_app_config_dir().join("skills"),
-            SkillStorageLocation::Unified => crate::config::home_dir()
-                .unwrap_or_else(|| get_app_config_dir())
-                .join(".agents")
-                .join("skills"),
-        };
-        fs::create_dir_all(&new_dir).map_err(|e| AppError::io(&new_dir, e))?;
+        let new_dir = Self::ssot_dir_for(target);
+        // 与 get_ssot_dir 一致：目标目录用受管安全创建（Unix 下拒绝符号链接组件）。
+        create_managed_config_dir_all(&new_dir)?;
         Self::validate_skill_storage_destination(&new_dir)?;
 
         // 步骤 0【迁移前备份】: 目录复制（简单可靠），后续可精化为 zip 归档。
@@ -699,11 +703,24 @@ impl SkillService {
                     }
                     Err(_) => match Self::copy_dir_recursive(&src, &dst) {
                         Ok(()) => {
-                            let _ = fs::remove_dir_all(&src);
+                            if let Err(e) = fs::remove_dir_all(&src) {
+                                // 源未删干净：新旧各有一份，提示用户手动清理。
+                                result.errors.push(format!(
+                                    "{directory}: 源目录清理失败（已复制，旧目录保留）: {e}"
+                                ));
+                            }
                             migrated_dirs.push(directory);
                             result.migrated_count += 1;
                         }
-                        Err(e) => result.errors.push(format!("{directory}: {e}")),
+                        Err(e) => {
+                            // 复制失败可能留下半成品目标目录：清理它，避免后续
+                            // sync_to_app_dir 用残缺副本覆盖 app 完整副本。
+                            let clean_msg = match fs::remove_dir_all(&dst) {
+                                Ok(()) => String::new(),
+                                Err(ce) => format!("；清理半成品目标目录失败: {ce}"),
+                            };
+                            result.errors.push(format!("{directory}: {e}{clean_msg}"));
+                        }
                     },
                 }
             }
@@ -2906,6 +2923,49 @@ mod tests {
             snapshot.join("test-skill").join("SKILL.md").exists(),
             "backup snapshot must contain the migrated skill: {:?}",
             snapshot
+        );
+    }
+
+    /// P1-1 回归：迁移目标路径被占用导致 rename 与 copy 都失败时，
+    /// 失败项必须记入 errors，源目录保持不动，且存储位置不得切换
+    /// （避免后续 sync_to_app_dir 用半成品覆盖 app 完整副本）。
+    #[test]
+    fn migrate_storage_keeps_source_and_setting_on_failure() {
+        let home = tempfile::tempdir().expect("create isolated home");
+        let _env = crate::test_support::TestEnvGuard::isolated(home.path());
+        crate::settings::set_skill_storage_location(SkillStorageLocation::CcSwitch)
+            .expect("set cc_switch storage");
+
+        let old_dir = SkillService::get_ssot_dir().expect("resolve cc_switch SSOT");
+        let skill_dir = old_dir.join("test-skill");
+        fs::create_dir_all(&skill_dir).expect("create test skill directory");
+        fs::write(skill_dir.join("SKILL.md"), "# Test Skill").expect("write test skill manifest");
+
+        // 让迁移目标路径变成一个普通文件（而非目录）：
+        // rename 失败（dest 已是文件），copy 的 create_dir_all(dest) 也失败 → Err 分支。
+        let new_dir = crate::config::home_dir()
+            .expect("home")
+            .join(".agents")
+            .join("skills");
+        fs::create_dir_all(new_dir.parent().expect("parent")).expect("create parent");
+        fs::write(&new_dir, "blocker").expect("write blocker file at dest path");
+
+        // 目标路径被文件占用：受管创建在迁移任何内容前就应失败（P1-3 行为），
+        // 源目录与设置都必须保持原样。
+        let err = SkillService::migrate_storage(SkillStorageLocation::Unified)
+            .expect_err("migration must fail when dest path is blocked by a file");
+        assert!(
+            err.to_string().contains("File exists") || err.to_string().contains("AlreadyExists"),
+            "error should mention the blocked destination: {err}"
+        );
+        assert!(
+            skill_dir.join("SKILL.md").exists(),
+            "source skill must remain untouched after failure"
+        );
+        assert_eq!(
+            crate::settings::get_skill_storage_location(),
+            SkillStorageLocation::CcSwitch,
+            "location must not switch when migration fails early"
         );
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -578,6 +578,9 @@ pub struct AppSettings {
     /// Skills 同步方式（auto|symlink|copy）
     #[serde(default)]
     pub skill_sync_method: crate::services::skill::SyncMethod,
+    /// Skill 存储位置：cc_switch（默认）或 unified（~/.agents/skills/）
+    #[serde(default)]
+    pub skill_storage_location: crate::services::skill::SkillStorageLocation,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security: Option<SecuritySettings>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -646,6 +649,7 @@ impl Default for AppSettings {
             unify_codex_migrate_existing: None,
             usage_auto_sync: default_usage_auto_sync(),
             skill_sync_method: crate::services::skill::SyncMethod::default(),
+            skill_storage_location: crate::services::skill::SkillStorageLocation::default(),
             security: None,
             webdav_sync: None,
             s3_sync: None,
@@ -1249,6 +1253,21 @@ pub fn effective_backup_retain_count() -> usize {
 pub fn set_skill_sync_method(method: crate::services::skill::SyncMethod) -> Result<(), AppError> {
     let mut settings = get_settings();
     settings.skill_sync_method = method;
+    update_settings(settings)
+}
+
+pub fn get_skill_storage_location() -> crate::services::skill::SkillStorageLocation {
+    settings_store()
+        .read()
+        .map(|s| s.skill_storage_location)
+        .unwrap_or_default()
+}
+
+pub fn set_skill_storage_location(
+    location: crate::services::skill::SkillStorageLocation,
+) -> Result<(), AppError> {
+    let mut settings = get_settings();
+    settings.skill_storage_location = location;
     update_settings(settings)
 }
 

--- a/src-tauri/tests/skills_service.rs
+++ b/src-tauri/tests/skills_service.rs
@@ -379,3 +379,24 @@ fn storage_location_persists_and_roundtrips() {
         "set value should be readable back after persisting"
     );
 }
+
+#[test]
+fn storage_location_cli_roundtrips_via_service() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    set_skill_storage_location(SkillStorageLocation::Unified).expect("set unified");
+    assert_eq!(
+        get_skill_storage_location(),
+        SkillStorageLocation::Unified,
+        "value set through settings API should be readable"
+    );
+
+    set_skill_storage_location(SkillStorageLocation::CcSwitch).expect("set cc_switch");
+    assert_eq!(
+        get_skill_storage_location(),
+        SkillStorageLocation::CcSwitch,
+        "switching back should roundtrip"
+    );
+}

--- a/src-tauri/tests/skills_service.rs
+++ b/src-tauri/tests/skills_service.rs
@@ -1,4 +1,7 @@
-use cc_switch_lib::{AppType, Database, ImportSkillSelection, SkillApps, SkillService};
+use cc_switch_lib::{
+    get_skill_storage_location, set_skill_storage_location, AppType, Database, ImportSkillSelection,
+    SkillApps, SkillService, SkillStorageLocation,
+};
 
 #[path = "support.rs"]
 mod support;
@@ -348,5 +351,32 @@ fn pending_migration_with_existing_managed_list_does_not_claim_unmanaged_skills(
     assert!(
         all.values().all(|s| s.directory != "unmanaged-skill"),
         "unmanaged skill should remain unmanaged (not added to db)"
+    );
+}
+
+#[test]
+fn storage_location_defaults_to_cc_switch() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+
+    assert_eq!(
+        get_skill_storage_location(),
+        SkillStorageLocation::CcSwitch,
+        "without configuration the storage location should default to CC Switch"
+    );
+}
+
+#[test]
+fn storage_location_persists_and_roundtrips() {
+    let _guard = lock_test_mutex();
+    reset_test_fs();
+
+    set_skill_storage_location(SkillStorageLocation::Unified)
+        .expect("set skill storage location");
+
+    assert_eq!(
+        get_skill_storage_location(),
+        SkillStorageLocation::Unified,
+        "set value should be readable back after persisting"
     );
 }

--- a/src-tauri/tests/skills_service.rs
+++ b/src-tauri/tests/skills_service.rs
@@ -1,6 +1,6 @@
 use cc_switch_lib::{
-    get_skill_storage_location, set_skill_storage_location, AppType, Database, ImportSkillSelection,
-    SkillApps, SkillService, SkillStorageLocation,
+    get_skill_storage_location, set_skill_storage_location, AppType, Database,
+    ImportSkillSelection, SkillApps, SkillService, SkillStorageLocation,
 };
 
 #[path = "support.rs"]
@@ -371,8 +371,7 @@ fn storage_location_persists_and_roundtrips() {
     let _guard = lock_test_mutex();
     reset_test_fs();
 
-    set_skill_storage_location(SkillStorageLocation::Unified)
-        .expect("set skill storage location");
+    set_skill_storage_location(SkillStorageLocation::Unified).expect("set skill storage location");
 
     assert_eq!(
         get_skill_storage_location(),


### PR DESCRIPTION
## Summary

Add configurable skills SSOT storage location (`skill_storage_location`: `cc-switch` | `unified`) to the CLI, aligning with the upstream GUI's `skillStorageLocation` feature (farion1231/cc-switch). In `unified` mode, `~/.agents/skills/` becomes the SSOT — the cross-tool standard directory adopted by skills.sh, LangChain, and six major harnesses.

Closes #413

## Motivation

`~/.agents/skills/` is the de-facto cross-harness standard for agent skills (Codex, Gemini CLI, DSH, OpenCode, Windsurf, Warp scan it natively; LangChain deepagents and skills.sh adopt it). The CLI's SSOT was hardcoded to `{config_dir}/skills`, forcing users of the `.agents` convention into two divergent skill copies. See #413 for the full harness adoption matrix.

## Changes

| File | Change |
|---|---|
| `src/services/skill.rs` | `SkillStorageLocation` enum; `get_ssot_dir()` honors location; `migrate_storage()` with pre-migration backup; `validate_skill_storage_destination()` |
| `src/settings.rs` | `skill_storage_location` field (`#[serde(default)]`), get/set functions |
| `src/lib.rs` | re-exports for tests/callers |
| `src/cli/commands/skills.rs` | `skills storage-location` command (get/set + triggers migration) |
| `tests/skills_service.rs` | tests for default, roundtrip, storage-location CLI |

### CLI usage

```bash
cc-switch skills storage-location              # show current (cc-switch | unified)
cc-switch skills storage-location unified      # switch to ~/.agents/skills + migrate
cc-switch skills storage-location cc-switch    # switch back + migrate
```

### Behavior (aligned with upstream GUI's migrate_storage)

1. Pre-migration backup of the old SSOT to `{config_dir}/skill-backups/` (new: upstream has no backup; added for rollback safety)
2. Validate destination (rejects aliased app skills dirs via canonicalize)
3. Move skills one-by-one (rename → copy+delete fallback; soft-fail per skill)
4. Update setting only after files moved
5. Re-sync app skill dirs to the new SSOT

## Testing

- New: 5 unit tests (`migrate_storage_*`, `get_ssot_dir_switches_on_location`) + 3 integration tests (`storage_location_*`) — all pass
- `services::skill` module: 20/20 pass
- Full lib: 4088 passed; 16 failed — **all 16 failures are pre-existing `cli::tui::theme::tests` (terminal color detection fails in non-TTY env), unrelated to this change** (verified on clean baseline via `git stash`)
- `cargo fmt --check` clean; `cargo clippy` no new warnings

## Notes

- Values: clap kebab-case `cc-switch`/`unified` for CLI args; serde snake_case `cc_switch`/`unified` in settings.json
- Migration backup uses directory copy (not zip) for simplicity — sufficient for rollback
- `migrate_storage` traverses the SSOT directory (not the index), so traversal-safe by construction
