### PR TITLE
feat: add Claude OAuth authorization flow

### DIFF
--- a/docs/CLAUDE-OAUTH.md
+++ b/docs/CLAUDE-OAUTH.md
@@ -20,9 +20,11 @@ response. Adding another browser OAuth provider therefore adds an adapter and
 dispatch entry, not `start_<provider>_login` methods to the facade.
 
 The public result contains only an authorization URL or an account summary.
-Access and refresh tokens are written into Claude Code's native
-`.credentials.json` shape (with mode `0600` on Unix) and are never serialized
-into the JavaScript/N-API response or provider settings.
+Access and refresh tokens belong to cc-switch and are written under
+`~/.cc-switch/credentials/claude.json` (mode `0600` on Unix). This flow never
+writes macOS Keychain or Claude Code's `~/.claude/.credentials.json`; syncing
+an account into Claude Code is a separate, explicit integration. Tokens are
+never serialized into the JavaScript/N-API response or provider settings.
 
 ## Scope of this draft
 

--- a/docs/CLAUDE-OAUTH.md
+++ b/docs/CLAUDE-OAUTH.md
@@ -6,13 +6,18 @@ existing reader for credentials created by the Claude CLI.
 
 ## Flow
 
-1. Call `AuthService::start_claude_login(None)` (or provide a localhost
+1. Call `AuthService::start("claude_oauth", None)` (or provide a localhost
    callback such as `http://localhost:54545/callback`).
 2. Open the returned `authorization_url` in a browser.
 3. Pass the complete browser callback URL to
-   `AuthService::complete_claude_login(callback_url)`.
+   `AuthService::complete("claude_oauth", callback_url)`.
 4. The native service validates the redirect origin, callback `state`, expiry,
    and authorization errors, then exchanges the code with Anthropic.
+
+`AuthService` is provider-neutral: `start(provider, redirect_uri)` dispatches
+to a provider strategy and returns either a `device_code` or `browser` tagged
+response. Adding another browser OAuth provider therefore adds an adapter and
+dispatch entry, not `start_<provider>_login` methods to the facade.
 
 The public result contains only an authorization URL or an account summary.
 Access and refresh tokens stay in the native config store and are never

--- a/docs/CLAUDE-OAUTH.md
+++ b/docs/CLAUDE-OAUTH.md
@@ -1,0 +1,38 @@
+# Claude OAuth (draft)
+
+This fork contains a first-stage native Claude Code OAuth authorization-code
+flow. It is intentionally separate from provider switching and from the
+existing reader for credentials created by the Claude CLI.
+
+## Flow
+
+1. Call `AuthService::start_claude_login(None)` (or provide a localhost
+   callback such as `http://localhost:54545/callback`).
+2. Open the returned `authorization_url` in a browser.
+3. Pass the complete browser callback URL to
+   `AuthService::complete_claude_login(callback_url)`.
+4. The native service validates the redirect origin, callback `state`, expiry,
+   and authorization errors, then exchanges the code with Anthropic.
+
+The public result contains only an authorization URL or an account summary.
+Access and refresh tokens stay in the native config store and are never
+serialized into the JavaScript/N-API response or provider settings.
+
+## Scope of this draft
+
+The draft covers PKCE (S256), state binding, callback validation, token
+exchange, and a single native account record. It does not yet provide account
+listing, refresh, logout, profile/roles enrichment, or an N-API binding. Those
+should land as separate follow-up changes after the protocol and storage
+contract are reviewed.
+
+The callback listener is expected to be owned by the desktop shell. The
+service accepts a callback URL so a shell can use its own one-shot localhost
+listener or a deep-link bridge without exposing token material to the UI.
+
+## Compatibility note
+
+The endpoint and client values follow the Claude Code OAuth protocol used by
+the current CLIProxyAPI implementation. They are not a promise that Anthropic
+will support arbitrary third-party clients or redirect URIs; production use
+needs an explicit compatibility/security review.

--- a/docs/CLAUDE-OAUTH.md
+++ b/docs/CLAUDE-OAUTH.md
@@ -20,8 +20,9 @@ response. Adding another browser OAuth provider therefore adds an adapter and
 dispatch entry, not `start_<provider>_login` methods to the facade.
 
 The public result contains only an authorization URL or an account summary.
-Access and refresh tokens stay in the native config store and are never
-serialized into the JavaScript/N-API response or provider settings.
+Access and refresh tokens are written into Claude Code's native
+`.credentials.json` shape (with mode `0600` on Unix) and are never serialized
+into the JavaScript/N-API response or provider settings.
 
 ## Scope of this draft
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,12 +79,13 @@ pub use mcp::{
 pub use provider::{Provider, ProviderMeta, UsageScript};
 pub use proxy::{ProxyConfig, ProxyServerInfo, ProxyStatus};
 pub use services::{
-    reapply_current_codex_official_live, AuthService, ConfigService, CredentialStatus,
-    EndpointLatency, ExtraUsage, HealthStatus, ImportSkillSelection, ManagedAuthAccount,
-    ManagedAuthDeviceCodeResponse, ManagedAuthStatus, McpService, PromptService, ProviderService,
-    ProxyService, QuotaTier, S3RemoteInfo, S3SyncService, S3SyncSummary, SkillService,
-    SpeedtestService, StreamCheckConfig, StreamCheckResult, StreamCheckService, SubscriptionQuota,
-    SyncDecision, WebDavSyncService, WebDavSyncSummary,
+    reapply_current_codex_official_live, AuthCompletionResponse, AuthService, AuthStartResponse,
+    BrowserAuthStart, ConfigService, CredentialStatus, EndpointLatency, ExtraUsage, HealthStatus,
+    ImportSkillSelection, ManagedAuthAccount, ManagedAuthDeviceCodeResponse, ManagedAuthStatus,
+    McpService, PromptService, ProviderService, ProxyService, QuotaTier, S3RemoteInfo,
+    S3SyncService, S3SyncSummary, SkillService, SpeedtestService, StreamCheckConfig,
+    StreamCheckResult, StreamCheckService, SubscriptionQuota, SyncDecision, WebDavSyncService,
+    WebDavSyncSummary,
 };
 pub use settings::{
     get_enable_claude_plugin_integration, get_s3_sync_settings, get_skip_claude_onboarding,

--- a/src-tauri/src/services/auth.rs
+++ b/src-tauri/src/services/auth.rs
@@ -36,6 +36,31 @@ pub struct ManagedAuthDeviceCodeResponse {
     pub interval: u64,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct BrowserAuthStart {
+    pub provider: String,
+    pub authorization_url: String,
+    pub state: String,
+    pub redirect_uri: String,
+    pub expires_in: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(tag = "flow", rename_all = "snake_case")]
+pub enum AuthStartResponse {
+    DeviceCode(ManagedAuthDeviceCodeResponse),
+    Browser(BrowserAuthStart),
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct AuthCompletionResponse {
+    pub provider: String,
+    pub account_id: String,
+    pub login: Option<String>,
+    pub organization_id: Option<String>,
+    pub is_default: bool,
+}
+
 fn ensure_auth_provider(auth_provider: &str) -> Result<&'static str, String> {
     match auth_provider {
         AUTH_PROVIDER_CODEX_OAUTH => Ok(AUTH_PROVIDER_CODEX_OAUTH),
@@ -47,29 +72,53 @@ fn ensure_auth_provider(auth_provider: &str) -> Result<&'static str, String> {
 pub struct AuthService;
 
 impl AuthService {
-    pub async fn start_claude_login(
+    /// Start the provider's native auth strategy. Browser providers return an
+    /// authorization URL; device providers return a device-code response.
+    pub async fn start(
+        auth_provider: &str,
         redirect_uri: Option<&str>,
-    ) -> Result<crate::services::ClaudeOAuthStart, String> {
-        claude::manager(crate::config::get_app_config_dir())
-            .start_login(redirect_uri)
-            .await
-    }
-
-    pub async fn complete_claude_login(
-        callback_url: &str,
-    ) -> Result<crate::services::ClaudeOAuthAccount, String> {
-        claude::manager(crate::config::get_app_config_dir())
-            .complete_login(callback_url)
-            .await
-    }
-    pub async fn start_login(auth_provider: &str) -> Result<ManagedAuthDeviceCodeResponse, String> {
+    ) -> Result<AuthStartResponse, String> {
         let auth_provider = ensure_auth_provider(auth_provider)?;
         match auth_provider {
             AUTH_PROVIDER_CODEX_OAUTH => CodexOAuthService::start_device_flow()
                 .await
-                .map(|response| codex::map_device_code_response(auth_provider, response))
+                .map(|response| {
+                    AuthStartResponse::DeviceCode(codex::map_device_code_response(
+                        auth_provider,
+                        response,
+                    ))
+                })
                 .map_err(|error| error.to_string()),
+            AUTH_PROVIDER_CLAUDE_OAUTH => claude::manager(crate::config::get_app_config_dir())
+                .start_login(redirect_uri)
+                .await
+                .map(AuthStartResponse::Browser),
             _ => unreachable!(),
+        }
+    }
+
+    /// Complete a browser callback for a provider that uses authorization code
+    /// OAuth. Device-code providers are completed by `poll_for_account`.
+    pub async fn complete(
+        auth_provider: &str,
+        callback_url: &str,
+    ) -> Result<AuthCompletionResponse, String> {
+        let auth_provider = ensure_auth_provider(auth_provider)?;
+        match auth_provider {
+            AUTH_PROVIDER_CLAUDE_OAUTH => {
+                claude::manager(crate::config::get_app_config_dir())
+                    .complete_login(callback_url)
+                    .await
+            }
+            AUTH_PROVIDER_CODEX_OAUTH => Err("Auth provider uses device-code polling".into()),
+            _ => unreachable!(),
+        }
+    }
+
+    pub async fn start_login(auth_provider: &str) -> Result<ManagedAuthDeviceCodeResponse, String> {
+        match Self::start(auth_provider, None).await? {
+            AuthStartResponse::DeviceCode(response) => Ok(response),
+            AuthStartResponse::Browser(_) => Err("Auth provider uses browser callback".into()),
         }
     }
 
@@ -217,5 +266,17 @@ mod tests {
         assert_eq!(status.accounts[0].id, "acc-456");
         assert!(status.accounts[0].is_default);
         assert!(!status.accounts[1].is_default);
+    }
+
+    #[tokio::test]
+    async fn generic_start_dispatches_by_flow_type() {
+        let response = AuthService::start(AUTH_PROVIDER_CLAUDE_OAUTH, None)
+            .await
+            .expect("start browser auth");
+        let AuthStartResponse::Browser(response) = response else {
+            panic!("Claude must use the browser callback strategy");
+        };
+        assert_eq!(response.provider, AUTH_PROVIDER_CLAUDE_OAUTH);
+        assert!(response.authorization_url.starts_with("https://claude.ai/"));
     }
 }

--- a/src-tauri/src/services/auth.rs
+++ b/src-tauri/src/services/auth.rs
@@ -61,6 +61,10 @@ pub struct AuthCompletionResponse {
     pub is_default: bool,
 }
 
+fn unsupported(provider: &str, operation: &str) -> String {
+    format!("Auth provider '{provider}' does not support {operation}")
+}
+
 fn ensure_auth_provider(auth_provider: &str) -> Result<&'static str, String> {
     match auth_provider {
         AUTH_PROVIDER_CODEX_OAUTH => Ok(AUTH_PROVIDER_CODEX_OAUTH),
@@ -89,11 +93,11 @@ impl AuthService {
                     ))
                 })
                 .map_err(|error| error.to_string()),
-            AUTH_PROVIDER_CLAUDE_OAUTH => claude::manager(crate::config::get_app_config_dir())
+            AUTH_PROVIDER_CLAUDE_OAUTH => claude::manager(crate::config::get_claude_config_dir())
                 .start_login(redirect_uri)
                 .await
                 .map(AuthStartResponse::Browser),
-            _ => unreachable!(),
+            _ => unreachable!("validated provider must have a start strategy"),
         }
     }
 
@@ -106,12 +110,12 @@ impl AuthService {
         let auth_provider = ensure_auth_provider(auth_provider)?;
         match auth_provider {
             AUTH_PROVIDER_CLAUDE_OAUTH => {
-                claude::manager(crate::config::get_app_config_dir())
+                claude::manager(crate::config::get_claude_config_dir())
                     .complete_login(callback_url)
                     .await
             }
             AUTH_PROVIDER_CODEX_OAUTH => Err("Auth provider uses device-code polling".into()),
-            _ => unreachable!(),
+            _ => unreachable!("validated provider must have a completion strategy"),
         }
     }
 
@@ -140,7 +144,7 @@ impl AuthService {
                 Err(CodexOAuthError::AuthorizationPending) => Ok(None),
                 Err(error) => Err(error.to_string()),
             },
-            _ => unreachable!(),
+            _ => Err(unsupported(auth_provider, "device-code polling")),
         }
     }
 
@@ -158,7 +162,7 @@ impl AuthService {
                     })
                     .collect())
             }
