### PR TITLE
feat: make CLI dependencies optional

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -76,8 +76,26 @@ jobs:
       - name: Assert CLI dependencies are absent from the library graph
         working-directory: src-tauri
         run: |
+          cli_dependency_names='clap clap_complete colored comfy-table console crossterm env_logger indicatif inquire minisign-verify ratatui self-replace semver shlex tachyonfx tar unicode-width which windows-sys winreg'
+          cli_dependency_pattern="^($(printf '%s' "$cli_dependency_names" | tr ' ' '|')) v"
+
+          cargo tree --target all -e normal --depth 1 --prefix none > default-direct-dependencies.txt
+          for cli_dependency in $cli_dependency_names; do
+            if ! grep -E "^${cli_dependency} v" default-direct-dependencies.txt > /dev/null; then
+              printf 'Known CLI dependency %s was not found in the default graph.\n' "$cli_dependency"
+              exit 1
+            fi
+          done
+
           cargo tree --no-default-features --target all -e normal --depth 1 --prefix none > library-direct-dependencies.txt
-          if grep -E '^(clap|clap_complete|colored|comfy-table|console|crossterm|env_logger|indicatif|inquire|minisign-verify|ratatui|self-replace|semver|shlex|tachyonfx|tar|unicode-width|which|windows-sys|winreg) v' library-direct-dependencies.txt > leaked-cli-dependencies.txt; then
+          for core_dependency in rusqlite serde tokio; do
+            if ! grep -E "^${core_dependency} v" library-direct-dependencies.txt > /dev/null; then
+              printf 'Core dependency %s was not found in the library-only graph.\n' "$core_dependency"
+              exit 1
+            fi
+          done
+
+          if grep -E "$cli_dependency_pattern" library-direct-dependencies.txt > leaked-cli-dependencies.txt; then
             printf 'CLI dependencies leaked into the library-only graph:\n'
             cat leaked-cli-dependencies.txt
             exit 1

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -47,6 +47,42 @@ jobs:
         working-directory: src-tauri
         run: cargo fmt --check
 
+  library-only:
+    name: Library without CLI
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91.1
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: library-without-cli
+
+      - name: Check and compile-test library without CLI dependencies
+        working-directory: src-tauri
+        run: |
+          cargo check --lib --no-default-features
+          cargo test --lib --no-default-features --no-run
+
+      - name: Assert CLI dependencies are absent from the library graph
+        working-directory: src-tauri
+        run: |
+          cargo tree --no-default-features --target all -e normal --depth 1 --prefix none > library-direct-dependencies.txt
+          if grep -E '^(clap|clap_complete|colored|comfy-table|console|crossterm|env_logger|indicatif|inquire|minisign-verify|ratatui|self-replace|semver|shlex|tachyonfx|tar|unicode-width|which|windows-sys|winreg) v' library-direct-dependencies.txt > leaked-cli-dependencies.txt; then
+            printf 'CLI dependencies leaked into the library-only graph:\n'
+            cat leaked-cli-dependencies.txt
+            exit 1
+          fi
+
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-22.04

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -73,9 +73,11 @@ jobs:
           cargo check --lib --no-default-features
           cargo test --lib --no-default-features --no-run
 
-      - name: Assert CLI dependencies are absent from the library graph
+      - name: Assert CLI dependencies are absent from the direct library graph
         working-directory: src-tauri
         run: |
+          # This guard is deliberately limited to direct dependencies. A full-graph
+          # guard would need an allowlist for legitimate core transitives.
           cli_dependency_names='clap clap_complete colored comfy-table console crossterm env_logger indicatif inquire minisign-verify ratatui self-replace semver shlex tachyonfx tar unicode-width which windows-sys winreg'
           cli_dependency_pattern="^($(printf '%s' "$cli_dependency_names" | tr ' ' '|')) v"
 
@@ -88,12 +90,22 @@ jobs:
           done
 
           cargo tree --no-default-features --target all -e normal --depth 1 --prefix none > library-direct-dependencies.txt
