### PR TITLE
docs: add Related Projects section (ccse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,11 @@ src-tauri/src/
 ```
 
 
+## 🔗 Related Projects
+
+- [cc-switch-enhanced (ccse)](https://github.com/Tonystarkw12/cc-switch-enhanced) — A fleet-wide model switcher for AI coding agents, complementary to CC-Switch CLI's deep per-app management. Where CC-Switch CLI manages 7 apps in depth (provider switching, proxy, usage stats), `ccse` takes a lightweight cross-agent approach: one command rewrites model / base URL / API key across 37 coding agents at once, with endpoint verification, automatic snapshots and one-key rollback. Handy when running many agents side by side against aggregator APIs (NewAPI / omniroute / mirrors).
+
+
 ## 🤝 Contributing
 
 Contributions welcome! This fork focuses on CLI functionality.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -737,6 +737,11 @@ src-tauri/src/
 ```
 
 
+## 🔗 相关项目
+
+- [cc-switch-enhanced (ccse)](https://github.com/Tonystarkw12/cc-switch-enhanced) —— 面向 AI 编程助手的"机队级"模型切换器，与 CC-Switch CLI 的单应用深度管理互补。CC-Switch CLI 深度管理 7 个应用（供应商切换、代理、用量统计），ccse 则走轻量跨助手路线：一行命令同时改写 37 个编程助手的模型 / 中转地址 / API key，自带端点校验、自动快照与一键回滚。适合多个助手并行接聚合 API（NewAPI / omniroute / 镜像站）的场景。
+
+
 ## 🤝 贡献
 
 欢迎贡献！本分支专注于 CLI 功能。


### PR DESCRIPTION
## What

Adds a small bilingual **Related Projects / 相关项目** section to both READMEs (before Contributing), listing [cc-switch-enhanced (ccse)](https://github.com/Tonystarkw12/cc-switch-enhanced).

## Why

ccse is a lightweight, fleet-wide model switcher for AI coding agents: one command rewrites model / base URL / API key across 37 coding agents, with endpoint verification, automatic snapshots and one-key rollback.

The positioning is complementary rather than competing — CC-Switch CLI does deep per-app management (provider switching, proxy, usage stats) for 7 apps, while ccse covers breadth (37 agents) for users who run many agents side by side against aggregator APIs. I'm the author of ccse; happy to adjust wording, drop the badge-style claims, or close this if a related-projects section isn't wanted here.

## Notes

- Diff is intentionally minimal: 2 files, +10 lines, docs only — no code changes, no CI impact.
- I saw the "open an issue for discussion first" note in Contributing; given the tiny, easily-reversible scope I submitted the PR directly — glad to move to an issue if preferred.