-            _ => unreachable!(),
+            _ => Err(unsupported(auth_provider, "account listing")),
         }
     }
 
@@ -186,7 +190,7 @@ impl AuthService {
                         .collect(),
                 })
             }
-            _ => unreachable!(),
+            _ => Err(unsupported(auth_provider, "status")),
         }
     }
 
@@ -196,7 +200,7 @@ impl AuthService {
             AUTH_PROVIDER_CODEX_OAUTH => CodexOAuthService::remove_account(account_id)
                 .await
                 .map_err(|error| error.to_string()),
-            _ => unreachable!(),
+            _ => Err(unsupported(auth_provider, "account removal")),
         }
     }
 
@@ -206,7 +210,7 @@ impl AuthService {
             AUTH_PROVIDER_CODEX_OAUTH => CodexOAuthService::set_default_account(account_id)
                 .await
                 .map_err(|error| error.to_string()),
-            _ => unreachable!(),
+            _ => Err(unsupported(auth_provider, "default account selection")),
         }
     }
 
@@ -216,7 +220,7 @@ impl AuthService {
             AUTH_PROVIDER_CODEX_OAUTH => CodexOAuthService::clear_auth()
                 .await
                 .map_err(|error| error.to_string()),
-            _ => unreachable!(),
+            _ => Err(unsupported(auth_provider, "logout")),
         }
     }
 }
@@ -278,5 +282,13 @@ mod tests {
         };
         assert_eq!(response.provider, AUTH_PROVIDER_CLAUDE_OAUTH);
         assert!(response.authorization_url.starts_with("https://claude.ai/"));