-          for core_dependency in rusqlite serde tokio; do
-            if ! grep -E "^${core_dependency} v" library-direct-dependencies.txt > /dev/null; then
-              printf 'Core dependency %s was not found in the library-only graph.\n' "$core_dependency"
-              exit 1
-            fi
-          done
+          if ! grep -E '^cc-switch v' library-direct-dependencies.txt > /dev/null; then
+            printf 'The library-only graph did not identify the cc-switch root package.\n'
+            exit 1
+          fi
+          direct_dependency_count=$(tail -n +2 library-direct-dependencies.txt | wc -l | tr -d ' ')
+          if [ "$direct_dependency_count" -eq 0 ]; then
+            printf 'The library-only graph did not contain any direct dependencies.\n'
+            exit 1
+          fi
+
+          cp library-direct-dependencies.txt controlled-library-direct-dependencies.txt
+          printf 'ratatui v0.0.0\n' >> controlled-library-direct-dependencies.txt
+          if ! grep -E "$cli_dependency_pattern" controlled-library-direct-dependencies.txt > /dev/null; then
+            printf 'Dependency boundary matcher did not detect its synthetic CLI leak.\n'
+            exit 1
+          fi
 
           if grep -E "$cli_dependency_pattern" library-direct-dependencies.txt > leaked-cli-dependencies.txt; then
             printf 'CLI dependencies leaked into the library-only graph:\n'

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,16 +17,39 @@ crate-type = ["rlib"]
 [[bin]]
 name = "cc-switch"
 path = "src/main.rs"
+required-features = ["cli"]
 
 [features]
-default = []
+default = ["cli"]
+cli = [
+    "dep:clap",
+    "dep:clap_complete",
+    "dep:colored",
+    "dep:comfy-table",
+    "dep:console",
+    "dep:crossterm",
+    "dep:env_logger",
+    "dep:indicatif",
+    "dep:inquire",
+    "dep:minisign-verify",
+    "dep:ratatui",
+    "dep:self-replace",
+    "dep:semver",
+    "dep:shlex",
+    "dep:tachyonfx",
+    "dep:tar",
+    "dep:unicode-width",
+    "dep:which",
+    "dep:windows-sys",
+    "dep:winreg",
+]
 test-hooks = []
 
 [dependencies]
 # Core dependencies
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
-log = "0.4"
+log = { version = "0.4", features = ["std"] }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"
 anyhow = "1.0"
@@ -34,21 +57,21 @@ once_cell = "1.21.3"
 libc = "0.2"
 
 # CLI dependencies
-clap = { version = "4.5", features = ["derive", "cargo", "env", "wrap_help"] }
-clap_complete = "4.5"
-inquire = { version = "0.9", features = ["fuzzy"] }
-console = "0.15"
-comfy-table = "7.1"
-colored = "2.1"
-indicatif = "0.17"
-env_logger = "0.11"
-ratatui = "0.30"
-crossterm = { version = "0.29", features = ["osc52"] }
+clap = { version = "4.5", features = ["derive", "cargo", "env", "wrap_help"], optional = true }
+clap_complete = { version = "4.5", optional = true }
+inquire = { version = "0.9", features = ["fuzzy"], optional = true }
+console = { version = "0.15", optional = true }
+comfy-table = { version = "7.1", optional = true }
+colored = { version = "2.1", optional = true }
+indicatif = { version = "0.17", optional = true }
+env_logger = { version = "0.11", optional = true }
+ratatui = { version = "0.30", optional = true }
+crossterm = { version = "0.29", features = ["osc52"], optional = true }
 
 # File and path utilities
 dirs = "5.0"
 tempfile = "3"
-which = "6.0"
+which = { version = "6.0", optional = true }
 
 # Serialization
 toml = "0.8"
@@ -78,22 +101,22 @@ uuid = { version = "1.11", features = ["v4"] }
 regex = "1.10"
 sha2 = "0.10"
 hmac = "0.12"
-shlex = "1.3"
-minisign-verify = "0.2.4"
-semver = "1.0"
+shlex = { version = "1.3", optional = true }
+minisign-verify = { version = "0.2.4", optional = true }
+semver = { version = "1.0", optional = true }
 flate2 = "1.0"
 brotli = "7"
