### PR TITLE
fix(tui): replace provider template chip row with a template field and grouped picker

### DIFF
--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -3188,6 +3188,41 @@ pub mod texts {
         }
     }
 
+    /// Singular label for the provider form's Template field row, which holds
+    /// one selection. The plural `tui_form_templates_title` still titles the
+    /// MCP chips box, which shows the whole list at once.
+    pub fn tui_label_provider_template() -> &'static str {
+        if is_chinese() {
+            "模板"
+        } else {
+            "Template"
+        }
+    }
+
+    pub fn tui_provider_template_picker_title() -> &'static str {
+        if is_chinese() {
+            "供应商模板"
+        } else {
+            "Provider templates"
+        }
+    }
+
+    pub fn tui_provider_template_section_builtin() -> &'static str {
+        if is_chinese() {
+            "内置"
+        } else {
+            "Built-in"
+        }
+    }
+
+    pub fn tui_provider_template_section_sponsors() -> &'static str {
+        if is_chinese() {
+            "赞助商"
+        } else {
+            "Sponsors"
+        }
+    }
+
     pub fn tui_form_common_config_button() -> &'static str {
         if is_chinese() {
             "通用配置"

--- a/src-tauri/src/cli/tui/app/form_handlers/mod.rs
+++ b/src-tauri/src/cli/tui/app/form_handlers/mod.rs
@@ -38,10 +38,6 @@ impl App {
             return Action::None;
         }
 
-        if let Some(action) = self.handle_provider_template_key(key, data) {
-            return action;
-        }
-
         if let Some(action) = self.handle_mcp_template_key(key) {
             return action;
         }

--- a/src-tauri/src/cli/tui/app/form_handlers/provider.rs
+++ b/src-tauri/src/cli/tui/app/form_handlers/provider.rs
@@ -9,48 +9,6 @@ enum ProviderValidationTarget {
 }
 
 impl App {
-    pub(super) fn handle_provider_template_key(
-        &mut self,
-        key: KeyEvent,
-        data: &UiData,
-    ) -> Option<Action> {
-        let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
-            return None;
-        };
-
-        if !matches!(provider.page, form::ProviderFormPage::Main) {
-            return None;
-        }
-
-        if provider.focus != FormFocus::Templates || !matches!(provider.mode, FormMode::Add) {
-            return None;
-        }
-
-        match key.code {
-            KeyCode::Left => {
-                provider.template_idx = provider.template_idx.saturating_sub(1);
-                Some(Action::None)
-            }
-            KeyCode::Right => {
-                let max = provider.template_count().saturating_sub(1);
-                provider.template_idx = (provider.template_idx + 1).min(max);
-                Some(Action::None)
-            }
-            KeyCode::Enter => {
-                let existing_ids = data.existing_provider_ids();
-                provider.apply_template(provider.template_idx, &existing_ids);
-                let refresh_result =
-                    provider.refresh_quick_config_from_common_snippet(&data.config.common_snippet);
-                provider.focus = FormFocus::Fields;
-                if let Err(err) = refresh_result {
-                    self.push_toast(err, ToastKind::Warning);
-                }
-                Some(Action::None)
-            }
-            _ => None,
-        }
-    }
-
     pub(super) fn handle_provider_focus_key(
         &mut self,
         key: KeyEvent,
@@ -374,6 +332,23 @@ impl App {
         data: &UiData,
     ) -> Action {
         match selected {
+            // Enter only: Space and the arrow keys keep their field-level
+            // meanings while the Fields pane has focus.
+            ProviderAddField::Template => {
+                if !matches!(key.code, KeyCode::Enter) {
+                    return Action::None;
+                }
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_ref() else {
+                    return Action::None;
+                };
+                if !matches!(provider.mode, FormMode::Add) {
+                    return Action::None;
+                }
+                self.overlay = Overlay::ProviderTemplatePicker {
+                    selected: provider.template_idx,
+                };
+                Action::None
+            }
             ProviderAddField::ClaudeApiFormat => {
                 if !matches!(key.code, KeyCode::Enter) {
                     return Action::None;
@@ -1986,7 +1961,8 @@ fn is_provider_divider_field(field: Option<&ProviderAddField>) -> bool {
     matches!(
         field,
         Some(
-            ProviderAddField::ClaudeAdvancedDivider
+            ProviderAddField::TemplateDivider
+                | ProviderAddField::ClaudeAdvancedDivider
                 | ProviderAddField::CodexAdvancedDivider
                 | ProviderAddField::HermesAdvancedDivider
                 | ProviderAddField::CommonConfigDivider

--- a/src-tauri/src/cli/tui/app/form_handlers/tab.rs
+++ b/src-tauri/src/cli/tui/app/form_handlers/tab.rs
@@ -86,7 +86,10 @@ impl App {
                         provider.focus,
                         provider.codex_preview_section,
                     ) {
-                        (FormMode::Add, FormFocus::Templates, _) => {
+                        // The template is a field row now, so the provider form
+                        // never rests on `Templates`; the arm only exists to
+                        // recover if some other path sets it.
+                        (_, FormFocus::Templates, _) => {
                             provider.focus = FormFocus::Fields;
                         }
                         (FormMode::Add, FormFocus::Fields, _) => {
@@ -106,7 +109,7 @@ impl App {
                             FormFocus::JsonPreview,
                             form::CodexPreviewSection::Config,
                         ) => {
-                            provider.focus = FormFocus::Templates;
+                            provider.focus = FormFocus::Fields;
                         }
                         (FormMode::Edit { .. }, FormFocus::Fields, _) => {
                             provider.focus = FormFocus::JsonPreview;
@@ -127,23 +130,17 @@ impl App {
                         ) => {
                             provider.focus = FormFocus::Fields;
                         }
-                        (FormMode::Edit { .. }, FormFocus::Templates, _) => {
-                            provider.focus = FormFocus::Fields;
-                        }
                         (_, FormFocus::Content, _) => {
                             provider.focus = FormFocus::Fields;
                         }
                     }
                 } else {
-                    provider.focus = match (&provider.mode, provider.focus) {
-                        (FormMode::Add, FormFocus::Templates) => FormFocus::Fields,
-                        (FormMode::Add, FormFocus::Fields) => FormFocus::JsonPreview,
-                        (FormMode::Add, FormFocus::JsonPreview) => FormFocus::Templates,
-                        (FormMode::Add, FormFocus::Content) => FormFocus::Fields,
-                        (FormMode::Edit { .. }, FormFocus::Fields) => FormFocus::JsonPreview,
-                        (FormMode::Edit { .. }, FormFocus::JsonPreview) => FormFocus::Fields,
-                        (FormMode::Edit { .. }, FormFocus::Templates) => FormFocus::Fields,
-                        (FormMode::Edit { .. }, FormFocus::Content) => FormFocus::Fields,
+                    // Add and Edit now share the same two-stop cycle: the
+                    // template lives in the field table, not its own pane.
+                    provider.focus = match provider.focus {
+                        FormFocus::Fields => FormFocus::JsonPreview,
+                        FormFocus::JsonPreview => FormFocus::Fields,
+                        FormFocus::Templates | FormFocus::Content => FormFocus::Fields,
                     };
                 }
             }

--- a/src-tauri/src/cli/tui/app/overlay_handlers/pickers.rs
+++ b/src-tauri/src/cli/tui/app/overlay_handlers/pickers.rs
@@ -97,6 +97,9 @@ impl App {
         if let Some(action) = self.handle_usage_query_template_picker_key(key) {
             return Some(action);
         }
+        if let Some(action) = self.handle_provider_template_picker_key(key, data) {
+            return Some(action);
+        }
         if let Some(action) = self.handle_s3_preset_picker_key(key) {
             return Some(action);
         }
@@ -390,6 +393,74 @@ impl App {
                 provider.set_usage_query_template(template);
                 provider.touch_usage_query();
                 self.overlay = Overlay::None;
+                Action::None
+            }
+            _ => Action::None,
+        })
+    }
+
+    fn handle_provider_template_picker_key(
+        &mut self,
+        key: KeyEvent,
+        data: &UiData,
+    ) -> Option<Action> {
+        let Overlay::ProviderTemplatePicker { selected } = &mut self.overlay else {
+            return None;
+        };
+        let requested = *selected;
+
+        let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() else {
+            self.overlay = Overlay::None;
+            return Some(Action::None);
+        };
+
+        let rows = provider.template_picker_rows();
+        // A stale selection (e.g. an index that no longer maps to a template)
+        // falls back to the first selectable row instead of applying nothing.
+        let current = match form::provider_template_row_for_flat_idx(&rows, requested) {
+            Some(_) => requested,
+            None => match form::provider_template_first_flat_idx(&rows) {
+                Some(first) => {
+                    *selected = first;
+                    first
+                }
+                None => {
+                    self.overlay = Overlay::None;
+                    return Some(Action::None);
+                }
+            },
+        };
+
+        Some(match key.code {
+            KeyCode::Esc => {
+                self.overlay = Overlay::None;
+                Action::None
+            }
+            KeyCode::Up => {
+                if let Some(next) = form::provider_template_step_flat_idx(&rows, current, false) {
+                    *selected = next;
+                }
+                Action::None
+            }
+            KeyCode::Down => {
+                if let Some(next) = form::provider_template_step_flat_idx(&rows, current, true) {
+                    *selected = next;
+                }
+                Action::None
+            }
+            KeyCode::Enter => {
+                let existing_ids = data.existing_provider_ids();
+                provider.apply_template(current, &existing_ids);
+                let refresh_result =
+                    provider.refresh_quick_config_from_common_snippet(&data.config.common_snippet);
+                // Land on the first real field so the user can start typing;
+                // the template row itself stays one Up away.
+                provider.focus = FormFocus::Fields;
+                provider.field_idx = provider.first_field_after_template();
+                self.overlay = Overlay::None;
+                if let Err(err) = refresh_result {
+                    self.push_toast(err, ToastKind::Warning);
+                }
                 Action::None
             }
             _ => Action::None,

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -215,10 +215,18 @@ mod tests {
         }
     }
 
+    /// Applies the provider Add form's current template and leaves focus on
+    /// the fields. The template row is collapsed into a picker overlay, so
+    /// this takes two Enters: one to open the picker, one to apply.
+    fn apply_current_provider_template(app: &mut App, data: &UiData) {
+        app.on_key(key(KeyCode::Enter), data);
+        app.on_key(key(KeyCode::Enter), data);
+    }
+
     fn open_provider_fields_form(app_type: AppType) -> App {
         let mut app = App::new(Some(app_type));
         app.open_provider_add_form(&UiData::default());
-        app.on_key(key(KeyCode::Enter), &data());
+        apply_current_provider_template(&mut app, &data());
         app
     }
 
@@ -1642,7 +1650,7 @@ mod tests {
         app.route = Route::Providers;
         app.focus = Focus::Content;
         app.on_key(key(KeyCode::Char('a')), &data());
-        app.on_key(key(KeyCode::Enter), &data());
+        apply_current_provider_template(&mut app, &data());
 
         let name_idx = match app.form.as_ref() {
             Some(FormState::ProviderAdd(form)) => form
@@ -1944,7 +1952,7 @@ mod tests {
         app.route = Route::Providers;
         app.focus = Focus::Content;
         app.on_key(key(KeyCode::Char('a')), &data());
-        app.on_key(key(KeyCode::Enter), &data());
+        apply_current_provider_template(&mut app, &data());
 
         if let Some(FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.name.set("Provider One");
@@ -4772,7 +4780,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
 
         app.on_key(key(KeyCode::Tab), &data); // fields -> auth preview
         let (focus, section) = match app.form.as_ref() {
@@ -4790,12 +4798,16 @@ mod tests {
         assert_eq!(focus, super::super::form::FormFocus::JsonPreview);
         assert_eq!(section, super::super::form::CodexPreviewSection::Config);
 
-        app.on_key(key(KeyCode::Tab), &data); // config preview -> templates
+        app.on_key(key(KeyCode::Tab), &data); // config preview -> fields
         let focus = match app.form.as_ref() {
             Some(FormState::ProviderAdd(form)) => form.focus,
             other => panic!("expected ProviderAdd form, got: {other:?}"),
         };
-        assert_eq!(focus, super::super::form::FormFocus::Templates);
+        assert_eq!(
+            focus,
+            super::super::form::FormFocus::Fields,
+            "the template is a field row now, so there is no Templates stop"
+        );
     }
 
     #[test]
@@ -4806,8 +4818,9 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
         app.on_key(key(KeyCode::Tab), &data); // fields -> auth preview
+        assert!(matches!(app.overlay, Overlay::None));
 
         app.on_key(key(KeyCode::Right), &data);
         let section = match app.form.as_ref() {
@@ -4832,7 +4845,7 @@ mod tests {
 
         let data = data();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
         select_provider_common_snippet_row(&mut app);
 
         let action = app.on_key(key(KeyCode::Enter), &data);
@@ -4857,7 +4870,7 @@ mod tests {
 
         let data = data();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
         select_provider_common_snippet_row(&mut app);
         app.on_key(key(KeyCode::Enter), &data);
 
@@ -4910,7 +4923,7 @@ mod tests {
 
         let data = data();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
         select_provider_common_snippet_row(&mut app);
 
         let action = app.on_key(key(KeyCode::Enter), &data);
@@ -4935,7 +4948,7 @@ mod tests {
 
         let data = data();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
         select_provider_common_snippet_row(&mut app);
 
         let action = app.on_key(key(KeyCode::Enter), &data);
@@ -5171,7 +5184,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
         app.on_key(key(KeyCode::Tab), &data); // fields -> preview
 
         let action = app.on_key(key(KeyCode::Enter), &data);
@@ -5190,7 +5203,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
 
         if let Some(FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -5223,7 +5236,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
 
         if let Some(FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -5311,7 +5324,7 @@ mod tests {
         let mut data = UiData::default();
         data.config.common_snippet = "[features]\ngoals = true\n".to_string();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
         app.on_key(key(KeyCode::Tab), &data); // fields -> preview
         app.on_key(key(KeyCode::Tab), &data); // auth -> config
 
@@ -5339,7 +5352,7 @@ mod tests {
         data.config.common_snippet = "disable_response_storage = true".to_string();
 
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
         app.on_key(key(KeyCode::Tab), &data); // fields -> preview
 
         let action = app.on_key(key(KeyCode::Char('c')), &data);
@@ -5356,7 +5369,8 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Right), &data); // select OpenAI Official
+        app.on_key(key(KeyCode::Enter), &data); // Template field -> picker
+        app.on_key(key(KeyCode::Down), &data); // select OpenAI Official
         app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
         app.on_key(key(KeyCode::Tab), &data); // fields -> preview
 
@@ -12537,59 +12551,547 @@ mod tests {
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
 
-        let focus = match app.form.as_ref() {
-            Some(super::super::form::FormState::ProviderAdd(form)) => form.focus,
-            other => panic!("expected ProviderAdd form, got: {other:?}"),
-        };
-        assert_eq!(focus, super::super::form::FormFocus::Templates);
+        // The form opens on the Fields pane with the Template row selected.
+        assert_eq!(provider_form_focus(&app), FormFocus::Fields);
+        assert_eq!(
+            provider_selected_field(&app),
+            Some(ProviderAddField::Template)
+        );
 
         app.on_key(key(KeyCode::Tab), &data);
-        let focus = match app.form.as_ref() {
+        assert_eq!(provider_form_focus(&app), FormFocus::JsonPreview);
+
+        // Add mode no longer has a Templates stop: preview cycles back to fields.
+        app.on_key(key(KeyCode::Tab), &data);
+        assert_eq!(provider_form_focus(&app), FormFocus::Fields);
+    }
+
+    fn provider_form_template_idx(app: &App) -> usize {
+        match app.form.as_ref() {
+            Some(super::super::form::FormState::ProviderAdd(form)) => form.template_idx,
+            other => panic!("expected ProviderAdd form, got: {other:?}"),
+        }
+    }
+
+    fn provider_form_focus(app: &App) -> FormFocus {
+        match app.form.as_ref() {
             Some(super::super::form::FormState::ProviderAdd(form)) => form.focus,
             other => panic!("expected ProviderAdd form, got: {other:?}"),
-        };
-        assert_eq!(focus, super::super::form::FormFocus::Fields);
+        }
     }
 
+    fn provider_selected_field(app: &App) -> Option<ProviderAddField> {
+        match app.form.as_ref() {
+            Some(super::super::form::FormState::ProviderAdd(form)) => {
+                form.fields().get(form.field_idx).copied()
+            }
+            other => panic!("expected ProviderAdd form, got: {other:?}"),
+        }
+    }
+
+    fn provider_template_picker_selection(app: &App) -> usize {
+        match app.overlay {
+            Overlay::ProviderTemplatePicker { selected } => selected,
+            ref other => panic!("expected ProviderTemplatePicker overlay, got: {other:?}"),
+        }
+    }
+
+    /// Flat index of the first sponsor preset. Labels no longer carry the
+    /// `"* "` chip marker, so sponsors are identified by their picker section.
+    fn first_sponsor_flat_idx(rows: &[super::super::form::ProviderTemplateRow]) -> Option<usize> {
+        rows.iter().find_map(|row| match row {
+            super::super::form::ProviderTemplateRow::Item {
+                flat_idx,
+                section: super::super::form::ProviderTemplateSection::Sponsors,
+                ..
+            } => Some(*flat_idx),
+            _ => None,
+        })
+    }
+
+    /// Enter on the Template field row opens the picker preseeded with the
+    /// current template, without applying anything yet.
     #[test]
-    fn provider_add_form_right_moves_template_selection() {
+    fn provider_add_form_template_field_enter_opens_picker_without_applying() {
         let mut app = App::new(Some(AppType::Claude));
         app.route = Route::Providers;
         app.focus = Focus::Content;
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
+        assert_eq!(provider_form_focus(&app), FormFocus::Fields);
+        assert_eq!(
+            provider_selected_field(&app),
+            Some(ProviderAddField::Template)
+        );
 
-        let idx = match app.form.as_ref() {
-            Some(super::super::form::FormState::ProviderAdd(form)) => form.template_idx,
-            other => panic!("expected ProviderAdd form, got: {other:?}"),
-        };
-        assert_eq!(idx, 0);
+        if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
+            form.template_idx = 2;
+        }
 
-        app.on_key(key(KeyCode::Right), &data);
-        let idx = match app.form.as_ref() {
-            Some(super::super::form::FormState::ProviderAdd(form)) => form.template_idx,
-            other => panic!("expected ProviderAdd form, got: {other:?}"),
-        };
-        assert_eq!(idx, 1);
-    }
-
-    #[test]
-    fn provider_add_form_enter_applies_template_and_focuses_fields() {
-        let mut app = App::new(Some(AppType::Claude));
-        app.route = Route::Providers;
-        app.focus = Focus::Content;
-
-        let data = UiData::default();
-        app.on_key(key(KeyCode::Char('a')), &data);
         let action = app.on_key(key(KeyCode::Enter), &data);
         assert!(matches!(action, Action::None));
         assert!(app.editor.is_none());
-        let focus = match app.form.as_ref() {
-            Some(super::super::form::FormState::ProviderAdd(form)) => form.focus,
-            other => panic!("expected ProviderAdd form, got: {other:?}"),
+        assert_eq!(provider_template_picker_selection(&app), 2);
+        // Opening the picker must not apply anything yet.
+        assert_eq!(provider_form_template_idx(&app), 2);
+        assert_eq!(provider_form_focus(&app), FormFocus::Fields);
+    }
+
+    /// Space and the arrows keep their field-level meanings in the Fields
+    /// pane, so only Enter may open the picker.
+    #[test]
+    fn provider_add_form_template_field_ignores_space_and_arrows() {
+        for inert_key in [KeyCode::Char(' '), KeyCode::Left, KeyCode::Right] {
+            let mut app = App::new(Some(AppType::Claude));
+            app.route = Route::Providers;
+            app.focus = Focus::Content;
+
+            let data = UiData::default();
+            app.on_key(key(KeyCode::Char('a')), &data);
+            app.on_key(key(inert_key), &data);
+
+            assert!(
+                matches!(app.overlay, Overlay::None),
+                "{inert_key:?} must not open the template picker"
+            );
+            assert_eq!(provider_form_template_idx(&app), 0);
+        }
+    }
+
+    #[test]
+    fn provider_template_picker_down_skips_section_headers() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.form = Some(FormState::ProviderAdd(ProviderAddFormState::new(
+            AppType::Claude,
+        )));
+
+        let rows = match app.form.as_ref() {
+            Some(FormState::ProviderAdd(form)) => form.template_picker_rows(),
+            _ => panic!("expected provider form"),
         };
-        assert_eq!(focus, super::super::form::FormFocus::Fields);
+        let builtin_count = rows
+            .iter()
+            .filter(|row| {
+                matches!(
+                    row,
+                    super::super::form::ProviderTemplateRow::Item {
+                        section: super::super::form::ProviderTemplateSection::BuiltIn,
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert!(builtin_count >= 3, "{rows:?}");
+        assert!(rows.iter().any(|row| matches!(
+            row,
+            super::super::form::ProviderTemplateRow::Header(
+                super::super::form::ProviderTemplateSection::Sponsors
+            )
+        )));
+
+        // Walk from the last built-in row into the sponsor section: the
+        // Sponsors header sits between them and must never be selected.
+        app.overlay = Overlay::ProviderTemplatePicker {
+            selected: builtin_count - 1,
+        };
+        let data = UiData::default();
+        app.on_key(key(KeyCode::Down), &data);
+        let after_down = provider_template_picker_selection(&app);
+        assert_eq!(
+            after_down, builtin_count,
+            "Down must land on the first sponsor, not the header"
+        );
+
+        app.on_key(key(KeyCode::Up), &data);
+        assert_eq!(
+            provider_template_picker_selection(&app),
+            builtin_count - 1,
+            "Up must skip back over the header"
+        );
+
+        // Up at the very first row keeps the selection.
+        app.overlay = Overlay::ProviderTemplatePicker { selected: 0 };
+        app.on_key(key(KeyCode::Up), &data);
+        assert_eq!(provider_template_picker_selection(&app), 0);
+
+        // Down at the very last selectable row keeps the selection.
+        let last_flat = rows
+            .iter()
+            .rev()
+            .find_map(super::super::form::ProviderTemplateRow::flat_idx)
+            .expect("at least one selectable row");
+        app.overlay = Overlay::ProviderTemplatePicker {
+            selected: last_flat,
+        };
+        app.on_key(key(KeyCode::Down), &data);
+        assert_eq!(
+            provider_template_picker_selection(&app),
+            last_flat,
+            "Down at the last row must not move or wrap"
+        );
+    }
+
+    /// Codex's display order diverges from its flat order: DeepSeek has the
+    /// LAST flat index but renders as the last Built-in row, directly above
+    /// the Sponsors header. Navigation must follow display order, so a naive
+    /// flat-index ±1 stepping implementation cannot pass this.
+    #[test]
+    fn provider_template_picker_navigates_codex_in_display_order() {
+        let mut app = App::new(Some(AppType::Codex));
+        let form = ProviderAddFormState::new(AppType::Codex);
+        let rows = form.template_picker_rows();
+        let labels = form.template_labels();
+
+        let deepseek_flat = labels
+            .iter()
+            .position(|label| *label == "DeepSeek")
+            .expect("codex exposes DeepSeek");
+        let first_sponsor_flat =
+            first_sponsor_flat_idx(&rows).expect("codex exposes sponsor presets");
+
+        // Precondition: flat order and display order really do disagree here.
+        assert_eq!(
+            deepseek_flat,
+            labels.len() - 1,
+            "DeepSeek should hold the last flat index"
+        );
+        assert!(
+            first_sponsor_flat < deepseek_flat,
+            "sponsors precede DeepSeek in flat order"
+        );
+
+        app.form = Some(FormState::ProviderAdd(form));
+        let data = UiData::default();
+
+        // Down from the last Built-in row crosses the Sponsors header.
+        app.overlay = Overlay::ProviderTemplatePicker {
+            selected: deepseek_flat,
+        };
+        app.on_key(key(KeyCode::Down), &data);
+        assert_eq!(
+            provider_template_picker_selection(&app),
+            first_sponsor_flat,
+            "Down from DeepSeek must reach the first sponsor, not flat+1"
+        );
+
+        // And Up returns to DeepSeek rather than stepping to flat-1.
+        app.on_key(key(KeyCode::Up), &data);
+        assert_eq!(
+            provider_template_picker_selection(&app),
+            deepseek_flat,
+            "Up from the first sponsor must return to DeepSeek, not flat-1"
+        );
+
+        // DeepSeek is the last display row, so Down past it is a no-op only
+        // after the sponsors are exhausted, never a wrap to flat order.
+        app.overlay = Overlay::ProviderTemplatePicker { selected: 0 };
+        app.on_key(key(KeyCode::Down), &data);
+        assert_eq!(
+            provider_template_picker_selection(&app),
+            1,
+            "Custom -> OpenAI Official stays within the Built-in group"
+        );
+    }
+
+    /// Codex's DeepSeek is stored after the sponsor presets in the flat index
+    /// space but belongs to the Built-in group in the picker.
+    #[test]
+    fn provider_template_picker_groups_after_sponsor_defs_with_builtins() {
+        let form = ProviderAddFormState::new(AppType::Codex);
+        let rows = form.template_picker_rows();
+        let labels = form.template_labels();
+
+        let deepseek_flat = labels
+            .iter()
+            .position(|label| *label == "DeepSeek")
+            .expect("codex should expose a DeepSeek template");
+        let sponsor_flat = first_sponsor_flat_idx(&rows).expect("codex should expose sponsors");
+        assert!(
+            deepseek_flat > sponsor_flat,
+            "DeepSeek is expected to sit after sponsors in the flat order"
+        );
+
+        let deepseek_row = rows
+            .iter()
+            .find(|row| row.flat_idx() == Some(deepseek_flat))
+            .expect("DeepSeek row");
+        assert!(matches!(
+            deepseek_row,
+            super::super::form::ProviderTemplateRow::Item {
+                section: super::super::form::ProviderTemplateSection::BuiltIn,
+                label: "DeepSeek",
+                ..
+            }
+        ));
+
+        let deepseek_display = rows
+            .iter()
+            .position(|row| row.flat_idx() == Some(deepseek_flat))
+            .expect("DeepSeek display row");
+        let sponsors_header = rows
+            .iter()
+            .position(|row| {
+                matches!(
+                    row,
+                    super::super::form::ProviderTemplateRow::Header(
+                        super::super::form::ProviderTemplateSection::Sponsors
+                    )
+                )
+            })
+            .expect("sponsors header");
+        assert!(
+            deepseek_display < sponsors_header,
+            "DeepSeek must render above the Sponsors header"
+        );
+
+        // Sponsor rows drop the flat-row "* " marker.
+        assert!(rows.iter().all(|row| !matches!(
+            row,
+            super::super::form::ProviderTemplateRow::Item { label, .. } if label.starts_with("* ")
+        )));
+    }
+
+    #[test]
+    fn provider_template_picker_enter_applies_and_focuses_fields() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+
+        let data = UiData::default();
+        app.on_key(key(KeyCode::Char('a')), &data);
+        app.on_key(key(KeyCode::Enter), &data);
+        assert_eq!(provider_template_picker_selection(&app), 0);
+
+        // Move onto "Claude Official" and apply it.
+        app.on_key(key(KeyCode::Down), &data);
+        assert_eq!(provider_template_picker_selection(&app), 1);
+
+        let action = app.on_key(key(KeyCode::Enter), &data);
+        assert!(matches!(action, Action::None));
+        assert!(matches!(app.overlay, Overlay::None));
+        assert_eq!(provider_form_focus(&app), FormFocus::Fields);
+        assert_eq!(provider_form_template_idx(&app), 1);
+        // Applying advances past the template group so the user can type.
+        assert_eq!(
+            provider_selected_field(&app),
+            Some(ProviderAddField::Name),
+            "picker apply should land on the first real field"
+        );
+
+        let Some(FormState::ProviderAdd(form)) = app.form.as_ref() else {
+            panic!("expected provider form");
+        };
+        assert_eq!(form.name.value, "Claude Official");
+    }
+
+    #[test]
+    fn provider_template_picker_enter_applies_sponsor_by_flat_index() {
+        let mut app = App::new(Some(AppType::Claude));
+        let form = ProviderAddFormState::new(AppType::Claude);
+        let sponsor_flat = first_sponsor_flat_idx(&form.template_picker_rows())
+            .expect("claude should expose sponsor presets");
+        app.form = Some(FormState::ProviderAdd(form));
+        app.overlay = Overlay::ProviderTemplatePicker {
+            selected: sponsor_flat,
+        };
+
+        app.on_key(key(KeyCode::Enter), &UiData::default());
+        assert!(matches!(app.overlay, Overlay::None));
+        let Some(FormState::ProviderAdd(form)) = app.form.as_ref() else {
+            panic!("expected provider form");
+        };
+        assert_eq!(form.template_idx, sponsor_flat);
+        assert_eq!(form.focus, FormFocus::Fields);
+        assert!(
+            form.extra
+                .pointer("/meta/isPartner")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false),
+            "sponsor presets set the partner marker: {:?}",
+            form.extra
+        );
+    }
+
+    #[test]
+    fn provider_template_picker_esc_closes_without_applying() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+
+        let data = UiData::default();
+        app.on_key(key(KeyCode::Char('a')), &data);
+
+        // Fill real work into the form first: Esc must leave all of it alone.
+        if let Some(FormState::ProviderAdd(form)) = app.form.as_mut() {
+            form.claude_api_key.set("sk-typed-by-hand");
+            form.name.set("Typed Name");
+            form.usage_query_enabled = true;
+            form.usage_query_code = "return { balance: 1 }".to_string();
+            form.usage_query_access_token.set("token-typed-by-hand");
+            form.usage_query_base_url.set("https://usage.example.com");
+        }
+
+        app.on_key(key(KeyCode::Enter), &data);
+        app.on_key(key(KeyCode::Down), &data);
+        assert_eq!(provider_template_picker_selection(&app), 1);
+
+        let action = app.on_key(key(KeyCode::Esc), &data);
+        assert!(matches!(action, Action::None));
+        assert!(matches!(app.overlay, Overlay::None));
+        assert_eq!(provider_form_template_idx(&app), 0);
+        // Esc leaves the selection exactly where it was: on the Template row.
+        assert_eq!(provider_form_focus(&app), FormFocus::Fields);
+        assert_eq!(
+            provider_selected_field(&app),
+            Some(ProviderAddField::Template)
+        );
+
+        let Some(FormState::ProviderAdd(form)) = app.form.as_ref() else {
+            panic!("expected provider form");
+        };
+        assert_eq!(
+            form.name.value, "Typed Name",
+            "Esc must not apply a template"
+        );
+        assert_eq!(
+            form.claude_api_key.value, "sk-typed-by-hand",
+            "a typed API key must survive Esc untouched"
+        );
+        assert!(form.usage_query_enabled);
+        assert_eq!(form.usage_query_code, "return { balance: 1 }");
+        assert_eq!(form.usage_query_access_token.value, "token-typed-by-hand");
+        assert_eq!(form.usage_query_base_url.value, "https://usage.example.com");
+    }
+
+    /// The picker's Enter arm must forward the real existing-id set into
+    /// `apply_template`, otherwise a template whose generated id already
+    /// exists would silently collide.
+    #[test]
+    fn provider_template_picker_enter_deconflicts_generated_id() {
+        // Establish the uncontested id this template would generate.
+        let mut baseline = App::new(Some(AppType::Claude));
+        baseline.route = Route::Providers;
+        baseline.focus = Focus::Content;
+        let empty = UiData::default();
+        baseline.on_key(key(KeyCode::Char('a')), &empty);
+        baseline.on_key(key(KeyCode::Enter), &empty);
+        baseline.on_key(key(KeyCode::Down), &empty); // Claude Official
+        baseline.on_key(key(KeyCode::Enter), &empty);
+        let Some(FormState::ProviderAdd(form)) = baseline.form.as_ref() else {
+            panic!("expected provider form");
+        };
+        let natural_id = form.id.value.clone();
+        assert!(!natural_id.is_empty(), "template should generate an id");
+
+        // Now do the same with that id already taken.
+        let mut data = UiData::default();
+        data.providers.rows.push(claude_provider_row(&natural_id));
+
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+        app.on_key(key(KeyCode::Char('a')), &data);
+        app.on_key(key(KeyCode::Enter), &data);
+        app.on_key(key(KeyCode::Down), &data);
+        app.on_key(key(KeyCode::Enter), &data);
+
+        assert!(matches!(app.overlay, Overlay::None));
+        let Some(FormState::ProviderAdd(form)) = app.form.as_ref() else {
+            panic!("expected provider form");
+        };
+        assert_eq!(form.name.value, "Claude Official");
+        assert_ne!(
+            form.id.value, natural_id,
+            "the generated id must be de-conflicted against existing providers"
+        );
+        assert!(
+            form.id.value.starts_with(&natural_id),
+            "de-conflicted id should derive from the natural one, got: {}",
+            form.id.value
+        );
+    }
+
+    /// An out-of-range flat index must snap to the first selectable row so
+    /// Enter still applies something instead of silently doing nothing.
+    #[test]
+    fn provider_template_picker_recovers_from_a_stale_selection() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+
+        let data = UiData::default();
+        app.on_key(key(KeyCode::Char('a')), &data);
+        app.on_key(key(KeyCode::Enter), &data);
+        app.overlay = Overlay::ProviderTemplatePicker { selected: 999 };
+
+        // Any key runs the clamp; Down then moves off the recovered row.
+        app.on_key(key(KeyCode::Up), &data);
+        assert_eq!(
+            provider_template_picker_selection(&app),
+            0,
+            "a stale index must snap to the first selectable row"
+        );
+
+        app.overlay = Overlay::ProviderTemplatePicker { selected: 999 };
+        let action = app.on_key(key(KeyCode::Enter), &data);
+        assert!(matches!(action, Action::None));
+        assert!(matches!(app.overlay, Overlay::None));
+        assert_eq!(
+            provider_form_template_idx(&app),
+            0,
+            "Enter on a stale index applies the recovered row"
+        );
+        assert_eq!(provider_form_focus(&app), FormFocus::Fields);
+    }
+
+    /// The common-snippet refresh moved into the picker's Enter arm; its
+    /// failure path must still surface as a Warning toast.
+    #[test]
+    fn provider_template_picker_enter_warns_on_malformed_common_snippet() {
+        let mut form = ProviderAddFormState::new(AppType::Claude);
+        form.include_common_config = true;
+
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+        app.form = Some(FormState::ProviderAdd(form));
+
+        let mut data = data();
+        data.config.common_snippet = r#"{"env": {"#.to_string();
+        app.on_key(key(KeyCode::Enter), &data);
+        assert!(matches!(
+            app.overlay,
+            Overlay::ProviderTemplatePicker { .. }
+        ));
+
+        // Claude Official, so the apply path is a real template, not a reset.
+        app.on_key(key(KeyCode::Down), &data);
+        let action = app.on_key(key(KeyCode::Enter), &data);
+        assert!(matches!(action, Action::None));
+        assert!(matches!(app.overlay, Overlay::None));
+        assert_eq!(provider_form_focus(&app), FormFocus::Fields);
+        assert!(
+            matches!(
+                app.toast.as_ref(),
+                Some(Toast {
+                    kind: ToastKind::Warning,
+                    ..
+                })
+            ),
+            "expected a Warning toast, got: {:?}",
+            app.toast
+        );
+    }
+
+    #[test]
+    fn provider_template_picker_closes_when_form_is_gone() {
+        let mut app = App::new(Some(AppType::Claude));
+        app.overlay = Overlay::ProviderTemplatePicker { selected: 3 };
+
+        let action = app.on_key(key(KeyCode::Down), &UiData::default());
+        assert!(matches!(action, Action::None));
+        assert!(matches!(app.overlay, Overlay::None));
     }
 
     #[test]
@@ -13196,7 +13698,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
         app.on_key(key(KeyCode::Tab), &data); // fields -> json
 
         let action = app.on_key(key(KeyCode::Enter), &data);
@@ -13239,7 +13741,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
         app.on_key(key(KeyCode::Tab), &data); // fields -> json
         app.on_key(key(KeyCode::Enter), &data); // json -> editor(edit mode)
 
@@ -13275,7 +13777,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
         app.on_key(key(KeyCode::Tab), &data); // fields -> json
         app.on_key(key(KeyCode::Enter), &data); // json -> editor
 
@@ -13342,7 +13844,7 @@ mod tests {
         data.config.common_snippet = r#"{"alwaysThinkingEnabled":false,"statusLine":{"type":"command","command":"~/.claude/statusline.sh","padding":0}}"#.to_string();
 
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.id.set("p1");
@@ -13382,7 +13884,7 @@ mod tests {
         data.config.common_snippet = "network_access = true".to_string();
 
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data); // apply template -> fields
+        apply_current_provider_template(&mut app, &data); // apply template -> fields
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.id.set("p1");
@@ -13412,7 +13914,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -13446,7 +13948,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -13483,7 +13985,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -13629,7 +14131,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -13685,7 +14187,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -13721,7 +14223,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -13766,7 +14268,7 @@ mod tests {
         data.proxy.codex_takeover = true;
 
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -13829,7 +14331,7 @@ mod tests {
         data.proxy.codex_takeover = true;
 
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -14310,7 +14812,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -14352,7 +14854,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -14385,7 +14887,7 @@ mod tests {
         data.proxy.claude_takeover = true;
 
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(super::super::form::FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.focus = super::super::form::FormFocus::Fields;
@@ -14999,11 +15501,25 @@ mod tests {
     fn provider_form_jk_navigates_fields() {
         let mut app = open_provider_fields_form(AppType::Claude);
 
-        assert_eq!(provider_field_idx(&app), 0);
+        // Applying a template lands on the first field after the template row.
+        let first = provider_field_idx(&app);
+        assert_eq!(
+            provider_selected_field(&app),
+            Some(ProviderAddField::Name),
+            "expected to land on the first real field"
+        );
         app.on_key(key(KeyCode::Char('j')), &data());
-        assert_eq!(provider_field_idx(&app), 1);
+        assert_eq!(provider_field_idx(&app), first + 1);
         app.on_key(key(KeyCode::Char('k')), &data());
-        assert_eq!(provider_field_idx(&app), 0);
+        assert_eq!(provider_field_idx(&app), first);
+
+        // k at the first real field walks back over the divider to Template.
+        app.on_key(key(KeyCode::Char('k')), &data());
+        assert_eq!(
+            provider_selected_field(&app),
+            Some(ProviderAddField::Template),
+            "the divider must be skipped, not selected"
+        );
     }
 
     #[test]
@@ -15275,14 +15791,15 @@ mod tests {
             let mut data = data();
             data.config.common_snippet = common_snippet.to_string();
 
-            assert!(matches!(
-                app.on_key(key(KeyCode::Enter), &data),
-                Action::None
-            ));
+            // Go through the picker so the apply + common-snippet refresh path
+            // is genuinely exercised, not just the constructor's seed state.
+            apply_current_provider_template(&mut app, &data);
+            assert!(matches!(app.overlay, Overlay::None));
 
             let Some(FormState::ProviderAdd(form)) = app.form.as_ref() else {
                 panic!("expected provider form for {app_type:?}");
             };
+            assert_eq!(form.focus, FormFocus::Fields);
             assert!(form.include_common_config);
             match app_type {
                 AppType::Claude => assert!(form.claude_teammates),
@@ -15972,6 +16489,62 @@ mod tests {
         assert_eq!(help.scroll, 1);
     }
 
+    /// `?` on the Template field row must show the template help, not the
+    /// generic per-field help.
+    #[test]
+    fn context_help_provider_template_field_shows_template_help() {
+        let _lang = use_test_language(Language::English);
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+
+        let data = UiData::default();
+        app.on_key(key(KeyCode::Char('a')), &data);
+        assert_eq!(
+            provider_selected_field(&app),
+            Some(ProviderAddField::Template)
+        );
+
+        app.on_key(key(KeyCode::Char('?')), &data);
+        let text = help_text(&app);
+        assert!(
+            text.contains("The Template field row shows only the current selection"),
+            "{text}"
+        );
+        assert!(
+            text.contains("Applying a template rewrites the form for that template"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn context_help_provider_template_picker_restores_after_close() {
+        let _lang = use_test_language(Language::English);
+        let mut app = App::new(Some(AppType::Claude));
+        app.form = Some(FormState::ProviderAdd(ProviderAddFormState::new(
+            AppType::Claude,
+        )));
+        app.overlay = Overlay::ProviderTemplatePicker { selected: 1 };
+
+        app.on_key(key(KeyCode::Char('?')), &UiData::default());
+        let text = help_text(&app);
+        assert!(
+            text.contains("Applying a template rewrites the form for that template"),
+            "{text}"
+        );
+        assert!(matches!(
+            app.pending_overlay,
+            Some(Overlay::ProviderTemplatePicker { selected: 1 })
+        ));
+
+        app.on_key(key(KeyCode::Char('?')), &UiData::default());
+        assert!(matches!(
+            app.overlay,
+            Overlay::ProviderTemplatePicker { selected: 1 }
+        ));
+        assert!(app.pending_overlay.is_none());
+    }
+
     #[test]
     fn context_help_usage_query_template_picker_restores_after_close() {
         let _lang = use_test_language(Language::English);
@@ -16290,7 +16863,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
         select_provider_usage_query_row(&mut app);
 
         let action = app.on_key(key(KeyCode::Enter), &data);
@@ -16319,7 +16892,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
         select_provider_usage_query_row(&mut app);
 
         let action = app.on_key(key(KeyCode::Enter), &data);
@@ -16388,7 +16961,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(FormState::ProviderAdd(form)) = app.form.as_mut() {
             mark_claude_usage_query_provider_non_official(form);
@@ -16465,7 +17038,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(FormState::ProviderAdd(form)) = app.form.as_mut() {
             mark_claude_usage_query_provider_non_official(form);
@@ -16494,7 +17067,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(FormState::ProviderAdd(form)) = app.form.as_mut() {
             mark_claude_usage_query_provider_non_official(form);
@@ -16528,7 +17101,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(FormState::ProviderAdd(form)) = app.form.as_mut() {
             form.name.set("Provider One");
@@ -16690,7 +17263,7 @@ mod tests {
 
         let data = UiData::default();
         app.on_key(key(KeyCode::Char('a')), &data);
-        app.on_key(key(KeyCode::Enter), &data);
+        apply_current_provider_template(&mut app, &data);
 
         if let Some(FormState::ProviderAdd(form)) = app.form.as_mut() {
             mark_claude_usage_query_provider_non_official(form);

--- a/src-tauri/src/cli/tui/app/types.rs
+++ b/src-tauri/src/cli/tui/app/types.rs
@@ -4616,6 +4616,12 @@ pub enum Overlay {
     UsageQueryTemplatePicker {
         selected: usize,
     },
+    /// Provider Add form template picker. `selected` is the flat template
+    /// index shared with `ProviderAddFormState::apply_template`, not the
+    /// picker's display row, because the picker regroups templates.
+    ProviderTemplatePicker {
+        selected: usize,
+    },
     S3PresetPicker {
         selected: usize,
     },
@@ -4845,6 +4851,7 @@ impl Overlay {
                 | Overlay::UserAgentPicker { .. }
                 | Overlay::ExternalEditorPicker { .. }
                 | Overlay::UsageQueryTemplatePicker { .. }
+                | Overlay::ProviderTemplatePicker { .. }
                 | Overlay::S3PresetPicker { .. }
                 | Overlay::ManagedAccountPicker { .. }
                 | Overlay::ManagedAccountActionPicker { .. }
@@ -4890,6 +4897,7 @@ impl Overlay {
             | Overlay::UserAgentPicker { .. }
             | Overlay::ExternalEditorPicker { .. }
             | Overlay::UsageQueryTemplatePicker { .. }
+            | Overlay::ProviderTemplatePicker { .. }
             | Overlay::S3PresetPicker { .. }
             | Overlay::ManagedAccountPicker { .. }
             | Overlay::ManagedAccountActionPicker { .. }

--- a/src-tauri/src/cli/tui/form.rs
+++ b/src-tauri/src/cli/tui/form.rs
@@ -46,6 +46,10 @@ pub(crate) use provider_state::resolve_provider_id_for_submit;
 pub(crate) use provider_state::{
     detect_balance_provider_for_usage_query, detect_coding_plan_provider_for_usage_query,
 };
+pub(crate) use provider_templates::{
+    provider_template_first_flat_idx, provider_template_row_for_flat_idx,
+    provider_template_step_flat_idx, ProviderTemplateRow, ProviderTemplateSection,
+};
 pub(crate) use s3::{S3Preset, S3SyncField, S3SyncFormState};
 pub(crate) use webdav::{WebDavSyncField, WebDavSyncFormState};
 
@@ -246,6 +250,10 @@ impl FormMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderAddField {
+    /// Add-mode only pseudo-field: Enter opens the provider template picker.
+    /// It leads the field list so the very first Enter still picks a template.
+    Template,
+    TemplateDivider,
     Id,
     Name,
     WebsiteUrl,

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -135,7 +135,9 @@ impl ProviderAddFormState {
             app_type,
             mode: FormMode::Add,
             copy_source_id: None,
-            focus: FormFocus::Templates,
+            // The template is a field row now, and `fields()` puts it first in
+            // Add mode, so the form opens with it selected.
+            focus: FormFocus::Fields,
             page: ProviderFormPage::Main,
             template_idx: 0,
             field_idx: 0,
@@ -334,6 +336,10 @@ impl ProviderAddFormState {
             }
         }
         form.id.set(provider_copy_id(&provider.id, existing_ids));
+        // A copy arrives pre-filled, so opening on the template row would both
+        // mislabel it as "Custom" and put a values-wiping Enter one keypress
+        // away. Start on the first real field, as this form always used to.
+        form.field_idx = form.first_field_after_template();
         form
     }
 
@@ -572,7 +578,30 @@ impl ProviderAddFormState {
         }
         fields.push(ProviderAddField::UsageQueryDivider);
         fields.push(ProviderAddField::UsageQuery);
+
+        // Add mode leads with the template picker row plus its divider, so the
+        // template reads as its own group above the real fields. Inserted last
+        // so app-specific `insert(0, ...)` rules above stay index-correct.
+        if matches!(self.mode, FormMode::Add) {
+            fields.insert(0, ProviderAddField::TemplateDivider);
+            fields.insert(0, ProviderAddField::Template);
+        }
         fields
+    }
+
+    /// Index of the first real field, i.e. the row after the template group.
+    /// Used after applying a template so the user lands ready to type.
+    pub fn first_field_after_template(&self) -> usize {
+        let fields = self.fields();
+        fields
+            .iter()
+            .position(|field| {
+                !matches!(
+                    field,
+                    ProviderAddField::Template | ProviderAddField::TemplateDivider
+                )
+            })
+            .unwrap_or(0)
     }
 
     pub fn usage_query_fields(&self) -> Vec<UsageQueryField> {
@@ -727,7 +756,9 @@ impl ProviderAddFormState {
             | ProviderAddField::CommonSnippet
             | ProviderAddField::IncludeCommonConfig
             | ProviderAddField::UsageQueryDivider
-            | ProviderAddField::UsageQuery => None,
+            | ProviderAddField::UsageQuery
+            | ProviderAddField::Template
+            | ProviderAddField::TemplateDivider => None,
         }
     }
 
@@ -795,7 +826,9 @@ impl ProviderAddFormState {
             | ProviderAddField::CommonSnippet
             | ProviderAddField::IncludeCommonConfig
             | ProviderAddField::UsageQueryDivider
-            | ProviderAddField::UsageQuery => None,
+            | ProviderAddField::UsageQuery
+            | ProviderAddField::Template
+            | ProviderAddField::TemplateDivider => None,
         }
     }
 

--- a/src-tauri/src/cli/tui/form/provider_templates.rs
+++ b/src-tauri/src/cli/tui/form/provider_templates.rs
@@ -41,6 +41,77 @@ pub(super) struct ProviderTemplateDef {
     label: &'static str,
 }
 
+/// Section grouping used by the provider template picker overlay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderTemplateSection {
+    BuiltIn,
+    Sponsors,
+}
+
+/// One display row of the provider template picker.
+///
+/// Headers are never selectable. Every item carries the flat template index,
+/// so `apply_template` stays correct even though the picker groups templates
+/// in a different order than [`ProviderAddFormState::template_labels`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderTemplateRow {
+    Header(ProviderTemplateSection),
+    Item {
+        flat_idx: usize,
+        label: &'static str,
+        section: ProviderTemplateSection,
+    },
+}
+
+impl ProviderTemplateRow {
+    pub fn flat_idx(&self) -> Option<usize> {
+        match self {
+            ProviderTemplateRow::Item { flat_idx, .. } => Some(*flat_idx),
+            ProviderTemplateRow::Header(_) => None,
+        }
+    }
+}
+
+/// Sponsor chip labels carry a leading `"* "` marker so they stand out in the
+/// flat chip row. The picker renders them under an explicit Sponsors header,
+/// so the marker is redundant there.
+fn strip_sponsor_chip_marker(label: &'static str) -> &'static str {
+    label.strip_prefix("* ").unwrap_or(label)
+}
+
+/// Display-row index of `flat_idx`, when the picker still contains it.
+pub fn provider_template_row_for_flat_idx(
+    rows: &[ProviderTemplateRow],
+    flat_idx: usize,
+) -> Option<usize> {
+    rows.iter().position(|row| row.flat_idx() == Some(flat_idx))
+}
+
+/// First selectable flat index; used to recover from a stale selection.
+pub fn provider_template_first_flat_idx(rows: &[ProviderTemplateRow]) -> Option<usize> {
+    rows.iter().find_map(ProviderTemplateRow::flat_idx)
+}
+
+/// Neighbouring selectable flat index, skipping non-selectable section
+/// headers. Returns `None` at either end so callers keep the current row.
+pub fn provider_template_step_flat_idx(
+    rows: &[ProviderTemplateRow],
+    flat_idx: usize,
+    forward: bool,
+) -> Option<usize> {
+    let current = provider_template_row_for_flat_idx(rows, flat_idx)?;
+    if forward {
+        rows.get(current.saturating_add(1)..)?
+            .iter()
+            .find_map(ProviderTemplateRow::flat_idx)
+    } else {
+        rows.get(..current)?
+            .iter()
+            .rev()
+            .find_map(ProviderTemplateRow::flat_idx)
+    }
+}
+
 #[cfg(test)]
 impl SponsorProviderPreset {
     pub(super) fn id(&self) -> &'static str {
@@ -192,6 +263,12 @@ impl ProviderAddFormState {
             + provider_after_sponsor_template_defs(&self.app_type).len()
     }
 
+    /// Flat template labels, indexed the same way as [`Self::apply_template`].
+    ///
+    /// Sponsor labels drop the `"* "` chip marker here, matching the picker
+    /// overlay: the collapsed template row shows one label at a time, so the
+    /// marker no longer separates sponsors from built-ins the way it did in
+    /// the old chip row (which the MCP form and the CLI chooser still use).
     pub fn template_labels(&self) -> Vec<&'static str> {
         let mut labels = provider_builtin_template_defs(&self.app_type)
             .iter()
@@ -200,7 +277,7 @@ impl ProviderAddFormState {
         labels.extend(
             provider_sponsor_presets(&self.app_type)
                 .iter()
-                .map(|preset| preset.chip_label),
+                .map(|preset| strip_sponsor_chip_marker(preset.chip_label)),
         );
         labels.extend(
             provider_after_sponsor_template_defs(&self.app_type)
@@ -208,6 +285,57 @@ impl ProviderAddFormState {
                 .map(|def| def.label),
         );
         labels
+    }
+
+    /// Display rows for the template picker overlay.
+    ///
+    /// Built-in templates and the after-sponsor built-ins (e.g. Codex's
+    /// DeepSeek) share one section; sponsor presets get their own. Section
+    /// headers are only emitted when the app actually has sponsor presets,
+    /// so single-section apps stay a plain list.
+    pub fn template_picker_rows(&self) -> Vec<ProviderTemplateRow> {
+        let builtin_defs = provider_builtin_template_defs(&self.app_type);
+        let sponsor_presets = provider_sponsor_presets(&self.app_type);
+        let after_sponsor_defs = provider_after_sponsor_template_defs(&self.app_type);
+
+        let grouped = !sponsor_presets.is_empty();
+        // Every template plus the two section headers.
+        let mut rows = Vec::with_capacity(self.template_count().saturating_add(2));
+
+        if grouped {
+            rows.push(ProviderTemplateRow::Header(
+                ProviderTemplateSection::BuiltIn,
+            ));
+        }
+        for (idx, def) in builtin_defs.iter().enumerate() {
+            rows.push(ProviderTemplateRow::Item {
+                flat_idx: idx,
+                label: def.label,
+                section: ProviderTemplateSection::BuiltIn,
+            });
+        }
+        for (offset, def) in after_sponsor_defs.iter().enumerate() {
+            rows.push(ProviderTemplateRow::Item {
+                flat_idx: builtin_defs.len() + sponsor_presets.len() + offset,
+                label: def.label,
+                section: ProviderTemplateSection::BuiltIn,
+            });
+        }
+
+        if grouped {
+            rows.push(ProviderTemplateRow::Header(
+                ProviderTemplateSection::Sponsors,
+            ));
+            for (offset, preset) in sponsor_presets.iter().enumerate() {
+                rows.push(ProviderTemplateRow::Item {
+                    flat_idx: builtin_defs.len() + offset,
+                    label: strip_sponsor_chip_marker(preset.chip_label),
+                    section: ProviderTemplateSection::Sponsors,
+                });
+            }
+        }
+
+        rows
     }
 
     pub fn apply_template(&mut self, idx: usize, existing_ids: &[String]) {

--- a/src-tauri/src/cli/tui/form/tests.rs
+++ b/src-tauri/src/cli/tui/form/tests.rs
@@ -12,27 +12,27 @@ fn template_index_by_label(app_type: AppType, label: &str) -> usize {
 }
 
 fn claudeapi_template_index(app_type: AppType) -> usize {
-    template_index_by_label(app_type, "* ClaudeAPI")
+    template_index_by_label(app_type, "ClaudeAPI")
 }
 
 fn packycode_template_index(app_type: AppType) -> usize {
-    template_index_by_label(app_type, "* PackyCode")
+    template_index_by_label(app_type, "PackyCode")
 }
 
 fn aicodemirror_template_index(app_type: AppType) -> usize {
-    template_index_by_label(app_type, "* AICodeMirror")
+    template_index_by_label(app_type, "AICodeMirror")
 }
 
 fn cubence_template_index(app_type: AppType) -> usize {
-    template_index_by_label(app_type, "* Cubence")
+    template_index_by_label(app_type, "Cubence")
 }
 
 fn runapi_template_index(app_type: AppType) -> usize {
-    template_index_by_label(app_type, "* RunAPI")
+    template_index_by_label(app_type, "RunAPI")
 }
 
 fn dds_template_index(app_type: AppType) -> usize {
-    template_index_by_label(app_type, "* DDS")
+    template_index_by_label(app_type, "DDS")
 }
 
 fn deepseek_template_index(app_type: AppType) -> usize {
@@ -79,18 +79,33 @@ fn assert_cli_template_matches_tui_serializer(
     );
 }
 
+/// Chip labels keep the ASCII `"* "` marker for the chip-row consumers (the
+/// MCP form and the CLI template chooser); the provider form's flat labels
+/// strip it, because its collapsed row and picker show sponsors under an
+/// explicit Sponsors header instead.
 #[test]
 fn provider_add_form_template_labels_use_ascii_prefix_for_packycode() {
-    let form = ProviderAddFormState::new(AppType::Claude);
-    let labels = form.template_labels();
+    let chip_labels =
+        crate::provider_preset_sponsors::sponsor_provider_presets_for_app(&AppType::Claude)
+            .iter()
+            .map(|preset| preset.chip_label)
+            .collect::<Vec<_>>();
 
     assert!(
-        labels.contains(&"* PackyCode"),
+        chip_labels.contains(&"* PackyCode"),
         "expected PackyCode chip label to use ASCII prefix for alignment stability"
     );
     assert!(
-        labels.contains(&"* ClaudeAPI"),
+        chip_labels.contains(&"* ClaudeAPI"),
         "expected ClaudeAPI chip label to use ASCII prefix for alignment stability"
+    );
+
+    let labels = ProviderAddFormState::new(AppType::Claude).template_labels();
+    assert!(labels.contains(&"PackyCode"), "{labels:?}");
+    assert!(labels.contains(&"ClaudeAPI"), "{labels:?}");
+    assert!(
+        labels.iter().all(|label| !label.starts_with("* ")),
+        "provider template labels must drop the chip marker: {labels:?}"
     );
 }
 
@@ -103,15 +118,15 @@ fn provider_add_form_template_labels_follow_explicit_support_matrix() {
             "Custom",
             "Claude Official",
             "Codex",
-            "* AICodeMirror",
-            "* ClaudeAPI",
-            "* Cubence",
-            "* OpenModel",
-            "* RunAPI",
-            "* Qiniu",
-            "* FennoAI",
-            "* PackyCode",
-            "* DDS",
+            "AICodeMirror",
+            "ClaudeAPI",
+            "Cubence",
+            "OpenModel",
+            "RunAPI",
+            "Qiniu",
+            "FennoAI",
+            "PackyCode",
+            "DDS",
         ]
     );
 
@@ -121,14 +136,14 @@ fn provider_add_form_template_labels_follow_explicit_support_matrix() {
         vec![
             "Custom",
             "OpenAI Official",
-            "* AICodeMirror",
-            "* Cubence",
-            "* OpenModel",
-            "* RunAPI",
-            "* Qiniu",
-            "* FennoAI",
-            "* PackyCode",
-            "* DDS",
+            "AICodeMirror",
+            "Cubence",
+            "OpenModel",
+            "RunAPI",
+            "Qiniu",
+            "FennoAI",
+            "PackyCode",
+            "DDS",
             "DeepSeek",
         ]
     );
@@ -139,11 +154,11 @@ fn provider_add_form_template_labels_follow_explicit_support_matrix() {
         vec![
             "Custom",
             "Google OAuth",
-            "* AICodeMirror",
-            "* Cubence",
-            "* OpenModel",
-            "* Qiniu",
-            "* PackyCode",
+            "AICodeMirror",
+            "Cubence",
+            "OpenModel",
+            "Qiniu",
+            "PackyCode",
         ]
     );
 
@@ -152,17 +167,17 @@ fn provider_add_form_template_labels_follow_explicit_support_matrix() {
         opencode_labels,
         vec![
             "Custom",
-            "* AICodeMirror",
-            "* Cubence",
-            "* OpenModel",
-            "* RunAPI",
-            "* Qiniu",
-            "* FennoAI",
-            "* PackyCode"
+            "AICodeMirror",
+            "Cubence",
+            "OpenModel",
+            "RunAPI",
+            "Qiniu",
+            "FennoAI",
+            "PackyCode"
         ]
     );
     assert!(
-        !opencode_labels.contains(&"* ClaudeAPI"),
+        !opencode_labels.contains(&"ClaudeAPI"),
         "OpenCode should not expose Claude-only sponsor presets"
     );
 
@@ -171,13 +186,13 @@ fn provider_add_form_template_labels_follow_explicit_support_matrix() {
         hermes_labels,
         vec![
             "Custom",
-            "* AICodeMirror",
-            "* Cubence",
-            "* OpenModel",
-            "* RunAPI",
-            "* Qiniu",
-            "* FennoAI",
-            "* PackyCode"
+            "AICodeMirror",
+            "Cubence",
+            "OpenModel",
+            "RunAPI",
+            "Qiniu",
+            "FennoAI",
+            "PackyCode"
         ]
     );
 
@@ -186,17 +201,17 @@ fn provider_add_form_template_labels_follow_explicit_support_matrix() {
         openclaw_labels,
         vec![
             "Custom",
-            "* AICodeMirror",
-            "* Cubence",
-            "* OpenModel",
-            "* RunAPI",
-            "* Qiniu",
-            "* FennoAI",
-            "* PackyCode"
+            "AICodeMirror",
+            "Cubence",
+            "OpenModel",
+            "RunAPI",
+            "Qiniu",
+            "FennoAI",
+            "PackyCode"
         ]
     );
     assert!(
-        !openclaw_labels.contains(&"* ClaudeAPI"),
+        !openclaw_labels.contains(&"ClaudeAPI"),
         "OpenClaw should not expose Claude-only sponsor presets"
     );
 }
@@ -220,97 +235,69 @@ fn cli_provider_templates_match_tui_serializer_output() {
             ProviderAddTemplate::GoogleOauth,
             "Google OAuth",
         ),
-        (
-            AppType::Claude,
-            ProviderAddTemplate::Claudeapi,
-            "* ClaudeAPI",
-        ),
-        (
-            AppType::Claude,
-            ProviderAddTemplate::Packycode,
-            "* PackyCode",
-        ),
-        (
-            AppType::Claude,
-            ProviderAddTemplate::Openmodel,
-            "* OpenModel",
-        ),
-        (
-            AppType::Codex,
-            ProviderAddTemplate::Openmodel,
-            "* OpenModel",
-        ),
-        (
-            AppType::Gemini,
-            ProviderAddTemplate::Openmodel,
-            "* OpenModel",
-        ),
+        (AppType::Claude, ProviderAddTemplate::Claudeapi, "ClaudeAPI"),
+        (AppType::Claude, ProviderAddTemplate::Packycode, "PackyCode"),
+        (AppType::Claude, ProviderAddTemplate::Openmodel, "OpenModel"),
+        (AppType::Codex, ProviderAddTemplate::Openmodel, "OpenModel"),
+        (AppType::Gemini, ProviderAddTemplate::Openmodel, "OpenModel"),
         (
             AppType::OpenCode,
             ProviderAddTemplate::Openmodel,
-            "* OpenModel",
+            "OpenModel",
         ),
-        (
-            AppType::Hermes,
-            ProviderAddTemplate::Openmodel,
-            "* OpenModel",
-        ),
+        (AppType::Hermes, ProviderAddTemplate::Openmodel, "OpenModel"),
         (
             AppType::OpenClaw,
             ProviderAddTemplate::Openmodel,
-            "* OpenModel",
+            "OpenModel",
         ),
         (
             AppType::Codex,
             ProviderAddTemplate::Aicodemirror,
-            "* AICodeMirror",
+            "AICodeMirror",
         ),
-        (AppType::Codex, ProviderAddTemplate::Runapi, "* RunAPI"),
+        (AppType::Codex, ProviderAddTemplate::Runapi, "RunAPI"),
         (AppType::Codex, ProviderAddTemplate::Deepseek, "DeepSeek"),
-        (AppType::Gemini, ProviderAddTemplate::Cubence, "* Cubence"),
-        (AppType::Claude, ProviderAddTemplate::Dds, "* DDS"),
+        (AppType::Gemini, ProviderAddTemplate::Cubence, "Cubence"),
+        (AppType::Claude, ProviderAddTemplate::Dds, "DDS"),
         (
             AppType::OpenCode,
             ProviderAddTemplate::Aicodemirror,
-            "* AICodeMirror",
+            "AICodeMirror",
         ),
-        (AppType::OpenCode, ProviderAddTemplate::Cubence, "* Cubence"),
-        (AppType::OpenCode, ProviderAddTemplate::Runapi, "* RunAPI"),
+        (AppType::OpenCode, ProviderAddTemplate::Cubence, "Cubence"),
+        (AppType::OpenCode, ProviderAddTemplate::Runapi, "RunAPI"),
         (
             AppType::OpenCode,
             ProviderAddTemplate::Packycode,
-            "* PackyCode",
+            "PackyCode",
         ),
-        (AppType::Hermes, ProviderAddTemplate::Cubence, "* Cubence"),
-        (AppType::Hermes, ProviderAddTemplate::Runapi, "* RunAPI"),
-        (
-            AppType::Hermes,
-            ProviderAddTemplate::Packycode,
-            "* PackyCode",
-        ),
+        (AppType::Hermes, ProviderAddTemplate::Cubence, "Cubence"),
+        (AppType::Hermes, ProviderAddTemplate::Runapi, "RunAPI"),
+        (AppType::Hermes, ProviderAddTemplate::Packycode, "PackyCode"),
         (
             AppType::OpenClaw,
             ProviderAddTemplate::Aicodemirror,
-            "* AICodeMirror",
+            "AICodeMirror",
         ),
-        (AppType::OpenClaw, ProviderAddTemplate::Cubence, "* Cubence"),
-        (AppType::OpenClaw, ProviderAddTemplate::Runapi, "* RunAPI"),
+        (AppType::OpenClaw, ProviderAddTemplate::Cubence, "Cubence"),
+        (AppType::OpenClaw, ProviderAddTemplate::Runapi, "RunAPI"),
         (
             AppType::OpenClaw,
             ProviderAddTemplate::Packycode,
-            "* PackyCode",
+            "PackyCode",
         ),
-        (AppType::Claude, ProviderAddTemplate::Qiniu, "* Qiniu"),
-        (AppType::Codex, ProviderAddTemplate::Qiniu, "* Qiniu"),
-        (AppType::Gemini, ProviderAddTemplate::Qiniu, "* Qiniu"),
-        (AppType::OpenCode, ProviderAddTemplate::Qiniu, "* Qiniu"),
-        (AppType::Hermes, ProviderAddTemplate::Qiniu, "* Qiniu"),
-        (AppType::OpenClaw, ProviderAddTemplate::Qiniu, "* Qiniu"),
-        (AppType::Claude, ProviderAddTemplate::Fenno, "* FennoAI"),
-        (AppType::Codex, ProviderAddTemplate::Fenno, "* FennoAI"),
-        (AppType::OpenCode, ProviderAddTemplate::Fenno, "* FennoAI"),
-        (AppType::Hermes, ProviderAddTemplate::Fenno, "* FennoAI"),
-        (AppType::OpenClaw, ProviderAddTemplate::Fenno, "* FennoAI"),
+        (AppType::Claude, ProviderAddTemplate::Qiniu, "Qiniu"),
+        (AppType::Codex, ProviderAddTemplate::Qiniu, "Qiniu"),
+        (AppType::Gemini, ProviderAddTemplate::Qiniu, "Qiniu"),
+        (AppType::OpenCode, ProviderAddTemplate::Qiniu, "Qiniu"),
+        (AppType::Hermes, ProviderAddTemplate::Qiniu, "Qiniu"),
+        (AppType::OpenClaw, ProviderAddTemplate::Qiniu, "Qiniu"),
+        (AppType::Claude, ProviderAddTemplate::Fenno, "FennoAI"),
+        (AppType::Codex, ProviderAddTemplate::Fenno, "FennoAI"),
+        (AppType::OpenCode, ProviderAddTemplate::Fenno, "FennoAI"),
+        (AppType::Hermes, ProviderAddTemplate::Fenno, "FennoAI"),
+        (AppType::OpenClaw, ProviderAddTemplate::Fenno, "FennoAI"),
     ] {
         assert_cli_template_matches_tui_serializer(app_type, template, label);
     }
@@ -5707,13 +5694,13 @@ fn provider_add_form_opencode_exposes_supported_sponsor_presets() {
         labels,
         vec![
             "Custom",
-            "* AICodeMirror",
-            "* Cubence",
-            "* OpenModel",
-            "* RunAPI",
-            "* Qiniu",
-            "* FennoAI",
-            "* PackyCode"
+            "AICodeMirror",
+            "Cubence",
+            "OpenModel",
+            "RunAPI",
+            "Qiniu",
+            "FennoAI",
+            "PackyCode"
         ]
     );
 }
@@ -5730,13 +5717,13 @@ fn provider_add_form_openclaw_uses_dedicated_template_defs() {
         openclaw_labels,
         vec![
             "Custom",
-            "* AICodeMirror",
-            "* Cubence",
-            "* OpenModel",
-            "* RunAPI",
-            "* Qiniu",
-            "* FennoAI",
-            "* PackyCode"
+            "AICodeMirror",
+            "Cubence",
+            "OpenModel",
+            "RunAPI",
+            "Qiniu",
+            "FennoAI",
+            "PackyCode"
         ]
     );
     assert!(
@@ -5753,6 +5740,8 @@ fn provider_add_form_hermes_exposes_upstream_provider_fields_only() {
     assert_eq!(
         fields,
         vec![
+            ProviderAddField::Template,
+            ProviderAddField::TemplateDivider,
             ProviderAddField::Id,
             ProviderAddField::Name,
             ProviderAddField::WebsiteUrl,
@@ -6110,7 +6099,15 @@ fn provider_add_form_openclaw_exposes_minimal_dedicated_fields() {
     let form = ProviderAddFormState::new(AppType::OpenClaw);
     let fields = form.fields();
 
-    assert_eq!(fields.first(), Some(&ProviderAddField::Id));
+    // Add mode leads with the template group, then the app-specific key field.
+    assert_eq!(
+        &fields[..3],
+        &[
+            ProviderAddField::Template,
+            ProviderAddField::TemplateDivider,
+            ProviderAddField::Id,
+        ]
+    );
     assert!(fields.contains(&ProviderAddField::OpenClawApiProtocol));
     assert!(fields.contains(&ProviderAddField::OpenCodeApiKey));
     assert!(fields.contains(&ProviderAddField::OpenCodeBaseUrl));
@@ -6873,6 +6870,49 @@ fn provider_edit_form_roundtrip_no_duplicate_common_config_key() {
         .expect("roundtrip deserialization should succeed without duplicate field error");
     assert_eq!(roundtrip.id, "test-provider");
     assert_eq!(roundtrip.name, "Test Provider");
+}
+
+/// A copy form is Add mode, so it grows a Template row — but it arrives
+/// pre-filled, so it must not open on that row: "Custom" would mislabel the
+/// copied values and Enter-Enter would wipe them.
+#[test]
+fn provider_copy_form_opens_on_the_first_real_field() {
+    let provider = Provider::with_id(
+        "test-provider".to_string(),
+        "Test Provider".to_string(),
+        json!({ "env": { "ANTHROPIC_AUTH_TOKEN": "sk-copied" } }),
+        Some("https://example.com".to_string()),
+    );
+
+    let form = ProviderAddFormState::copy_from_provider_with_common_snippet(
+        AppType::Claude,
+        &provider,
+        "",
+        &["test-provider".to_string()],
+    );
+
+    assert!(matches!(form.mode, FormMode::Add));
+    assert_eq!(form.focus, FormFocus::Fields);
+
+    let fields = form.fields();
+    assert!(
+        fields.contains(&ProviderAddField::Template),
+        "add-mode copy forms still expose the template row"
+    );
+    let selected = fields.get(form.field_idx).copied();
+    assert!(
+        !matches!(
+            selected,
+            Some(ProviderAddField::Template) | Some(ProviderAddField::TemplateDivider)
+        ),
+        "copy form must not open on the template group, got: {selected:?}"
+    );
+    assert_eq!(selected, Some(ProviderAddField::Name));
+
+    // The copied values are intact and one Enter away from being edited.
+    assert_eq!(form.name.value, "Test Provider copy");
+    assert_eq!(form.claude_api_key.value, "sk-copied");
+    assert_eq!(form.website_url.value, "https://example.com");
 }
 
 #[test]

--- a/src-tauri/src/cli/tui/help.rs
+++ b/src-tauri/src/cli/tui/help.rs
@@ -103,6 +103,7 @@ fn current_help_target(app: &App) -> HelpTarget {
             Overlay::UsageQueryTemplatePicker { .. } => {
                 provider_usage_query_overlay_target(app, UsageQueryField::Template)
             }
+            Overlay::ProviderTemplatePicker { .. } => HelpTarget::ProviderTemplate,
             Overlay::ClaudeApiFormatPicker { .. } => {
                 provider_field_overlay_target(app, ProviderAddField::ClaudeApiFormat)
             }
@@ -283,9 +284,14 @@ fn current_help_target(app: &App) -> HelpTarget {
                 .get(provider.field_idx.min(fields.len().saturating_sub(1)))
                 .copied()
                 .filter(|field| !provider_field_is_divider(*field))
-                .map_or(HelpTarget::Empty, |field| HelpTarget::ProviderField {
-                    app_type: provider.app_type.clone(),
-                    field,
+                .map_or(HelpTarget::Empty, |field| match field {
+                    // The template row is a field now, but it keeps its own
+                    // dedicated help instead of a per-field description.
+                    ProviderAddField::Template => HelpTarget::ProviderTemplate,
+                    field => HelpTarget::ProviderField {
+                        app_type: provider.app_type.clone(),
+                        field,
+                    },
                 })
         }
         FormFocus::JsonPreview => HelpTarget::ProviderPreview {
@@ -336,10 +342,10 @@ fn help_for_target(target: HelpTarget, app: &App, data: &UiData) -> HelpContent 
             vec![texts::codex_unified_session_history_description().to_string()],
         ),
         HelpTarget::ProviderTemplate => HelpContent::new(
-            tr("供应商模板", "Provider templates"),
+            texts::tui_provider_template_picker_title(),
             help_lines(
-                "选择一个预设模板后按 Enter 应用。模板会填入供应商常用的地址、模型和元数据。\n如果没有合适模板，保留自定义后直接填写字段。",
-                "Choose a preset and press Enter to apply it. Templates fill common provider URLs, models, and metadata.\nKeep Custom selected when no preset fits.",
+                "模板列表包含全部可选模板：↑/↓ 移动，Enter 应用，Esc 关闭且不改动表单。表单字段里的“模板”行只显示当前选择，在该行按 Enter 即可打开列表。\n列表分为“内置”和“赞助商”两组；赞助商条目由社区赞助，选择前请自行确认服务条款。Codex 的 DeepSeek 属于内置分组。\n应用模板会按模板改写表单，并按模板名称重新生成供应商 ID；选择 Custom 则恢复为空白默认值。手动填写的 ID 一律不保留。其余已填内容有的会被重置（如备注、本地代理设置），有的会被保留（如其他鉴权方式下填过的 API Key、用量查询设置）——切换模板后请逐项检查，不要指望靠它清除密钥。\n如果没有合适模板，保留 Custom 后直接填写字段。",
+                "The list holds every available template: ↑/↓ to move, Enter to apply, Esc to close without changing anything. The Template field row shows only the current selection; press Enter on that row to open this list.\nThe list is grouped into Built-in and Sponsors; sponsor entries are community-sponsored presets, so review their terms yourself. Codex's DeepSeek belongs to the Built-in group.\nApplying a template rewrites the form for that template and regenerates the provider ID from its name; Custom instead restores the blank defaults. An ID you typed by hand never survives. Of everything else you already entered, some is reset (e.g. notes, local proxy settings) and some is kept (e.g. an API key typed under a different auth type, usage-query settings) — recheck the fields after switching, and do not rely on it to clear a secret.\nKeep Custom selected when no preset fits.",
             ),
         ),
         HelpTarget::ProviderField { app_type, field } => provider_field_help(app_type, field),
@@ -870,7 +876,10 @@ fn provider_field_help(app_type: AppType, field: ProviderAddField) -> HelpConten
         | ProviderAddField::CodexAdvancedDivider
         | ProviderAddField::HermesAdvancedDivider
         | ProviderAddField::CommonConfigDivider
-        | ProviderAddField::UsageQueryDivider => HelpContent::empty(),
+        | ProviderAddField::UsageQueryDivider
+        // Routed to `HelpTarget::ProviderTemplate` before reaching here.
+        | ProviderAddField::Template
+        | ProviderAddField::TemplateDivider => HelpContent::empty(),
     }
 }
 

--- a/src-tauri/src/cli/tui/ui/forms/provider.rs
+++ b/src-tauri/src/cli/tui/ui/forms/provider.rs
@@ -448,18 +448,11 @@ pub(crate) fn render_provider_add_form(
     frame.render_widget(outer.clone(), area);
     let inner = outer.inner(area);
 
-    let template_height = if matches!(provider.mode, super::form::FormMode::Add) {
-        3
-    } else {
-        0
-    };
+    // The template used to own a bordered row here; it is a field row inside
+    // the table now, so the body is just the key bar plus the fields/preview.
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),
-            Constraint::Length(template_height),
-            Constraint::Min(0),
-        ])
+        .constraints([Constraint::Length(1), Constraint::Min(0)])
         .split(inner);
 
     let fields = provider.fields();
@@ -483,18 +476,6 @@ pub(crate) fn render_provider_add_form(
         ),
     );
 
-    if matches!(provider.mode, super::form::FormMode::Add) {
-        let labels = provider.template_labels();
-        render_form_template_chips(
-            frame,
-            &labels,
-            provider.template_idx,
-            matches!(provider.focus, FormFocus::Templates),
-            chunks[1],
-            theme,
-        );
-    }
-
     let rows_data = fields
         .iter()
         .map(|field| provider_field_label_and_value(provider, *field))
@@ -510,24 +491,24 @@ pub(crate) fn render_provider_add_form(
         1,
     );
 
-    let split = form_can_split(chunks[2].width, label_col_width, theme);
+    let split = form_can_split(chunks[1].width, label_col_width, theme);
     let panes = split.then(|| {
         Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(58), Constraint::Percentage(42)])
-            .split(chunks[2])
+            .split(chunks[1])
     });
     let fields_area = if split {
         Some(panes.as_ref().expect("split panes")[0])
     } else if !matches!(provider.focus, FormFocus::JsonPreview) {
-        Some(chunks[2])
+        Some(chunks[1])
     } else {
         None
     };
     let preview_area = if split {
         Some(panes.as_ref().expect("split panes")[1])
     } else if matches!(provider.focus, FormFocus::JsonPreview) {
-        Some(chunks[2])
+        Some(chunks[1])
     } else {
         None
     };
@@ -598,6 +579,23 @@ fn render_provider_inline_fields(
                 ])
                 .style(Style::default().fg(theme.dim)),
             );
+            continue;
+        }
+
+        if matches!(*field, ProviderAddField::Template) {
+            let labels = provider.template_labels();
+            let spans = template_field_value_spans(
+                &labels,
+                provider.template_idx,
+                editor_active && idx == selected_idx,
+                value_width,
+                theme,
+            );
+            row_heights.push(1);
+            rows.push(Row::new(vec![
+                Cell::from(cell_pad(label)),
+                Cell::from(Line::from(spans)),
+            ]));
             continue;
         }
 
@@ -1962,6 +1960,8 @@ pub(crate) fn provider_field_label_and_value(
         ProviderAddField::IncludeCommonConfig => texts::tui_form_attach_common_config().to_string(),
         ProviderAddField::UsageQueryDivider => "- - - - - - - - -".to_string(),
         ProviderAddField::UsageQuery => texts::tui_config_item_usage_query().to_string(),
+        ProviderAddField::Template => texts::tui_label_provider_template().to_string(),
+        ProviderAddField::TemplateDivider => "- - - - - - - - -".to_string(),
     };
 
     let value = match field {
@@ -2101,6 +2101,15 @@ pub(crate) fn provider_field_label_and_value(
         ProviderAddField::CommonConfigDivider => "- - - - - - - - - -".to_string(),
         ProviderAddField::CommonSnippet => format!("{} ›", texts::tui_key_open()),
         ProviderAddField::UsageQueryDivider => String::new(),
+        ProviderAddField::TemplateDivider => String::new(),
+        // Plain-text fallback; the row itself renders chip-styled spans and
+        // this value only feeds column sizing and non-styled consumers.
+        ProviderAddField::Template => provider
+            .template_labels()
+            .get(provider.template_idx)
+            .copied()
+            .unwrap_or_default()
+            .to_string(),
         ProviderAddField::UsageQuery => {
             if provider.usage_query_enabled {
                 format!(
@@ -2190,7 +2199,8 @@ pub(crate) fn codex_local_routing_field_label_and_value(
 fn provider_field_is_divider(field: ProviderAddField) -> bool {
     matches!(
         field,
-        ProviderAddField::ClaudeAdvancedDivider
+        ProviderAddField::TemplateDivider
+            | ProviderAddField::ClaudeAdvancedDivider
             | ProviderAddField::CodexAdvancedDivider
             | ProviderAddField::HermesAdvancedDivider
             | ProviderAddField::CommonConfigDivider

--- a/src-tauri/src/cli/tui/ui/forms/shared.rs
+++ b/src-tauri/src/cli/tui/ui/forms/shared.rs
@@ -31,13 +31,12 @@ pub(crate) fn add_form_key_items(
     ];
 
     match focus {
-        FormFocus::Templates => keys.extend([
-            ("←→", texts::tui_key_select()),
-            ("Enter", texts::tui_key_apply()),
-        ]),
+        // The provider form never rests here; MCP owns the chip row.
+        FormFocus::Templates => {}
         FormFocus::Fields => {
             if !editing {
                 let enter_action = match selected_field {
+                    Some(ProviderAddField::Template) => texts::tui_key_select(),
                     Some(
                         ProviderAddField::ClaudeModelConfig
                         | ProviderAddField::ClaudeQuickConfig
@@ -233,6 +232,70 @@ pub(crate) fn usage_query_form_key_items(
     }
 
     keys
+}
+
+/// Chip-styled value spans for the provider form's Template field row.
+///
+/// The provider template list outgrew a flat chip row (built-ins plus ten
+/// sponsor presets overflow the terminal width and clip silently), so the row
+/// shows only the current selection and defers the list to the picker overlay.
+/// The label carries the meaning, so it wins the available width: the count
+/// hint is dropped first, then the `▾` indicator, and only then is the label
+/// truncated.
+pub(crate) fn template_field_value_spans(
+    labels: &[&str],
+    selected_idx: usize,
+    active: bool,
+    width: u16,
+    theme: &super::theme::Theme,
+) -> Vec<Span<'static>> {
+    if width == 0 {
+        return Vec::new();
+    }
+
+    let label = labels
+        .get(selected_idx.min(labels.len().saturating_sub(1)))
+        .copied()
+        .unwrap_or("");
+    let indicator = " ▾";
+    let count_hint = format!("  ({})", labels.len());
+
+    const CHIP_PADDING: usize = 2;
+    let width = width as usize;
+    let indicator_width = UnicodeWidthStr::width(indicator);
+    let count_width = UnicodeWidthStr::width(count_hint.as_str());
+    let chip_width = CHIP_PADDING.saturating_add(UnicodeWidthStr::width(label));
+
+    let show_count = chip_width
+        .saturating_add(indicator_width)
+        .saturating_add(count_width)
+        <= width;
+    let show_indicator = show_count || chip_width.saturating_add(indicator_width) <= width;
+
+    let mut label_budget = width.saturating_sub(CHIP_PADDING);
+    if show_indicator {
+        label_budget = label_budget.saturating_sub(indicator_width);
+    }
+    if show_count {
+        label_budget = label_budget.saturating_sub(count_width);
+    }
+    let label = truncate_to_display_width(label, label_budget.max(1) as u16);
+
+    let chip_style = if active {
+        active_chip_style(theme)
+    } else {
+        inactive_chip_style(theme)
+    };
+    let dim = Style::default().fg(theme.dim);
+    let mut spans = vec![Span::styled(format!(" {label} "), chip_style)];
+    if show_indicator {
+        spans.push(Span::styled(indicator.to_string(), dim));
+    }
+    if show_count {
+        spans.push(Span::styled(count_hint, dim));
+    }
+
+    truncate_spans_to_width(spans, width as u16)
 }
 
 pub(crate) fn render_form_template_chips(

--- a/src-tauri/src/cli/tui/ui/overlay/pickers.rs
+++ b/src-tauri/src/cli/tui/ui/overlay/pickers.rs
@@ -390,6 +390,97 @@ pub(super) fn render_usage_query_template_picker_overlay(
     frame.render_stateful_widget(list, body_area, &mut state);
 }
 
+const PROVIDER_TEMPLATE_PICKER_WIDTH: u16 = 40;
+
+pub(super) fn render_provider_template_picker_overlay(
+    frame: &mut Frame<'_>,
+    app: &App,
+    content_area: Rect,
+    theme: &theme::Theme,
+    selected: usize,
+) {
+    // Resolve everything before drawing: if the form is gone the handler will
+    // close this overlay on the next key, and painting an empty titled frame
+    // for that one tick just flashes chrome at the user.
+    let Some(FormState::ProviderAdd(provider)) = app.form.as_ref() else {
+        return;
+    };
+    let rows = provider.template_picker_rows();
+    if rows.is_empty() {
+        return;
+    }
+    let current = provider.template_idx;
+
+    let body_area = overlay_frame(
+        frame,
+        content_area,
+        theme,
+        texts::tui_provider_template_picker_title(),
+        &[
+            ("↑↓", texts::tui_key_select()),
+            ("Enter", texts::tui_key_apply()),
+            ("Esc", texts::tui_key_close()),
+        ],
+        OverlaySize::FitRows {
+            width: PROVIDER_TEMPLATE_PICKER_WIDTH,
+            body_rows: rows.len() as u16,
+        },
+        overlay_border_style(theme, false),
+    );
+
+    // A stale flat index must not park the highlight on a section header, so
+    // fall back to the first selectable row rather than display row 0.
+    let selected_row = form::provider_template_row_for_flat_idx(&rows, selected)
+        .or_else(|| rows.iter().position(|row| row.flat_idx().is_some()))
+        .unwrap_or(0);
+    let visible =
+        visible_selection_window(rows.len(), selected_row, body_area.height.max(1) as usize);
+    let visible_start = visible.start;
+    let items = visible
+        .filter_map(|idx| rows.get(idx))
+        .map(|row| match row {
+            form::ProviderTemplateRow::Header(section) => {
+                let title = match section {
+                    form::ProviderTemplateSection::BuiltIn => {
+                        texts::tui_provider_template_section_builtin()
+                    }
+                    form::ProviderTemplateSection::Sponsors => {
+                        texts::tui_provider_template_section_sponsors()
+                    }
+                };
+                ListItem::new(Line::styled(
+                    title.to_string(),
+                    Style::default().fg(theme.dim).add_modifier(Modifier::BOLD),
+                ))
+            }
+            form::ProviderTemplateRow::Item {
+                flat_idx,
+                label,
+                section,
+            } => {
+                let marker = if *flat_idx == current {
+                    texts::tui_marker_active()
+                } else {
+                    texts::tui_marker_inactive()
+                };
+                let style = match section {
+                    form::ProviderTemplateSection::Sponsors => Style::default().fg(theme.warn),
+                    form::ProviderTemplateSection::BuiltIn => Style::default(),
+                };
+                ListItem::new(Line::styled(format!("{marker}  {label}"), style))
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let list = List::new(items)
+        .highlight_style(selection_style(theme))
+        .highlight_symbol(highlight_symbol(theme));
+
+    let mut state = ListState::default();
+    state.select(Some(selected_row.saturating_sub(visible_start)));
+    frame.render_stateful_widget(list, body_area, &mut state);
+}
+
 pub(super) fn render_s3_preset_picker_overlay(
     frame: &mut Frame<'_>,
     app: &App,

--- a/src-tauri/src/cli/tui/ui/overlay/render.rs
+++ b/src-tauri/src/cli/tui/ui/overlay/render.rs
@@ -109,6 +109,15 @@ pub(crate) fn render_overlay(
                 *selected,
             )
         }
+        Overlay::ProviderTemplatePicker { selected } => {
+            super::pickers::render_provider_template_picker_overlay(
+                frame,
+                app,
+                content_area,
+                theme,
+                *selected,
+            )
+        }
         Overlay::S3PresetPicker { selected } => super::pickers::render_s3_preset_picker_overlay(
             frame,
             app,

--- a/src-tauri/src/cli/tui/ui/tests.rs
+++ b/src-tauri/src/cli/tui/ui/tests.rs
@@ -4012,10 +4012,14 @@ fn installed_skill(directory: &str, name: &str) -> InstalledSkill {
     }
 }
 
+/// The template is a field row inside the Fields table now: it shows only the
+/// current selection (the full list used to overflow the terminal width and
+/// clip silently) and defers the list to the picker overlay.
 #[test]
-fn add_form_template_chips_are_single_row() {
+fn add_form_template_row_shows_only_the_current_selection() {
     let _lock = lock_env();
     let _no_color = EnvGuard::remove("NO_COLOR");
+    let _lang = use_test_language(Language::English);
 
     let mut app = App::new(Some(AppType::Claude));
     app.route = Route::Providers;
@@ -4023,24 +4027,221 @@ fn add_form_template_chips_are_single_row() {
     app.form = Some(crate::cli::tui::form::FormState::ProviderAdd(
         crate::cli::tui::form::ProviderAddFormState::new(AppType::Claude),
     ));
+    let total = match app.form.as_ref() {
+        Some(FormState::ProviderAdd(form)) => form.template_labels().len(),
+        _ => panic!("expected provider form"),
+    };
 
     let data = minimal_data(&app.app_type);
     let buf = render(&app, &data);
 
-    let mut chips_y = None;
-    for y in 0..buf.area.height {
-        let line = line_at(&buf, y);
-        if line.contains("Custom") && line.contains("Claude Official") {
-            chips_y = Some(y);
-            break;
-        }
-    }
-
-    let chips_y = chips_y.expect("template chips row missing from add form");
-    let next = line_at(&buf, chips_y + 1);
+    let row = (0..buf.area.height)
+        .map(|y| line_at(&buf, y))
+        .find(|line| line.contains("Custom"))
+        .expect("template field row missing from add form");
     assert!(
-        next.contains('└'),
-        "expected template block border after chips, got: {next}"
+        row.contains(texts::tui_label_provider_template()),
+        "the row must carry the singular Template label, got: {row}"
+    );
+    assert!(
+        !row.contains(texts::tui_form_templates_title()),
+        "the field row is singular; the plural title belongs to the MCP chips box: {row}"
+    );
+    assert!(row.contains('▾'), "expected picker indicator, got: {row}");
+    assert!(
+        row.contains(&format!("({total})")),
+        "expected total template count, got: {row}"
+    );
+    assert!(
+        !row.contains("Claude Official") && !row.contains("PackyCode"),
+        "non-selected templates must not be rendered inline, got: {row}"
+    );
+
+    // With a sponsor selected the row must agree with the picker and drop the
+    // chip marker rather than showing "* PackyCode".
+    let mut form = crate::cli::tui::form::ProviderAddFormState::new(AppType::Claude);
+    let sponsor_idx = form
+        .template_labels()
+        .iter()
+        .position(|label| *label == "PackyCode")
+        .expect("PackyCode sponsor template");
+    form.template_idx = sponsor_idx;
+    app.form = Some(crate::cli::tui::form::FormState::ProviderAdd(form));
+
+    let buf = render(&app, &data);
+    let row = (0..buf.area.height)
+        .map(|y| line_at(&buf, y))
+        .find(|line| line.contains("PackyCode"))
+        .expect("template row should show the selected sponsor");
+    assert!(
+        !row.contains("* PackyCode"),
+        "the template row must strip the sponsor chip marker, got: {row}"
+    );
+}
+
+/// Edit mode has no template row: templates only make sense when creating.
+#[test]
+fn edit_form_has_no_template_field_row() {
+    let _lock = lock_env();
+    let _no_color = EnvGuard::remove("NO_COLOR");
+    let _lang = use_test_language(Language::English);
+
+    let provider = crate::provider::Provider::with_id(
+        "p1".to_string(),
+        "Provider One".to_string(),
+        json!({}),
+        None,
+    );
+    let form =
+        crate::cli::tui::form::ProviderAddFormState::from_provider(AppType::Claude, &provider);
+    assert!(
+        !form
+            .fields()
+            .contains(&crate::cli::tui::form::ProviderAddField::Template),
+        "edit mode must not expose the template field"
+    );
+
+    let mut app = App::new(Some(AppType::Claude));
+    app.route = Route::Providers;
+    app.focus = Focus::Content;
+    app.form = Some(crate::cli::tui::form::FormState::ProviderAdd(form));
+
+    let data = minimal_data(&app.app_type);
+    let buf = render(&app, &data);
+    let screen = (0..buf.area.height)
+        .map(|y| line_at(&buf, y))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !screen.contains('▾'),
+        "edit mode must not render the template picker indicator: {screen}"
+    );
+}
+
+#[test]
+fn provider_template_picker_overlay_groups_builtins_and_sponsors() {
+    let _lock = lock_env();
+    let _no_color = EnvGuard::remove("NO_COLOR");
+    let _lang = use_test_language(Language::English);
+
+    let mut app = App::new(Some(AppType::Claude));
+    app.route = Route::Providers;
+    app.focus = Focus::Content;
+    app.form = Some(crate::cli::tui::form::FormState::ProviderAdd(
+        crate::cli::tui::form::ProviderAddFormState::new(AppType::Claude),
+    ));
+    app.overlay = Overlay::ProviderTemplatePicker { selected: 0 };
+
+    let data = minimal_data(&app.app_type);
+    let buf = render(&app, &data);
+    let screen = (0..buf.area.height)
+        .map(|y| line_at(&buf, y))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(screen.contains("Built-in"), "{screen}");
+    assert!(screen.contains("Sponsors"), "{screen}");
+    assert!(screen.contains("Claude Official"), "{screen}");
+    assert!(screen.contains("PackyCode"), "{screen}");
+    assert!(
+        !screen.contains("* PackyCode"),
+        "sponsor rows drop the chip marker under the Sponsors header: {screen}"
+    );
+}
+
+/// In a short terminal the picker cannot show every row, so the scroll window
+/// must follow the selection instead of pinning row 0.
+#[test]
+fn provider_template_picker_overlay_scrolls_selection_into_view() {
+    let _lock = lock_env();
+    let _no_color = EnvGuard::remove("NO_COLOR");
+    let _lang = use_test_language(Language::English);
+
+    let mut app = App::new(Some(AppType::Claude));
+    app.route = Route::Providers;
+    app.focus = Focus::Content;
+    let form = crate::cli::tui::form::ProviderAddFormState::new(AppType::Claude);
+    let labels = form.template_labels();
+    let last_flat = labels.len() - 1;
+    let last_label = labels[last_flat].to_string();
+    app.form = Some(crate::cli::tui::form::FormState::ProviderAdd(form));
+    app.overlay = Overlay::ProviderTemplatePicker {
+        selected: last_flat,
+    };
+
+    let data = minimal_data(&app.app_type);
+    let buf = render_with_size(&app, &data, 100, 13);
+    let screen = (0..buf.area.height)
+        .map(|y| line_at(&buf, y))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        screen.contains(&last_label),
+        "last sponsor ({last_label}) must scroll into view in a short terminal: {screen}"
+    );
+    // Proof the viewport is actually constrained: the first row scrolled off.
+    assert!(
+        !screen.contains("Built-in"),
+        "expected the top of the list to scroll away: {screen}"
+    );
+}
+
+/// Narrow widths must keep the label readable: the count hint is dropped
+/// first, then the ▾ indicator, and only then is the label truncated.
+#[test]
+fn add_form_template_row_prefers_the_label_over_decorations_when_narrow() {
+    let _lock = lock_env();
+    let _no_color = EnvGuard::remove("NO_COLOR");
+
+    // 12 labels, so the hint is "  (12)" (6 cols) and the indicator " ▾" (2).
+    let labels = crate::cli::tui::form::ProviderAddFormState::new(AppType::Claude)
+        .template_labels()
+        .len();
+    let hint = format!("({labels})");
+    let label = "Claude Official"; // 15 columns
+    let all_labels = vec![label; labels];
+    let theme = theme_for(&AppType::Claude);
+
+    // `width` is the value column's width.
+    let row_at = |width: u16| -> String {
+        super::template_field_value_spans(&all_labels, 0, true, width, &theme)
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>()
+    };
+
+    // Everything fits: label + indicator + count.
+    let roomy = row_at(2 + 15 + 2 + 6);
+    assert!(roomy.contains(label), "{roomy}");
+    assert!(roomy.contains('▾'), "{roomy}");
+    assert!(roomy.contains(&hint), "{roomy}");
+
+    // One column short of the count hint: drop the hint, keep label + ▾.
+    let no_count = row_at(2 + 15 + 2 + 5);
+    assert!(
+        no_count.contains(label),
+        "the full label must survive before decorations: {no_count}"
+    );
+    assert!(no_count.contains('▾'), "{no_count}");
+    assert!(!no_count.contains(&hint), "{no_count}");
+
+    // One column short of the indicator: drop it too, keep the full label.
+    let label_only = row_at(2 + 15 + 1);
+    assert!(
+        label_only.contains(label),
+        "the full label must survive before decorations: {label_only}"
+    );
+    assert!(!label_only.contains('▾'), "{label_only}");
+    assert!(!label_only.contains(&hint), "{label_only}");
+
+    // Genuinely too narrow: the label truncates, but with the decorations
+    // already gone it still shows a meaningful prefix rather than 1-3 columns.
+    let tight = row_at(2 + 10);
+    assert!(!tight.contains('▾'), "{tight}");
+    assert!(
+        tight.contains("Claude"),
+        "a meaningful label prefix must remain: {tight}"
     );
 }
 
@@ -12366,6 +12567,20 @@ fn provider_form_model_field_hints_enter_edit_and_f_fetch() {
             .find(|(key, _label)| *key == "f")
             .map(|(_key, label)| *label),
         Some(texts::tui_key_fetch_model())
+    );
+}
+
+#[test]
+fn provider_template_field_key_bar_advertises_select() {
+    let _lang = use_test_language(Language::English);
+    let keys =
+        super::add_form_key_items(FormFocus::Fields, false, Some(ProviderAddField::Template));
+    assert_eq!(
+        keys.iter()
+            .find(|(key, _label)| *key == "Enter")
+            .map(|(_key, label)| *label),
+        Some(texts::tui_key_select()),
+        "{keys:?}"
     );
 }
 


### PR DESCRIPTION
Closes #416. Thanks @LeonardoTan19 for the report and the offer to help — this ended up as a UX redesign rather than a scroll fix, details below.

## Problem

The provider Add form rendered every template as one horizontal chip row. With 3 built-ins + 10 sponsor presets (~135 columns), the row overflows any realistic terminal width, and the overflow was silently clipped: the selected chip — and the sponsor entries — could become invisible and unreachable.

## Approach

Instead of adding horizontal scrolling (which would keep most sponsors hidden behind the fold), template selection now follows the same pattern the Usage Query page already uses — a field whose Enter opens a picker:

- **Template is a regular field** at the top of the Fields table: chip-styled current selection + dim `▾ (N)` count, followed by a divider. Label-first degradation at narrow widths (count dropped first, then the caret, then the label truncates). Nothing can overflow horizontally anymore.
- **Enter opens a grouped vertical picker** (`ProviderTemplatePicker`): Built-in / Sponsors sections (Codex's DeepSeek stays under Built-in), ↑/↓ skip section headers, selection kept in view via the shared scroll window on short terminals.
- **Apply semantics unchanged**: `apply_template` with existing provider ids (id de-confliction covered by a test), common-snippet quick-config refresh, warning toast on failure — then the cursor lands on the first real field. Esc changes nothing, including typed API keys and usage-query settings.
- **Simpler focus model**: the dedicated Templates pane and focus stop are gone; Tab cycles Fields ↔ JSON preview (Codex: Fields → Auth preview → Config preview). The MCP form and the CLI chooser are untouched.
- **Copy-provider flow** opens on the first real field instead of the template row, so copied values are not one accidental Enter-Enter away from being reset.
- **`?` help rewritten** (EN + ZH) to document the picker keys, the sponsor grouping, and — precisely — what applying a template does and does not reset (it deliberately avoids over-promising: some previously typed values survive a template switch, so the help now says not to rely on templates to clear secrets).

## Screenshot-able flow

`Providers → a` → first row is `Template  [ Custom ] ▾ (13)` → Enter opens the grouped list → pick → cursor lands on Name.

## Validation

- `cargo fmt --check` clean; no new clippy warnings in touched files.
- `cli::tui` suite: 1799 passed (≈20 new behavior tests: no-apply-on-open, header skipping incl. Codex display-order divergence, id de-confliction, Esc purity with typed secrets, warning-toast path, scroll-into-view at 100×13, narrow-width degradation ladder, copy-flow initial focus, help routing). Full-suite failures are byte-identical to the pre-change baseline on this machine (pre-existing umask/sandbox failures, none in `cli::tui`).
- Change went through multiple rounds of independent blind review (correctness, regression, security, UX, i18n accuracy, test quality) until convergence; the `?` help text was additionally fact-checked claim-by-claim against `apply_template`.

Note: `cargo clippy` currently cannot exit clean on `main` due to a pre-existing `reversed_empty_ranges` deny error in `src/cli/tui/ui/home_chart.rs:806` (untouched here) — worth a separate small fix.