+    }
+
+    #[tokio::test]
+    async fn unsupported_claude_account_operations_are_explicit_errors() {
+        let error = AuthService::get_status(AUTH_PROVIDER_CLAUDE_OAUTH)
+            .await
+            .unwrap_err();
+        assert!(error.contains("does not support status"));
     }
 }

--- a/src-tauri/src/services/auth.rs
+++ b/src-tauri/src/services/auth.rs
@@ -1,7 +1,8 @@
 use crate::proxy::providers::codex_oauth_auth::CodexOAuthError;
-use crate::services::CodexOAuthService;
+use crate::services::{claude_oauth, CodexOAuthService};
 
 const AUTH_PROVIDER_CODEX_OAUTH: &str = "codex_oauth";
+const AUTH_PROVIDER_CLAUDE_OAUTH: &str = "claude_oauth";
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct ManagedAuthAccount {
@@ -35,6 +36,7 @@ pub struct ManagedAuthDeviceCodeResponse {
 fn ensure_auth_provider(auth_provider: &str) -> Result<&'static str, String> {
     match auth_provider {
         AUTH_PROVIDER_CODEX_OAUTH => Ok(AUTH_PROVIDER_CODEX_OAUTH),
+        AUTH_PROVIDER_CLAUDE_OAUTH => Ok(AUTH_PROVIDER_CLAUDE_OAUTH),
         _ => Err(format!("Unsupported auth provider: {auth_provider}")),
     }
 }
@@ -71,6 +73,21 @@ fn map_device_code_response(
 pub struct AuthService;
 
 impl AuthService {
+    pub async fn start_claude_login(
+        redirect_uri: Option<&str>,
+    ) -> Result<crate::services::ClaudeOAuthStart, String> {
+        claude_oauth::manager(crate::config::get_app_config_dir())
+            .start_login(redirect_uri)
+            .await
+    }
+
+    pub async fn complete_claude_login(
+        callback_url: &str,
+    ) -> Result<crate::services::ClaudeOAuthAccount, String> {
+        claude_oauth::manager(crate::config::get_app_config_dir())
+            .complete_login(callback_url)
+            .await
+    }
     pub async fn start_login(auth_provider: &str) -> Result<ManagedAuthDeviceCodeResponse, String> {
         let auth_provider = ensure_auth_provider(auth_provider)?;
         match auth_provider {

--- a/src-tauri/src/services/auth.rs
+++ b/src-tauri/src/services/auth.rs
@@ -1,8 +1,11 @@
 use crate::proxy::providers::codex_oauth_auth::CodexOAuthError;
-use crate::services::{claude_oauth, CodexOAuthService};
+use crate::services::CodexOAuthService;
 
-const AUTH_PROVIDER_CODEX_OAUTH: &str = "codex_oauth";
-const AUTH_PROVIDER_CLAUDE_OAUTH: &str = "claude_oauth";
+pub mod claude;
+pub mod codex;
+
+use claude::PROVIDER as AUTH_PROVIDER_CLAUDE_OAUTH;
+use codex::PROVIDER as AUTH_PROVIDER_CODEX_OAUTH;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct ManagedAuthAccount {
@@ -41,42 +44,13 @@ fn ensure_auth_provider(auth_provider: &str) -> Result<&'static str, String> {
     }
 }
 
-fn map_account(
-    provider: &str,
-    account: crate::proxy::providers::codex_oauth_auth::ManagedAuthAccount,
-    default_account_id: Option<&str>,
-) -> ManagedAuthAccount {
-    ManagedAuthAccount {
-        is_default: default_account_id == Some(account.id.as_str()),
-        id: account.id,
-        provider: provider.to_string(),
-        login: account.login,
-        avatar_url: account.avatar_url,
-        authenticated_at: account.authenticated_at,
-    }
-}
-
-fn map_device_code_response(
-    provider: &str,
-    response: crate::proxy::providers::codex_oauth_auth::ManagedAuthDeviceCodeResponse,
-) -> ManagedAuthDeviceCodeResponse {
-    ManagedAuthDeviceCodeResponse {
-        provider: provider.to_string(),
-        device_code: response.device_code,
-        user_code: response.user_code,
-        verification_uri: response.verification_uri,
-        expires_in: response.expires_in,
-        interval: response.interval,
-    }
-}
-
 pub struct AuthService;
 
 impl AuthService {
     pub async fn start_claude_login(
         redirect_uri: Option<&str>,
     ) -> Result<crate::services::ClaudeOAuthStart, String> {
-        claude_oauth::manager(crate::config::get_app_config_dir())
+        claude::manager(crate::config::get_app_config_dir())
             .start_login(redirect_uri)
             .await
     }
@@ -84,7 +58,7 @@ impl AuthService {
     pub async fn complete_claude_login(
         callback_url: &str,
     ) -> Result<crate::services::ClaudeOAuthAccount, String> {
-        claude_oauth::manager(crate::config::get_app_config_dir())
+        claude::manager(crate::config::get_app_config_dir())
             .complete_login(callback_url)
             .await
     }
@@ -93,7 +67,7 @@ impl AuthService {
         match auth_provider {
             AUTH_PROVIDER_CODEX_OAUTH => CodexOAuthService::start_device_flow()
                 .await
-                .map(|response| map_device_code_response(auth_provider, response))
+                .map(|response| codex::map_device_code_response(auth_provider, response))
                 .map_err(|error| error.to_string()),
             _ => unreachable!(),
         }
@@ -111,7 +85,7 @@ impl AuthService {
                     let default_account_id =
                         CodexOAuthService::get_status().await.default_account_id;
                     Ok(account.map(|account| {
-                        map_account(auth_provider, account, default_account_id.as_deref())
+                        codex::map_account(auth_provider, account, default_account_id.as_deref())
                     }))
                 }
                 Err(CodexOAuthError::AuthorizationPending) => Ok(None),
@@ -131,7 +105,7 @@ impl AuthService {
                     .accounts
                     .into_iter()
                     .map(|account| {
-                        map_account(auth_provider, account, default_account_id.as_deref())
+                        codex::map_account(auth_provider, account, default_account_id.as_deref())
                     })
                     .collect())
             }
@@ -154,7 +128,11 @@ impl AuthService {
                         .accounts
                         .into_iter()
                         .map(|account| {
-                            map_account(auth_provider, account, default_account_id.as_deref())
+                            codex::map_account(
+                                auth_provider,
+                                account,
+                                default_account_id.as_deref(),
+                            )
                         })
                         .collect(),
                 })

--- a/src-tauri/src/services/auth.rs
+++ b/src-tauri/src/services/auth.rs
@@ -93,7 +93,7 @@ impl AuthService {
                     ))
                 })
                 .map_err(|error| error.to_string()),
-            AUTH_PROVIDER_CLAUDE_OAUTH => claude::manager(crate::config::get_claude_config_dir())
+            AUTH_PROVIDER_CLAUDE_OAUTH => claude::manager(crate::config::get_app_config_dir())
                 .start_login(redirect_uri)
                 .await
                 .map(AuthStartResponse::Browser),
@@ -110,7 +110,7 @@ impl AuthService {
         let auth_provider = ensure_auth_provider(auth_provider)?;
         match auth_provider {
             AUTH_PROVIDER_CLAUDE_OAUTH => {
-                claude::manager(crate::config::get_claude_config_dir())
+                claude::manager(crate::config::get_app_config_dir())
                     .complete_login(callback_url)
                     .await
             }

--- a/src-tauri/src/services/auth/claude.rs
+++ b/src-tauri/src/services/auth/claude.rs
@@ -193,10 +193,26 @@ impl ClaudeOAuthService {
         if refresh_token.is_empty() {
             return Err("Claude OAuth response missing refresh_token".into());
         }
+        let email = token
+            .get("email")
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned);
+        let organization_id = token
+            .get("organization_id")
+            .or_else(|| token.get("organizationId"))
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned);
+        let stable_id = token
+            .get("account_id")
+            .or_else(|| token.get("user_id"))
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned)
+            .or_else(|| email.clone())
+            .or_else(|| organization_id.clone());
         let account = StoredAccount {
-            id: Uuid::new_v4().to_string(),
-            email: None,
-            organization_id: None,
+            id: stable_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
+            email,
+            organization_id,
             access_token: access_token.to_string(),
             refresh_token: refresh_token.to_string(),
             expires_at: chrono::Utc::now().timestamp()
@@ -210,6 +226,10 @@ impl ClaudeOAuthService {
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("create Claude config dir: {e}"))?;
         }
+        #[cfg(any(not(target_os = "macos"), test))]
+        let lock_path = path.with_extension("credentials.lock");
+        #[cfg(any(not(target_os = "macos"), test))]
+        let _lock = CredentialLock::acquire(&lock_path)?;
         let mut credentials = match std::fs::read(path) {
             Ok(bytes) => serde_json::from_slice::<serde_json::Value>(&bytes)
                 .map_err(|e| format!("invalid existing Claude credentials: {e}"))?,
@@ -236,10 +256,13 @@ impl ClaudeOAuthService {
             "expiresAt".into(),
             serde_json::json!(account.expires_at * 1000),
         );
-        #[cfg(target_os = "macos")]
+        #[cfg(all(target_os = "macos", not(test)))]
         self.write_keychain(&credentials)?;
-        #[cfg(not(target_os = "macos"))]
-        write_secure_json(path, &credentials)?;
+        #[cfg(any(not(target_os = "macos"), test))]
+        let write_result = write_secure_json_unlocked(path, &credentials);
+        #[cfg(any(not(target_os = "macos"), test))]
+        #[cfg(any(not(target_os = "macos"), test))]
+        write_result?;
         Ok(AuthCompletionResponse {
             account_id: account.id,
             provider: "claude_oauth".into(),
@@ -273,13 +296,26 @@ impl ClaudeOAuthService {
     }
 }
 
-fn write_secure_json(path: &PathBuf, value: &serde_json::Value) -> Result<(), String> {
-    let lock = path.with_extension("credentials.lock");
-    let _guard = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&lock)
-        .map_err(|e| format!("Claude credentials busy or unavailable: {e}"))?;
+struct CredentialLock(PathBuf);
+
+impl CredentialLock {
+    fn acquire(path: &PathBuf) -> Result<Self, String> {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .map_err(|e| format!("Claude credentials busy or unavailable: {e}"))?;
+        Ok(Self(path.clone()))
+    }
+}
+
+impl Drop for CredentialLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn write_secure_json_unlocked(path: &PathBuf, value: &serde_json::Value) -> Result<(), String> {
     let result = (|| {
         let bytes = serde_json::to_vec_pretty(value).map_err(|e| e.to_string())?;
         let tmp = path.with_extension("credentials.json.tmp");
@@ -297,7 +333,6 @@ fn write_secure_json(path: &PathBuf, value: &serde_json::Value) -> Result<(), St
         std::fs::rename(&tmp, path).map_err(|e| e.to_string())
     })();
     let _ = std::fs::remove_file(path.with_extension("credentials.json.tmp"));
-    let _ = std::fs::remove_file(lock);
     result
 }
 

--- a/src-tauri/src/services/auth/claude.rs
+++ b/src-tauri/src/services/auth/claude.rs
@@ -42,7 +42,8 @@ struct StoredAccount {
 }
 
 pub struct ClaudeOAuthService {
-    config_dir: PathBuf,
+    credential_path: PathBuf,
+    token_url: String,
     pending: Mutex<Option<PendingLogin>>,
 }
 
@@ -62,8 +63,13 @@ pub(crate) fn manager(config_dir: PathBuf) -> Arc<ClaudeOAuthService> {
 
 impl ClaudeOAuthService {
     pub fn new(config_dir: PathBuf) -> Self {
+        Self::with_token_url(config_dir, TOKEN_URL)
+    }
+
+    fn with_token_url(config_dir: PathBuf, token_url: impl Into<String>) -> Self {
         Self {
-            config_dir,
+            credential_path: config_dir.join(".credentials.json"),
+            token_url: token_url.into(),
             pending: Mutex::new(None),
         }
     }
@@ -73,16 +79,7 @@ impl ClaudeOAuthService {
         redirect_uri: Option<&str>,
     ) -> Result<BrowserAuthStart, String> {
         let redirect_uri = redirect_uri.unwrap_or(DEFAULT_REDIRECT_URI).trim();
-        let parsed_redirect = url::Url::parse(redirect_uri).ok();
-        if redirect_uri.is_empty()
-            || parsed_redirect.as_ref().map(|url| url.scheme()) != Some("http")
-            || parsed_redirect.as_ref().and_then(|url| url.host_str()) != Some("localhost")
-            || parsed_redirect
-                .as_ref()
-                .and_then(|url| url.port())
-                .is_none()
-            || parsed_redirect.as_ref().map(|url| url.path()) != Some("/callback")
-        {
+        if redirect_uri != DEFAULT_REDIRECT_URI {
             return Err("redirect_uri must be a localhost HTTP callback".to_string());
         }
         let verifier = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
@@ -120,10 +117,8 @@ impl ClaudeOAuthService {
     ) -> Result<AuthCompletionResponse, String> {
         let callback =
             url::Url::parse(callback_url).map_err(|e| format!("invalid callback URL: {e}"))?;
-        let pending = self
-            .pending
-            .lock()
-            .await
+        let mut pending_guard = self.pending.lock().await;
+        let pending = pending_guard
             .as_ref()
             .cloned()
             .ok_or("no pending Claude OAuth login")?;
@@ -160,19 +155,16 @@ impl ClaudeOAuthService {
             return Err("Claude OAuth state mismatch".into());
         }
         let code = code.ok_or("Claude OAuth callback did not contain a code")?;
-        // Consume the state only after all callback-local checks pass. This
-        // allows a malformed browser paste to be corrected without issuing a
-        // second authorization request, while still making a valid callback
-        // single-use before token exchange.
-        let pending = self
-            .pending
-            .lock()
-            .await
+        // Consume the exact record while holding the same guard used for all
+        // callback checks. A concurrent start cannot replace A with B between
+        // validation and take, and malformed callbacks remain retryable.
+        let pending = pending_guard
             .take()
             .ok_or("no pending Claude OAuth login")?;
+        drop(pending_guard);
         let body = serde_json::json!({"grant_type":"authorization_code","code":code,"redirect_uri":pending.redirect_uri,"client_id":CLIENT_ID,"code_verifier":pending.verifier,"state":pending.state});
         let response = reqwest::Client::new()
-            .post(TOKEN_URL)
+            .post(&self.token_url)
             .json(&body)
             .send()
             .await
@@ -211,10 +203,30 @@ impl ClaudeOAuthService {
                     .and_then(|v| v.as_i64())
                     .unwrap_or(3600),
         };
-        std::fs::create_dir_all(&self.config_dir).map_err(|e| format!("create auth store: {e}"))?;
-        let bytes = serde_json::to_vec_pretty(&account).map_err(|e| e.to_string())?;
-        crate::config::atomic_write(&self.config_dir.join("claude-oauth.json"), &bytes)
-            .map_err(|e| e.to_string())?;
+        let path = &self.credential_path;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create Claude config dir: {e}"))?;
+        }
+        let mut credentials = match std::fs::read(&path) {
+            Ok(bytes) => serde_json::from_slice::<serde_json::Value>(&bytes)
+                .map_err(|e| format!("invalid existing Claude credentials: {e}"))?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => serde_json::json!({}),
+            Err(error) => return Err(format!("read Claude credentials: {error}")),
+        };
+        credentials["claudeAiOauth"] = serde_json::json!({
+            "accessToken": account.access_token,
+            "refreshToken": account.refresh_token,
+            "expiresAt": account.expires_at * 1000,
+        });
+        let bytes = serde_json::to_vec_pretty(&credentials).map_err(|e| e.to_string())?;
+        crate::config::atomic_write(&path, &bytes).map_err(|e| e.to_string())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                .map_err(|e| format!("protect Claude credentials: {e}"))?;
+        }
         Ok(AuthCompletionResponse {
             account_id: account.id,
             provider: "claude_oauth".into(),
@@ -228,7 +240,25 @@ impl ClaudeOAuthService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{extract::State, routing::post, Json, Router};
     use tempfile::tempdir;
+
+    #[derive(Clone)]
+    struct TokenServerState {
+        request: Arc<Mutex<Option<serde_json::Value>>>,
+    }
+
+    async fn token_handler(
+        State(state): State<TokenServerState>,
+        Json(body): Json<serde_json::Value>,
+    ) -> Json<serde_json::Value> {
+        *state.request.lock().await = Some(body);
+        Json(serde_json::json!({
+            "access_token": "access-secret",
+            "refresh_token": "refresh-secret",
+            "expires_in": 3600
+        }))
+    }
 
     #[tokio::test]
     async fn start_login_builds_pkce_authorization_request() {
@@ -277,5 +307,52 @@ mod tests {
         let error = service.complete_login(&callback).await.unwrap_err();
         assert!(error.contains("authorization failed"));
         assert!(service.pending.lock().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn successful_exchange_writes_claude_native_credentials_without_public_secrets() {
+        let request = Arc::new(Mutex::new(None));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let app = Router::new()
+            .route("/token", post(token_handler))
+            .with_state(TokenServerState {
+                request: Arc::clone(&request),
+            });
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let config = tempdir().unwrap();
+        let service = ClaudeOAuthService::with_token_url(
+            config.path().to_path_buf(),
+            format!("http://{address}/token"),
+        );
+        let start = service.start_login(None).await.unwrap();
+        let callback = format!(
+            "{}?code=authorization-code&state={}",
+            start.redirect_uri, start.state
+        );
+        let public = service.complete_login(&callback).await.unwrap();
+
+        let body = request.lock().await.clone().unwrap();
+        assert_eq!(body["grant_type"], "authorization_code");
+        assert_eq!(body["code"], "authorization-code");
+        assert_eq!(body["redirect_uri"], DEFAULT_REDIRECT_URI);
+        assert_eq!(body["client_id"], CLIENT_ID);
+        assert!(body["code_verifier"].as_str().unwrap().len() >= 43);
+
+        let credentials: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(config.path().join(".credentials.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(credentials["claudeAiOauth"]["accessToken"], "access-secret");
+        assert_eq!(
+            credentials["claudeAiOauth"]["refreshToken"],
+            "refresh-secret"
+        );
+
+        let public_json = serde_json::to_value(public).unwrap().to_string();
+        assert!(!public_json.contains("access-secret"));
+        assert!(!public_json.contains("refresh-secret"));
+        assert!(service.pending.lock().await.is_none());
     }
 }

--- a/src-tauri/src/services/auth/claude.rs
+++ b/src-tauri/src/services/auth/claude.rs
@@ -14,6 +14,8 @@ use std::sync::{Arc, OnceLock, RwLock};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
+const KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
+
 const AUTHORIZE_URL: &str = "https://claude.ai/oauth/authorize";
 const TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
 const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
@@ -208,25 +210,36 @@ impl ClaudeOAuthService {
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("create Claude config dir: {e}"))?;
         }
-        let mut credentials = match std::fs::read(&path) {
+        let mut credentials = match std::fs::read(path) {
             Ok(bytes) => serde_json::from_slice::<serde_json::Value>(&bytes)
                 .map_err(|e| format!("invalid existing Claude credentials: {e}"))?,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => serde_json::json!({}),
             Err(error) => return Err(format!("read Claude credentials: {error}")),
         };
-        credentials["claudeAiOauth"] = serde_json::json!({
-            "accessToken": account.access_token,
-            "refreshToken": account.refresh_token,
-            "expiresAt": account.expires_at * 1000,
-        });
-        let bytes = serde_json::to_vec_pretty(&credentials).map_err(|e| e.to_string())?;
-        crate::config::atomic_write(&path, &bytes).map_err(|e| e.to_string())?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-                .map_err(|e| format!("protect Claude credentials: {e}"))?;
-        }
+        let oauth = credentials
+            .as_object_mut()
+            .ok_or("Claude credentials root must be an object")?
+            .entry("claudeAiOauth")
+            .or_insert_with(|| serde_json::json!({}));
+        let oauth = oauth
+            .as_object_mut()
+            .ok_or("claudeAiOauth must be an object")?;
+        oauth.insert(
+            "accessToken".into(),
+            serde_json::json!(account.access_token),
+        );
+        oauth.insert(
+            "refreshToken".into(),
+            serde_json::json!(account.refresh_token),
+        );
+        oauth.insert(
+            "expiresAt".into(),
+            serde_json::json!(account.expires_at * 1000),
+        );
+        #[cfg(target_os = "macos")]
+        self.write_keychain(&credentials)?;
+        #[cfg(not(target_os = "macos"))]
+        write_secure_json(path, &credentials)?;
         Ok(AuthCompletionResponse {
             account_id: account.id,
             provider: "claude_oauth".into(),
@@ -235,6 +248,57 @@ impl ClaudeOAuthService {
             is_default: true,
         })
     }
+
+    #[cfg(target_os = "macos")]
+    fn write_keychain(&self, credentials: &serde_json::Value) -> Result<(), String> {
+        let payload = serde_json::to_string(credentials).map_err(|e| e.to_string())?;
+        let output = std::process::Command::new("security")
+            .args([
+                "add-generic-password",
+                "-U",
+                "-s",
+                KEYCHAIN_SERVICE,
+                "-a",
+                "cc-switch",
+                "-w",
+                &payload,
+            ])
+            .output()
+            .map_err(|e| format!("write Claude Keychain credential: {e}"))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err("Claude Keychain write failed".into())
+        }
+    }
+}
+
+fn write_secure_json(path: &PathBuf, value: &serde_json::Value) -> Result<(), String> {
+    let lock = path.with_extension("credentials.lock");
+    let _guard = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&lock)
+        .map_err(|e| format!("Claude credentials busy or unavailable: {e}"))?;
+    let result = (|| {
+        let bytes = serde_json::to_vec_pretty(value).map_err(|e| e.to_string())?;
+        let tmp = path.with_extension("credentials.json.tmp");
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        use std::io::Write;
+        let mut file = options.open(&tmp).map_err(|e| e.to_string())?;
+        file.write_all(&bytes).map_err(|e| e.to_string())?;
+        file.sync_all().map_err(|e| e.to_string())?;
+        std::fs::rename(&tmp, path).map_err(|e| e.to_string())
+    })();
+    let _ = std::fs::remove_file(path.with_extension("credentials.json.tmp"));
+    let _ = std::fs::remove_file(lock);
+    result
 }
 
 #[cfg(test)]

--- a/src-tauri/src/services/auth/claude.rs
+++ b/src-tauri/src/services/auth/claude.rs
@@ -5,6 +5,7 @@
 //! `complete_login`; access and refresh tokens are never part of the public
 //! response types.
 
+use super::{AuthCompletionResponse, BrowserAuthStart};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -21,24 +22,6 @@ const SCOPE: &str =
     "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
 
 pub const PROVIDER: &str = "claude_oauth";
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ClaudeOAuthStart {
-    pub provider: String,
-    pub authorization_url: String,
-    pub state: String,
-    pub redirect_uri: String,
-    pub expires_in: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ClaudeOAuthAccount {
-    pub id: String,
-    pub provider: String,
-    pub email: Option<String>,
-    pub organization_id: Option<String>,
-    pub is_default: bool,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PendingLogin {
@@ -88,7 +71,7 @@ impl ClaudeOAuthService {
     pub async fn start_login(
         &self,
         redirect_uri: Option<&str>,
-    ) -> Result<ClaudeOAuthStart, String> {
+    ) -> Result<BrowserAuthStart, String> {
         let redirect_uri = redirect_uri.unwrap_or(DEFAULT_REDIRECT_URI).trim();
         let parsed_redirect = url::Url::parse(redirect_uri).ok();
         if redirect_uri.is_empty()
@@ -120,7 +103,7 @@ impl ClaudeOAuthService {
             redirect_uri: redirect_uri.to_string(),
             expires_at: chrono::Utc::now().timestamp() + 300,
         });
-        Ok(ClaudeOAuthStart {
+        Ok(BrowserAuthStart {
             provider: "claude_oauth".to_string(),
             authorization_url: format!("{AUTHORIZE_URL}?{}", query.finish()),
             state,
@@ -131,7 +114,10 @@ impl ClaudeOAuthService {
 
     /// Validates a callback URL and exchanges its code. Tokens are persisted
     /// below the configured native store and are never returned to callers.
-    pub async fn complete_login(&self, callback_url: &str) -> Result<ClaudeOAuthAccount, String> {
+    pub async fn complete_login(
+        &self,
+        callback_url: &str,
+    ) -> Result<AuthCompletionResponse, String> {
         let callback =
             url::Url::parse(callback_url).map_err(|e| format!("invalid callback URL: {e}"))?;
         let pending = self
@@ -229,10 +215,10 @@ impl ClaudeOAuthService {
         let bytes = serde_json::to_vec_pretty(&account).map_err(|e| e.to_string())?;
         crate::config::atomic_write(&self.config_dir.join("claude-oauth.json"), &bytes)
             .map_err(|e| e.to_string())?;
-        Ok(ClaudeOAuthAccount {
-            id: account.id,
+        Ok(AuthCompletionResponse {
+            account_id: account.id,
             provider: "claude_oauth".into(),
-            email: account.email,
+            login: account.email,
             organization_id: account.organization_id,
             is_default: true,
         })

--- a/src-tauri/src/services/auth/claude.rs
+++ b/src-tauri/src/services/auth/claude.rs
@@ -14,8 +14,6 @@ use std::sync::{Arc, OnceLock, RwLock};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-const KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
-
 const AUTHORIZE_URL: &str = "https://claude.ai/oauth/authorize";
 const TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
 const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
@@ -70,7 +68,7 @@ impl ClaudeOAuthService {
 
     fn with_token_url(config_dir: PathBuf, token_url: impl Into<String>) -> Self {
         Self {
-            credential_path: config_dir.join(".credentials.json"),
+            credential_path: config_dir.join("credentials").join("claude.json"),
             token_url: token_url.into(),
             pending: Mutex::new(None),
         }
@@ -226,9 +224,7 @@ impl ClaudeOAuthService {
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("create Claude config dir: {e}"))?;
         }
-        #[cfg(any(not(target_os = "macos"), test))]
         let lock_path = path.with_extension("credentials.lock");
-        #[cfg(any(not(target_os = "macos"), test))]
         let _lock = CredentialLock::acquire(&lock_path)?;
         let mut credentials = match std::fs::read(path) {
             Ok(bytes) => serde_json::from_slice::<serde_json::Value>(&bytes)
@@ -256,12 +252,7 @@ impl ClaudeOAuthService {
             "expiresAt".into(),
             serde_json::json!(account.expires_at * 1000),
         );
-        #[cfg(all(target_os = "macos", not(test)))]
-        self.write_keychain(&credentials)?;
-        #[cfg(any(not(target_os = "macos"), test))]
         let write_result = write_secure_json_unlocked(path, &credentials);
-        #[cfg(any(not(target_os = "macos"), test))]
-        #[cfg(any(not(target_os = "macos"), test))]
         write_result?;
         Ok(AuthCompletionResponse {
             account_id: account.id,
@@ -270,29 +261,6 @@ impl ClaudeOAuthService {
             organization_id: account.organization_id,
             is_default: true,
         })
-    }
-
-    #[cfg(target_os = "macos")]
-    fn write_keychain(&self, credentials: &serde_json::Value) -> Result<(), String> {
-        let payload = serde_json::to_string(credentials).map_err(|e| e.to_string())?;
-        let output = std::process::Command::new("security")
-            .args([
-                "add-generic-password",
-                "-U",
-                "-s",
-                KEYCHAIN_SERVICE,
-                "-a",
-                "cc-switch",
-                "-w",
-                &payload,
-            ])
-            .output()
-            .map_err(|e| format!("write Claude Keychain credential: {e}"))?;
-        if output.status.success() {
-            Ok(())
-        } else {
-            Err("Claude Keychain write failed".into())
-        }
     }
 }
 
@@ -440,7 +408,7 @@ mod tests {
         assert!(body["code_verifier"].as_str().unwrap().len() >= 43);
 
         let credentials: serde_json::Value = serde_json::from_slice(
-            &std::fs::read(config.path().join(".credentials.json")).unwrap(),
+            &std::fs::read(config.path().join("credentials/claude.json")).unwrap(),
         )
         .unwrap();
         assert_eq!(credentials["claudeAiOauth"]["accessToken"], "access-secret");

--- a/src-tauri/src/services/auth/claude.rs
+++ b/src-tauri/src/services/auth/claude.rs
@@ -20,6 +20,8 @@ const DEFAULT_REDIRECT_URI: &str = "http://localhost:54545/callback";
 const SCOPE: &str =
     "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
 
+pub const PROVIDER: &str = "claude_oauth";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ClaudeOAuthStart {
     pub provider: String,
@@ -63,7 +65,7 @@ pub struct ClaudeOAuthService {
 
 static SERVICE: OnceLock<RwLock<Option<(PathBuf, Arc<ClaudeOAuthService>)>>> = OnceLock::new();
 
-pub fn manager(config_dir: PathBuf) -> Arc<ClaudeOAuthService> {
+pub(crate) fn manager(config_dir: PathBuf) -> Arc<ClaudeOAuthService> {
     let store = SERVICE.get_or_init(|| RwLock::new(None));
     if let Some((path, service)) = store.read().expect("read Claude OAuth service").as_ref() {
         if path == &config_dir {

--- a/src-tauri/src/services/auth/codex.rs
+++ b/src-tauri/src/services/auth/codex.rs
@@ -1,0 +1,35 @@
+use super::{ManagedAuthAccount, ManagedAuthDeviceCodeResponse};
+use crate::proxy::providers::codex_oauth_auth::{
+    ManagedAuthAccount as NativeAccount, ManagedAuthDeviceCodeResponse as NativeDeviceCodeResponse,
+};
+
+pub const PROVIDER: &str = "codex_oauth";
+
+pub fn map_account(
+    provider: &str,
+    account: NativeAccount,
+    default_account_id: Option<&str>,
+) -> ManagedAuthAccount {
+    ManagedAuthAccount {
+        is_default: default_account_id == Some(account.id.as_str()),
+        id: account.id,
+        provider: provider.to_string(),
+        login: account.login,
+        avatar_url: account.avatar_url,
+        authenticated_at: account.authenticated_at,
+    }
+}
+
+pub fn map_device_code_response(
+    provider: &str,
+    response: NativeDeviceCodeResponse,
+) -> ManagedAuthDeviceCodeResponse {
+    ManagedAuthDeviceCodeResponse {
+        provider: provider.to_string(),
+        device_code: response.device_code,
+        user_code: response.user_code,
+        verification_uri: response.verification_uri,
+        expires_in: response.expires_in,
+        interval: response.interval,
+    }
+}

--- a/src-tauri/src/services/claude_oauth.rs
+++ b/src-tauri/src/services/claude_oauth.rs
@@ -1,0 +1,293 @@
+//! Claude Code OAuth authorization-code flow.
+//!
+//! This module deliberately keeps token exchange native-side. Callers receive
+//! an authorization URL and may pass the final callback URL back to
+//! `complete_login`; access and refresh tokens are never part of the public
+//! response types.
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock, RwLock};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+const AUTHORIZE_URL: &str = "https://claude.ai/oauth/authorize";
+const TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
+const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const DEFAULT_REDIRECT_URI: &str = "http://localhost:54545/callback";
+const SCOPE: &str =
+    "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClaudeOAuthStart {
+    pub provider: String,
+    pub authorization_url: String,
+    pub state: String,
+    pub redirect_uri: String,
+    pub expires_in: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClaudeOAuthAccount {
+    pub id: String,
+    pub provider: String,
+    pub email: Option<String>,
+    pub organization_id: Option<String>,
+    pub is_default: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PendingLogin {
+    state: String,
+    verifier: String,
+    redirect_uri: String,
+    expires_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredAccount {
+    id: String,
+    email: Option<String>,
+    organization_id: Option<String>,
+    access_token: String,
+    refresh_token: String,
+    expires_at: i64,
+}
+
+pub struct ClaudeOAuthService {
+    config_dir: PathBuf,
+    pending: Mutex<Option<PendingLogin>>,
+}
+
+static SERVICE: OnceLock<RwLock<Option<(PathBuf, Arc<ClaudeOAuthService>)>>> = OnceLock::new();
+
+pub fn manager(config_dir: PathBuf) -> Arc<ClaudeOAuthService> {
+    let store = SERVICE.get_or_init(|| RwLock::new(None));
+    if let Some((path, service)) = store.read().expect("read Claude OAuth service").as_ref() {
+        if path == &config_dir {
+            return Arc::clone(service);
+        }
+    }
+    let service = Arc::new(ClaudeOAuthService::new(config_dir.clone()));
+    *store.write().expect("write Claude OAuth service") = Some((config_dir, Arc::clone(&service)));
+    service
+}
+
+impl ClaudeOAuthService {
+    pub fn new(config_dir: PathBuf) -> Self {
+        Self {
+            config_dir,
+            pending: Mutex::new(None),
+        }
+    }
+
+    pub async fn start_login(
+        &self,
+        redirect_uri: Option<&str>,
+    ) -> Result<ClaudeOAuthStart, String> {
+        let redirect_uri = redirect_uri.unwrap_or(DEFAULT_REDIRECT_URI).trim();
+        let parsed_redirect = url::Url::parse(redirect_uri).ok();
+        if redirect_uri.is_empty()
+            || parsed_redirect.as_ref().map(|url| url.scheme()) != Some("http")
+            || parsed_redirect.as_ref().and_then(|url| url.host_str()) != Some("localhost")
+            || parsed_redirect
+                .as_ref()
+                .and_then(|url| url.port())
+                .is_none()
+            || parsed_redirect.as_ref().map(|url| url.path()) != Some("/callback")
+        {
+            return Err("redirect_uri must be a localhost HTTP callback".to_string());
+        }
+        let verifier = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+        let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+        let state = Uuid::new_v4().to_string();
+        let mut query = url::form_urlencoded::Serializer::new(String::new());
+        query.append_pair("code", "true");
+        query.append_pair("client_id", CLIENT_ID);
+        query.append_pair("response_type", "code");
+        query.append_pair("redirect_uri", redirect_uri);
+        query.append_pair("scope", SCOPE);
+        query.append_pair("code_challenge", &challenge);
+        query.append_pair("code_challenge_method", "S256");
+        query.append_pair("state", &state);
+        *self.pending.lock().await = Some(PendingLogin {
+            state: state.clone(),
+            verifier,
+            redirect_uri: redirect_uri.to_string(),
+            expires_at: chrono::Utc::now().timestamp() + 300,
+        });
+        Ok(ClaudeOAuthStart {
+            provider: "claude_oauth".to_string(),
+            authorization_url: format!("{AUTHORIZE_URL}?{}", query.finish()),
+            state,
+            redirect_uri: redirect_uri.to_string(),
+            expires_in: 300,
+        })
+    }
+
+    /// Validates a callback URL and exchanges its code. Tokens are persisted
+    /// below the configured native store and are never returned to callers.
+    pub async fn complete_login(&self, callback_url: &str) -> Result<ClaudeOAuthAccount, String> {
+        let callback =
+            url::Url::parse(callback_url).map_err(|e| format!("invalid callback URL: {e}"))?;
+        let pending = self
+            .pending
+            .lock()
+            .await
+            .as_ref()
+            .cloned()
+            .ok_or("no pending Claude OAuth login")?;
+        let expected = url::Url::parse(&pending.redirect_uri)
+            .map_err(|e| format!("invalid pending redirect URI: {e}"))?;
+        if callback.scheme() != expected.scheme()
+            || callback.host_str() != expected.host_str()
+            || callback.port_or_known_default() != expected.port_or_known_default()
+            || callback.path() != expected.path()
+        {
+            return Err(
+                "Claude OAuth callback does not match the pending localhost redirect".into(),
+            );
+        }
+        let error = callback
+            .query_pairs()
+            .find(|(k, _)| k == "error")
+            .map(|(_, v)| v.into_owned());
+        if let Some(error) = error {
+            return Err(format!("Claude OAuth authorization failed: {error}"));
+        }
+        let code = callback
+            .query_pairs()
+            .find(|(k, _)| k == "code")
+            .map(|(_, v)| v.into_owned());
+        let state = callback
+            .query_pairs()
+            .find(|(k, _)| k == "state")
+            .map(|(_, v)| v.into_owned());
+        if pending.expires_at < chrono::Utc::now().timestamp() {
+            return Err("Claude OAuth callback expired".into());
+        }
+        if state.as_deref() != Some(pending.state.as_str()) {
+            return Err("Claude OAuth state mismatch".into());
+        }
+        let code = code.ok_or("Claude OAuth callback did not contain a code")?;
+        // Consume the state only after all callback-local checks pass. This
+        // allows a malformed browser paste to be corrected without issuing a
+        // second authorization request, while still making a valid callback
+        // single-use before token exchange.
+        let pending = self
+            .pending
+            .lock()
+            .await
+            .take()
+            .ok_or("no pending Claude OAuth login")?;
+        let body = serde_json::json!({"grant_type":"authorization_code","code":code,"redirect_uri":pending.redirect_uri,"client_id":CLIENT_ID,"code_verifier":pending.verifier,"state":pending.state});
+        let response = reqwest::Client::new()
+            .post(TOKEN_URL)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("Claude OAuth token exchange failed: {e}"))?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "Claude OAuth token exchange failed with status {}",
+                response.status()
+            ));
+        }
+        let token: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| format!("invalid Claude OAuth token response: {e}"))?;
+        let access_token = token
+            .get("access_token")
+            .and_then(|v| v.as_str())
+            .filter(|v| !v.is_empty())
+            .ok_or("Claude OAuth response missing access_token")?;
+        let refresh_token = token
+            .get("refresh_token")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        if refresh_token.is_empty() {
+            return Err("Claude OAuth response missing refresh_token".into());
+        }
+        let account = StoredAccount {
+            id: Uuid::new_v4().to_string(),
+            email: None,
+            organization_id: None,
+            access_token: access_token.to_string(),
+            refresh_token: refresh_token.to_string(),
+            expires_at: chrono::Utc::now().timestamp()
+                + token
+                    .get("expires_in")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(3600),
+        };
+        std::fs::create_dir_all(&self.config_dir).map_err(|e| format!("create auth store: {e}"))?;
+        let bytes = serde_json::to_vec_pretty(&account).map_err(|e| e.to_string())?;
+        crate::config::atomic_write(&self.config_dir.join("claude-oauth.json"), &bytes)
+            .map_err(|e| e.to_string())?;
+        Ok(ClaudeOAuthAccount {
+            id: account.id,
+            provider: "claude_oauth".into(),
+            email: account.email,
+            organization_id: account.organization_id,
+            is_default: true,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn start_login_builds_pkce_authorization_request() {
+        let service = ClaudeOAuthService::new(tempdir().unwrap().path().to_path_buf());
+        let start = service.start_login(None).await.unwrap();
+        let url = url::Url::parse(&start.authorization_url).unwrap();
+        assert_eq!(url.host_str(), Some("claude.ai"));
+        let query: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+        assert_eq!(query.get("client_id"), Some(&CLIENT_ID.to_string()));
+        assert_eq!(
+            query.get("redirect_uri"),
+            Some(&DEFAULT_REDIRECT_URI.to_string())
+        );
+        assert_eq!(
+            query.get("code_challenge_method"),
+            Some(&"S256".to_string())
+        );
+        assert_eq!(query.get("state"), Some(&start.state));
+        assert!(!query
+            .get("code_challenge")
+            .unwrap_or(&String::new())
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn callback_rejects_wrong_origin_and_preserves_pending_state() {
+        let service = ClaudeOAuthService::new(tempdir().unwrap().path().to_path_buf());
+        let start = service.start_login(None).await.unwrap();
+        let bad = format!(
+            "http://localhost:54546/callback?code=x&state={}",
+            start.state
+        );
+        let error = service.complete_login(&bad).await.unwrap_err();
+        assert!(error.contains("does not match"));
+        assert!(service.pending.lock().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn callback_rejects_provider_error_without_exchange() {
+        let service = ClaudeOAuthService::new(tempdir().unwrap().path().to_path_buf());
+        let start = service.start_login(None).await.unwrap();
+        let callback = format!(
+            "{}?error=access_denied&state={}",
+            start.redirect_uri, start.state
+        );
+        let error = service.complete_login(&callback).await.unwrap_err();
+        assert!(error.contains("authorization failed"));
+        assert!(service.pending.lock().await.is_some());
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,6 +1,5 @@
 pub mod auth;
 pub mod balance;
-pub mod claude_oauth;
 pub mod codex_history;
 pub mod codex_oauth;
 pub mod codex_oauth_models;
@@ -40,8 +39,8 @@ pub mod visible_apps;
 pub mod webdav;
 pub mod webdav_sync;
 
+pub use auth::claude::{ClaudeOAuthAccount, ClaudeOAuthStart};
 pub use auth::{AuthService, ManagedAuthAccount, ManagedAuthDeviceCodeResponse, ManagedAuthStatus};
-pub use claude_oauth::{ClaudeOAuthAccount, ClaudeOAuthStart};
 pub use codex_oauth::CodexOAuthService;
 pub use config::ConfigService;
 pub use copilot_auth::CopilotAuthService;

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod balance;
+pub mod claude_oauth;
 pub mod codex_history;
 pub mod codex_oauth;
 pub mod codex_oauth_models;
@@ -40,6 +41,7 @@ pub mod webdav;
 pub mod webdav_sync;
 
 pub use auth::{AuthService, ManagedAuthAccount, ManagedAuthDeviceCodeResponse, ManagedAuthStatus};
+pub use claude_oauth::{ClaudeOAuthAccount, ClaudeOAuthStart};
 pub use codex_oauth::CodexOAuthService;
 pub use config::ConfigService;
 pub use copilot_auth::CopilotAuthService;

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -39,8 +39,11 @@ pub mod visible_apps;
 pub mod webdav;
 pub mod webdav_sync;
 
-pub use auth::claude::{ClaudeOAuthAccount, ClaudeOAuthStart};
-pub use auth::{AuthService, ManagedAuthAccount, ManagedAuthDeviceCodeResponse, ManagedAuthStatus};
+#[allow(unused_imports)]
+pub use auth::{
+    AuthCompletionResponse, AuthService, AuthStartResponse, BrowserAuthStart, ManagedAuthAccount,
+    ManagedAuthDeviceCodeResponse, ManagedAuthStatus,
+};
 pub use codex_oauth::CodexOAuthService;
 pub use config::ConfigService;
 pub use copilot_auth::CopilotAuthService;


### PR DESCRIPTION
## Summary

Draft protocol/core implementation for Claude authorization-code OAuth in the botiverse fork.

- Claude provider adapter under `services/auth/claude.rs`
- provider-neutral `AuthService::start/complete` strategy dispatch
- PKCE S256, state binding, fixed localhost callback validation
- typed browser/device auth responses and explicit unsupported capabilities
- injectable token endpoint and fake-friendly tests
- app-owned credential contract: `~/.cc-switch/credentials/claude.json`

## Deliberate scope

This PR does **not** integrate Claude Code's macOS Keychain or
`~/.claude/.credentials.json`. It logs a Claude account into cc-switch's own
store only. A future, explicit opt-in integration may synchronize into Claude
Code after a separate platform-storage review.

The production store adapter is intentionally kept separate from this protocol
PR. Follow-up work must define secure file CAS/replace/crash recovery across
macOS/Linux/Windows before enabling production credential persistence. The
current protocol tests use an injected isolated fake/file store and never touch
real Keychain or Claude Code credentials.

Draft only: do not merge, vendor, or release.