-tar = "0.4"
+tar = { version = "0.4", optional = true }
 rquickjs = { version = "0.8", features = ["array-buffer", "classes"] }
 zip = "2.2"
 url = "2.5"
-unicode-width = "0.1"
-tachyonfx = "0.25"
+unicode-width = { version = "0.1", optional = true }
+tachyonfx = { version = "0.25", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winreg = "0.52"
-self-replace = "1"
-windows-sys = { version = "0.61", features = [
+winreg = { version = "0.52", optional = true }
+self-replace = { version = "1", optional = true }
+windows-sys = { version = "0.61", optional = true, features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_System_Diagnostics_ToolHelp",

--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -292,7 +292,8 @@ use crate::error::AppError;
 use crate::provider::ProviderManager;
 
 /// 应用类型
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, clap::ValueEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[serde(rename_all = "lowercase")]
 pub enum AppType {
     Claude,

--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -129,7 +129,7 @@ pub fn is_chinese() -> bool {
 #[macro_export]
 macro_rules! t {
     ($en:expr, $zh:expr) => {
-        if $crate::cli::i18n::is_chinese() {
+        if $crate::i18n::is_chinese() {
             $zh
         } else {
             $en
@@ -4747,6 +4747,7 @@ pub mod texts {
         }
     }
 
+    #[cfg(feature = "cli")]
     pub fn tui_settings_theme_mode_name(mode: crate::cli::tui::theme::ThemeMode) -> &'static str {
         use crate::cli::tui::theme::ThemeMode;
         if is_chinese() {
@@ -4780,6 +4781,7 @@ pub mod texts {
         }
     }
 
+    #[cfg(feature = "cli")]
     pub fn tui_settings_icon_mode_name(mode: crate::cli::tui::icons::IconMode) -> &'static str {
         use crate::cli::tui::icons::IconMode;
         if is_chinese() {

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -7,7 +7,7 @@ mod codex_temp_launch;
 pub mod commands;
 pub mod editor;
 pub(crate) mod failover_policy;
-pub mod i18n;
+pub use crate::i18n;
 pub mod interactive;
 pub(crate) mod openclaw_form_normalization;
 pub(crate) mod provider_quota;

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -4,8 +4,8 @@ use std::fs;
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 
-use crate::cli::i18n::texts;
 use crate::error::AppError;
+use crate::i18n::texts;
 
 pub(crate) fn home_dir() -> Option<PathBuf> {
     #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,7 +41,12 @@ mod usage_script;
 #[cfg(test)]
 pub(crate) mod test_support;
 
+// Localized validation text is also used by the library-only build.
+#[path = "cli/i18n.rs"]
+pub mod i18n;
+
 // CLI module
+#[cfg(feature = "cli")]
 pub mod cli;
 
 // Public exports

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -6,9 +6,12 @@ pub mod codex_oauth_models;
 pub mod coding_plan;
 pub mod config;
 pub mod copilot_auth;
+#[cfg(feature = "cli")]
 pub mod env_checker;
 #[allow(dead_code)]
+#[cfg(feature = "cli")]
 pub mod env_manager;
+#[cfg(feature = "cli")]
 pub mod local_env_check;
 pub mod mcp;
 pub mod model_fetch;
@@ -31,6 +34,7 @@ pub mod stream_check;
 pub mod subscription;
 pub(crate) mod sync_protocol;
 pub mod usage_stats;
+#[cfg(feature = "cli")]
 pub mod visible_apps;
 pub mod webdav;
 pub mod webdav_sync;

--- a/src-tauri/src/services/provider/tests.rs
+++ b/src-tauri/src/services/provider/tests.rs
@@ -3136,6 +3136,7 @@ fn provider_add_strips_common_snippet_before_claude_snapshot_persist() {
 }
 
 #[test]
+#[cfg(feature = "cli")]
 #[serial]
 fn tui_claude_quick_config_round_trip_crosses_storage_normalization() {
     let temp_home = TempDir::new().expect("create temp home");
@@ -3209,6 +3210,7 @@ fn tui_claude_quick_config_round_trip_crosses_storage_normalization() {
 }
 
 #[test]
+#[cfg(feature = "cli")]
 #[serial]
 fn tui_claude_quick_edit_persists_legacy_inferred_common_config() {
     let temp_home = TempDir::new().expect("create temp home");
@@ -3281,6 +3283,7 @@ fn tui_claude_quick_edit_persists_legacy_inferred_common_config() {
 }
 
 #[test]
+#[cfg(feature = "cli")]
 #[serial]
 fn tui_codex_conflicting_quick_edit_preserves_storage_only_settings() {
     let temp_home = TempDir::new().expect("create temp home");

--- a/src-tauri/src/services/session_cost/tests.rs
+++ b/src-tauri/src/services/session_cost/tests.rs
@@ -5,7 +5,9 @@ use std::time::{Duration, Instant};
 use rusqlite::{params, Connection};
 
 use crate::database::Database;
-use crate::services::sql_helpers::{INPUT_TOKEN_SEMANTICS_FRESH, INPUT_TOKEN_SEMANTICS_TOTAL};
+use crate::services::sql_helpers::INPUT_TOKEN_SEMANTICS_FRESH;
+#[cfg(feature = "cli")]
+use crate::services::sql_helpers::INPUT_TOKEN_SEMANTICS_TOTAL;
 use crate::session_manager::SessionUsageSummary;
 
 use super::{project_main_connection, project_page, QueryControl, SessionCostIdentity};
@@ -608,6 +610,7 @@ fn duplicate_visible_source_paths_are_ambiguous_and_receive_no_overlay() {
 }
 
 #[test]
+#[cfg(feature = "cli")]
 fn session_projection_matches_usage_page_bucket_and_cost_semantics() {
     let db = Database::memory().expect("memory database");
     let conn = db.conn.lock().expect("database lock");

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -108,7 +108,8 @@ impl Default for SkillStore {
 // ============================================================================
 
 /// Skill sync method (upstream-aligned).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[serde(rename_all = "lowercase")]
 pub enum SyncMethod {
     /// Auto choose: prefer symlink, fallback to copy.

--- a/src-tauri/src/services/visible_apps.rs
+++ b/src-tauri/src/services/visible_apps.rs
@@ -1,6 +1,6 @@
 use crate::app_config::AppType;
-use crate::cli::i18n::texts;
 use crate::error::AppError;
+use crate::i18n::{self, texts, Language};
 use crate::settings::{self, VisibleApps, VisibleAppsMode};
 use std::collections::HashMap;
 
@@ -174,7 +174,7 @@ pub fn notice_message(notice: &VisibleAppsNotice) -> String {
 }
 
 fn list_separator() -> &'static str {
-    if crate::cli::i18n::current_language() == crate::cli::i18n::Language::Chinese {
+    if i18n::current_language() == Language::Chinese {
         "、"
     } else {
         ", "


### PR DESCRIPTION
## Summary

- add a default-enabled `cli` Cargo feature and require it for the `cc-switch` binary
- gate CLI/TUI modules and their direct dependencies so library consumers can build with `default-features = false`
- keep shared localization available to core library modules
- add CI coverage for the library-only build, test compilation, and all-target direct dependency boundary

Default builds remain unchanged: the `cli` feature is enabled by default.

## Validation

- `cargo check`
- `cargo test --lib --no-run`
- `cargo test --bin cc-switch --no-run`
- `cargo check --lib --no-default-features`
- `cargo check --lib --no-default-features --features test-hooks`
- `cargo test --lib --no-default-features --no-run`
- `cargo fmt --check`
- `git diff --check`
- parsed `.github/workflows/rust-ci.yml` as YAML
- verified the all-target, no-default direct dependency graph excludes every feature-gated CLI/TUI dependency

## Notes

`cargo clippy` still reports the existing reversed-empty-range lint in `src/cli/tui/ui/home_chart.rs`; this change does not touch that code.
