### PR TITLE
feat(start): share Codex sessions across isolated providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ cc-switch provider export <id>       # Export a Claude provider to a standalone 
 cc-switch provider stream-check <id> # Check provider stream health
 cc-switch start claude <id>          # Launch Claude with this provider without switching globally
 cc-switch start codex <id>           # Launch Codex with this provider without switching globally
+cc-switch start codex <id> --shared-sessions # Share persistent Codex history across providers
 cc-switch start claude <id> --dry-run # Preview the launch without starting Claude
 cc-switch auth list                  # List managed ChatGPT/Codex OAuth accounts
 cc-switch sessions list --all        # Review saved assistant sessions
@@ -189,6 +190,10 @@ cc-switch --app pi provider list        # Manage Pi providers
 ```
 
 Use `cc-switch start` when you want different providers in multiple terminals. It only affects the Claude or Codex session launched by that command; `provider switch` and `use` still change the global provider. In the TUI, select a provider on the Providers page and press `o` for the same behavior.
+
+On macOS/Linux, add `--shared-sessions` to `start codex` to share the configured Codex home's sessions, archived sessions, and SQLite history index. Each provider uses a persistent, private directory under that home's `.cc-switch-launches/`; these directories must remain in place because Codex records session paths through them. Different providers can run concurrently; a second shared launch of the same provider is rejected while the first is running. Codex's per-thread writer locks are shared too, so close an active session before resuming it from another provider. Login changes are saved back to that provider, while launch-specific configuration is kept out of the saved provider settings. Native `--model`, `resume`, and `fork` arguments are supported; `--config`, `--profile`, and `--oss` overrides are not supported in shared mode.
+
+Shared launches use the existing unified `custom` provider identifier without changing the global history setting. To include older official sessions, use the existing **Unified Codex session history** setting and its optional migration. Cross-provider continuation still depends on the upstream accepting the old conversation's content, including encrypted reasoning. The default temporary launch and the TUI `o` shortcut remain unchanged.
 
 See the "Features" section for full command list.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -167,6 +167,7 @@ cc-switch provider export <id>       # 导出 Claude 供应商为独立 settings
 cc-switch provider stream-check <id> # 检查供应商流式健康
 cc-switch start claude <id>          # 用指定供应商启动 Claude，不切换全局供应商
 cc-switch start codex <id>           # 用指定供应商启动 Codex，不切换全局供应商
+cc-switch start codex <id> --shared-sessions # 不同供应商共享持久化 Codex 历史
 cc-switch start claude <id> --dry-run # 仅预览启动配置
 cc-switch auth list                  # 查看托管的 ChatGPT/Codex OAuth 账号
 cc-switch sessions list --all        # 查看历史会话
@@ -188,6 +189,10 @@ cc-switch --app pi provider list        # 管理 Pi 供应商
 ```
 
 需要在多个终端同时使用不同供应商时，请使用 `cc-switch start`。它只影响由该命令启动的 Claude 或 Codex 会话；`provider switch` 和 `use` 仍会切换全局供应商。在 TUI 的供应商页选中供应商后按 `o`，效果相同。
+
+在 macOS/Linux 上，为 `start codex` 添加 `--shared-sessions`，即可共享当前配置的 Codex 目录中的会话、归档会话和 SQLite 历史索引。各供应商使用该目录下 `.cc-switch-launches/` 中独立、持久化的私有目录；Codex 会通过这些目录记录会话路径，因此请保留它们。不同供应商可以并行运行；同一供应商已有共享实例运行时，会拒绝第二次共享启动。原生 Codex 的会话写锁也会共享，因此切换供应商继续同一会话前，请先退出原会话。登录变更会回写到对应供应商，启动专用配置不会写回供应商设置。支持透传 `--model`、`resume` 和 `fork`；共享模式不支持 `--config`、`--profile` 和 `--oss` 覆盖。
+
+共享启动复用已有的统一 `custom` 供应商标识，不改变全局历史设置。若需纳入旧的官方会话，请使用现有的「统一 Codex 会话历史」设置及其可选迁移。跨供应商继续对话仍取决于上游能否接受原会话内容，包括加密推理内容。默认临时启动和 TUI 的 `o` 快捷键保持原有行为。
 
 完整命令列表请参考「功能特性」章节。
 

--- a/src-tauri/src/cli/codex_shared_launch.rs
+++ b/src-tauri/src/cli/codex_shared_launch.rs
@@ -1,0 +1,489 @@
+//! Opt-in shared history for `start codex`; the ordinary temporary launch is unchanged.
+
+use std::ffi::OsString;
+use std::fs::{self, File, OpenOptions};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{symlink, DirBuilderExt, OpenOptionsExt};
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use sha2::{Digest, Sha256};
+use toml_edit::{value, DocumentMut};
+
+use super::codex_temp_launch::{preview_launch_with, resolve_codex_binary, PreparedCodexLaunch};
+use crate::codex_config::{get_codex_config_dir, inject_codex_unified_session_bucket};
+use crate::config::atomic_write_private;
+use crate::error::AppError;
+use crate::provider::Provider;
+
+pub(super) fn launch(
+    provider: &Provider,
+    native_args: &[OsString],
+    dry_run: bool,
+) -> Result<(), AppError> {
+    // These overrides can select a different provider or storage directory.
+    // Other native arguments (including resume/fork and --model) pass through.
+    if native_args.iter().any(|arg| {
+        let arg = arg.to_string_lossy();
+        arg == "--oss"
+            || arg == "--config"
+            || arg.starts_with("--config=")
+            || arg.starts_with("-c") && !arg.starts_with("--")
+            || arg == "--profile"
+            || arg.starts_with("--profile=")
+            || arg.starts_with("-p") && !arg.starts_with("--")
+    }) {
+        return Err(AppError::Config(crate::t!(
+            "--shared-sessions manages provider and storage settings; native --config, --profile and --oss overrides are not supported.",
+            "--shared-sessions 管理供应商与存储设置，不支持透传 --config、--profile 或 --oss 覆盖。"
+        ).to_string()));
+    }
+    let source = std::path::absolute(get_codex_config_dir())
+        .map_err(|err| AppError::Config(err.to_string()))?;
+    let mut prepared = preview_launch_with(provider, &std::env::temp_dir(), resolve_codex_binary)?;
+    let source_config = crate::codex_config::read_codex_config_text()?;
+    let sqlite_paths = crate::codex_state_db::codex_state_db_paths(&source, &source_config);
+    let sqlite_home = sqlite_paths.last().unwrap().parent().unwrap();
+    // Config paths are relative to config.toml; environment paths use the cwd.
+    let config_has_sqlite_home = source_config
+        .parse::<DocumentMut>()
+        .ok()
+        .is_some_and(|doc| {
+            doc.get("sqlite_home")
+                .and_then(|item| item.as_str())
+                .is_some_and(|path| !path.trim().is_empty())
+        });
+    let sqlite_home = std::path::absolute(if config_has_sqlite_home {
+        source.join(sqlite_home)
+    } else {
+        sqlite_home.to_path_buf()
+    })
+    .map_err(|err| AppError::Config(err.to_string()))?;
+    let config = shared_config(provider, &sqlite_home)?;
+    prepared.codex_home = provider_home(&source, &provider.id);
+    if dry_run {
+        println!("CODEX_HOME={}", prepared.codex_home.display());
+        println!(
+            "{} {}",
+            crate::t!("Shared history:", "共享历史："),
+            source.display()
+        );
+        println!(
+            "{}",
+            crate::t!(
+                "Dry run; no launch files were written.",
+                "仅预览，未写入启动文件。"
+            )
+        );
+        return Ok(());
+    }
+
+    let _lock = prepare_home(&prepared.codex_home, &source, provider, &config)?;
+    // Codex inherits the lock so killing only the supervisor cannot expose an
+    // active home. After native exit/capture, explicitly unlock the shared file
+    // description so surviving background children cannot retain a stale lock.
+    let fd = _lock.as_raw_fd();
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } < 0 {
+        return Err(AppError::io(
+            &prepared.codex_home,
+            std::io::Error::last_os_error(),
+        ));
+    }
+    let err = handoff_command(&prepared, &sqlite_home, fd, native_args).exec();
+    Err(AppError::Config(format!("Failed to launch Codex: {err}")))
+}
+
+fn provider_home(source: &Path, provider_id: &str) -> PathBuf {
+    source
+        .join(".cc-switch-launches")
+        .join(format!("{:x}", Sha256::digest(provider_id.as_bytes())))
+}
+
+fn shared_config(provider: &Provider, sqlite_home: &Path) -> Result<String, AppError> {
+    let text = provider
+        .settings_config
+        .get("config")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let mut doc = text
+        .parse::<DocumentMut>()
+        .map_err(|err| AppError::Config(err.to_string()))?;
+    let profile = doc
+        .get("profile")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let selected = profile
+        .as_deref()
+        .and_then(|name| doc.get("profiles")?.get(name)?.get("model_provider"))
+        .or_else(|| doc.get("model_provider"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("openai")
+        .to_string();
+    let existing = doc
+        .get("model_providers")
+        .and_then(|v| v.get(&selected))
+        .cloned();
+    let route = if selected == "openai" {
+        // Reuse the same official-auth route as the existing unified-history setting.
+        let official = inject_codex_unified_session_bucket("")?
+            .parse::<DocumentMut>()
+            .map_err(|err| AppError::Config(err.to_string()))?;
+        let mut route = official["model_providers"]["custom"].clone();
+        // Codex's built-in openai route ignores model_providers.openai and uses
+        // the top-level endpoint override instead. Keep that endpoint on custom.
+        if let Some(url) = doc
+            .get("openai_base_url")
+            .and_then(|item| item.as_str())
+            .filter(|url| !url.is_empty())
+        {
+            route["base_url"] = value(url);
+        }
+        route
+    } else {
+        existing.filter(|v| v.is_table_like()).ok_or_else(|| {
+            AppError::Config(format!(
+                "--shared-sessions requires a configured model_providers.{selected} table"
+            ))
+        })?
+    };
+    // Values work with both regular and inline model_providers tables.
+    doc["model_providers"]["custom"] = toml_edit::Item::Value(
+        route
+            .into_value()
+            .map_err(|_| AppError::Config("Invalid Codex provider table".into()))?,
+    );
+    doc["model_provider"] = value("custom");
+    if let Some(profile) = profile {
+        if doc.get("profiles").and_then(|v| v.get(&profile)).is_some() {
+            doc["profiles"][&profile]["model_provider"] = value("custom");
+        }
+    }
+    doc["sqlite_home"] = value(sqlite_home.to_string_lossy().as_ref());
+    doc["cli_auth_credentials_store"] = value("file");
+    Ok(doc.to_string())
+}
+
+fn private_dir(path: &Path) -> Result<(), AppError> {
+    match fs::DirBuilder::new().mode(0o700).create(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            let metadata = fs::symlink_metadata(path).map_err(|err| AppError::io(path, err))?;
+            if metadata.is_dir() {
+                Ok(())
+            } else {
+                Err(AppError::Config(format!(
+                    "Expected a directory, not a symlink or file: {}",
+                    path.display()
+                )))
+            }
+        }
+        Err(err) => Err(AppError::io(path, err)),
+    }
+}
+
+fn prepare_home(
+    home: &Path,
+    source: &Path,
+    provider: &Provider,
+    config: &str,
+) -> Result<File, AppError> {
+    fs::create_dir_all(source).map_err(|err| AppError::io(source, err))?;
+    private_dir(home.parent().unwrap())?;
+    private_dir(home)?;
+    let lock_path = home.join(".lock");
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(&lock_path)
+        .map_err(|err| AppError::io(&lock_path, err))?;
+    if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        let err = std::io::Error::last_os_error();
+        if err.kind() == std::io::ErrorKind::WouldBlock {
+            return Err(AppError::Config(
+                crate::t!(
+                    "This provider already has an active --shared-sessions launch.",
+                    "此供应商已有一个正在运行的 --shared-sessions 实例。"
+                )
+                .to_string(),
+            ));
+        }
+        return Err(AppError::io(&lock_path, err));
+    }
+    let source = source
+        .canonicalize()
+        .map_err(|err| AppError::io(source, err))?;
+    // SQLite supplies the shared resume/title index. Codex atomically replaces
+    // session_index.jsonl on deletion, so that local cache must not be a symlink.
+    for (name, directory) in [
+        ("sessions", true),
+        ("archived_sessions", true),
+        ("thread-writer-locks", true),
+        ("rollout-migrations", true),
+        (".tmp/rollout-maintenance.lock", false),
+    ] {
+        let target = source.join(name);
+        if directory {
+            fs::create_dir_all(&target).map_err(|err| AppError::io(&target, err))?;
+        } else {
+            private_dir(&home.join(".tmp"))?;
+            fs::create_dir_all(target.parent().unwrap())
+                .map_err(|err| AppError::io(&target, err))?;
+            OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .mode(0o600)
+                .open(&target)
+                .map_err(|err| AppError::io(&target, err))?;
+        }
+        let link = home.join(name);
+        match symlink(&target, &link) {
+            Ok(()) => (),
+            Err(err)
+                if err.kind() == std::io::ErrorKind::AlreadyExists
+                    && fs::read_link(&link).ok().as_ref() == Some(&target) => {}
+            Err(err) => return Err(AppError::io(&link, err)),
+        }
+    }
+    atomic_write_private(&home.join("config.toml"), config.as_bytes())?;
+    let auth_path = home.join("auth.json");
+    let auth = provider
+        .settings_config
+        .get("auth")
+        .filter(|auth| auth.as_object().is_some_and(|v| !v.is_empty()))
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
+    let auth_source_path = home.join(".auth-source");
+    let auth_source = format!("{:x}", Sha256::digest(auth.to_string().as_bytes()));
+    // The DB is the source for explicit credential edits. If it is unchanged,
+    // keep Codex's local refresh/logout, including after an untrappable exit.
+    if fs::read_to_string(&auth_source_path).ok().as_deref() == Some(&auth_source) {
+        return Ok(lock);
+    }
+    if auth.as_object().is_some_and(|auth| !auth.is_empty()) {
+        let bytes = serde_json::to_vec_pretty(&auth)
+            .map_err(|source| AppError::JsonSerialize { source })?;
+        atomic_write_private(&auth_path, &bytes)?;
+    } else {
+        match fs::remove_file(&auth_path) {
+            Ok(()) => (),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => (),
+            Err(err) => return Err(AppError::io(&auth_path, err)),
+        }
+    }
+    atomic_write_private(&auth_source_path, auth_source.as_bytes())?;
+    Ok(lock)
+}
+
+fn handoff_command(
+    prepared: &PreparedCodexLaunch,
+    sqlite_home: &Path,
+    lock_fd: i32,
+    native_args: &[OsString],
+) -> Command {
+    let mut command = Command::new("/bin/sh");
+    command.arg("-c").arg(
+        "provider_id=\"$1\"; export CODEX_HOME=\"$2\"; codex_bin=\"$3\"; cc_switch_bin=\"$4\"; lock_fd=\"$5\"; shift 5; persist() { \"$cc_switch_bin\" internal capture-codex-temp \"$provider_id\" \"$CODEX_HOME\" --auth-only; persist_status=$?; if [ \"$persist_status\" -ne 0 ]; then printf '%s\\n' 'cc-switch: failed to persist Codex login state' >&2; if [ \"$exit_status\" -eq 0 ]; then exit_status=$persist_status; fi; fi; \"$cc_switch_bin\" internal release-codex-lock \"$lock_fd\"; }; on_signal() { exit_status=\"$1\"; trap - INT TERM HUP; persist; exit \"$exit_status\"; }; trap 'on_signal 130' INT; trap 'on_signal 143' TERM; trap 'on_signal 129' HUP; \"$codex_bin\" \"$@\"; exit_status=$?; persist; exit \"$exit_status\""
+    );
+    command
+        .arg("cc-switch-codex-shared-handoff")
+        .arg(&prepared.provider_id)
+        .arg(&prepared.codex_home)
+        .arg(&prepared.executable)
+        .arg(&prepared.cc_switch_executable)
+        .arg(lock_fd.to_string())
+        // Native resume otherwise restores the provider saved in the old thread.
+        // An explicit CLI override keeps the provider selected for this launch.
+        .args(["--config", "model_provider=\"custom\""])
+        .args(["--config", "cli_auth_credentials_store=\"file\""])
+        .arg("--config")
+        .arg(format!(
+            "sqlite_home={}",
+            toml_edit::Value::from(sqlite_home.to_string_lossy().as_ref())
+        ))
+        .args(native_args);
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestEnvGuard;
+    use serde_json::json;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    fn provider(id: &str, config: &str) -> Provider {
+        Provider::with_id(
+            id.into(),
+            id.into(),
+            json!({
+                "config": config, "auth": {"OPENAI_API_KEY": format!("key-{id}")}
+            }),
+            None,
+        )
+    }
+
+    #[test]
+    fn shared_config_preserves_selected_endpoint_and_original_settings() {
+        let original = "model_provider = 'relay'\nmodel = 'demo'\n[model_providers.relay]\nname = 'Relay'\nbase_url = 'https://relay.invalid/v1'\nexperimental_bearer_token = 'private-token'\nwire_api = 'responses'\n";
+        let provider = provider("relay", original);
+        let config = shared_config(&provider, Path::new("/shared/sqlite")).unwrap();
+        let doc = config.parse::<DocumentMut>().unwrap();
+        assert_eq!(doc["model_provider"].as_str(), Some("custom"));
+        assert_eq!(
+            doc["model_providers"]["custom"]["base_url"].as_str(),
+            Some("https://relay.invalid/v1")
+        );
+        assert_eq!(
+            doc["model_providers"]["custom"]["experimental_bearer_token"].as_str(),
+            Some("private-token")
+        );
+        assert_eq!(doc["sqlite_home"].as_str(), Some("/shared/sqlite"));
+        assert_eq!(doc["cli_auth_credentials_store"].as_str(), Some("file"));
+        assert_eq!(provider.settings_config["config"], original);
+    }
+
+    #[test]
+    fn shared_config_reuses_official_route_and_selected_config_profile() {
+        for config in ["", "model_provider = 'openai'\n"] {
+            let doc = shared_config(&provider("official", config), Path::new("/shared"))
+                .unwrap()
+                .parse::<DocumentMut>()
+                .unwrap();
+            assert_eq!(doc["model_provider"].as_str(), Some("custom"));
+            assert_eq!(
+                doc["model_providers"]["custom"]["requires_openai_auth"].as_bool(),
+                Some(true)
+            );
+        }
+        let config = "openai_base_url = 'http://localhost:4321/v1'\n[model_providers.openai]\nname = 'Ignored by native Codex'\nbase_url = 'https://unused.invalid'\n";
+        let doc = shared_config(&provider("official", config), Path::new("/shared"))
+            .unwrap()
+            .parse::<DocumentMut>()
+            .unwrap();
+        assert_eq!(
+            doc["model_providers"]["custom"]["base_url"].as_str(),
+            Some("http://localhost:4321/v1")
+        );
+        let config = "profile = 'work'\n[profiles.work]\nmodel_provider = 'relay'\nmodel = 'work-model'\n[model_providers.relay]\nname = 'Relay'\nbase_url = 'https://relay.invalid'\n";
+        let doc = shared_config(&provider("profile", config), Path::new("/shared"))
+            .unwrap()
+            .parse::<DocumentMut>()
+            .unwrap();
+        assert_eq!(
+            doc["profiles"]["work"]["model_provider"].as_str(),
+            Some("custom")
+        );
+        assert_eq!(
+            doc["profiles"]["work"]["model"].as_str(),
+            Some("work-model")
+        );
+        assert_eq!(
+            doc["model_providers"]["custom"]["base_url"].as_str(),
+            Some("https://relay.invalid")
+        );
+    }
+
+    #[test]
+    fn shared_homes_keep_history_paths_and_isolate_credentials() {
+        let temp = TempDir::new().unwrap();
+        let _env = TestEnvGuard::isolated(temp.path());
+        let source = temp.path().join(".codex");
+        let a = provider("../team", "");
+        let b = provider("plus", "");
+        let a_home = provider_home(&source, &a.id);
+        let b_home = provider_home(&source, &b.id);
+        let config = shared_config(&a, &source).unwrap();
+        let a_lock = prepare_home(&a_home, &source, &a, &config).unwrap();
+        let b_lock = prepare_home(&b_home, &source, &b, &config).unwrap();
+        assert!(a_home.starts_with(source.join(".cc-switch-launches")));
+        fs::write(a_home.join("sessions/from-team.jsonl"), "history").unwrap();
+        fs::write(a_home.join("archived_sessions/from-team.jsonl"), "archived").unwrap();
+        assert_eq!(
+            fs::read_to_string(b_home.join("sessions/from-team.jsonl")).unwrap(),
+            "history"
+        );
+        assert_eq!(
+            fs::read_to_string(b_home.join("archived_sessions/from-team.jsonl")).unwrap(),
+            "archived"
+        );
+        assert_ne!(
+            fs::read(a_home.join("auth.json")).unwrap(),
+            fs::read(b_home.join("auth.json")).unwrap()
+        );
+        assert!(!source.join("auth.json").exists());
+        assert!(!source.join("config.toml").exists());
+        for name in [
+            "thread-writer-locks/thread.lock",
+            ".tmp/rollout-maintenance.lock",
+        ] {
+            let a_lock = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(a_home.join(name))
+                .unwrap();
+            a_lock.try_lock().unwrap();
+            let b_lock = OpenOptions::new()
+                .write(true)
+                .open(b_home.join(name))
+                .unwrap();
+            assert!(matches!(
+                b_lock.try_lock(),
+                Err(fs::TryLockError::WouldBlock)
+            ));
+            drop(a_lock);
+            b_lock.try_lock().unwrap();
+        }
+        assert_eq!(
+            fs::metadata(a_home.join("auth.json"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        assert!(prepare_home(&a_home, &source, &b, &config).is_err());
+        assert!(fs::read_to_string(a_home.join("auth.json"))
+            .unwrap()
+            .contains("key-../team"));
+        drop(a_lock);
+        drop(b_lock);
+        assert!(a_home.join("sessions/from-team.jsonl").exists());
+        let _again = prepare_home(&a_home, &source, &a, &config).unwrap();
+        assert_eq!(
+            fs::read_to_string(a_home.join("sessions/from-team.jsonl")).unwrap(),
+            "history"
+        );
+        fs::remove_file(a_home.join("auth.json")).unwrap();
+        drop(_again);
+        let _after_logout = prepare_home(&a_home, &source, &a, &config).unwrap();
+        assert!(!a_home.join("auth.json").exists());
+    }
+
+    #[test]
+    fn shared_home_rejects_redirected_private_directory() {
+        let temp = TempDir::new().unwrap();
+        let _env = TestEnvGuard::isolated(temp.path());
+        let source = temp.path().join(".codex");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, source.join(".cc-switch-launches")).unwrap();
+        let provider = provider("team", "");
+        assert!(prepare_home(
+            &provider_home(&source, &provider.id),
+            &source,
+            &provider,
+            ""
+        )
+        .is_err());
+        assert_eq!(fs::read_dir(outside).unwrap().count(), 0);
+    }
+}

--- a/src-tauri/src/cli/commands/internal.rs
+++ b/src-tauri/src/cli/commands/internal.rs
@@ -8,19 +8,43 @@ use crate::store::AppState;
 
 #[derive(Subcommand)]
 pub enum InternalCommand {
+    /// Release an inherited launch lock after Codex and credential capture finish.
+    #[cfg(unix)]
+    ReleaseCodexLock { lock_fd: i32 },
     /// Persist Codex files written during `cc-switch start codex`.
     CaptureCodexTemp {
         provider_id: String,
         codex_home: PathBuf,
+        /// Capture credentials without persisting launch-only configuration
+        #[arg(long)]
+        auth_only: bool,
     },
 }
 
 pub fn execute(cmd: InternalCommand) -> Result<(), AppError> {
     match cmd {
+        #[cfg(unix)]
+        InternalCommand::ReleaseCodexLock { lock_fd } => {
+            if unsafe { libc::flock(lock_fd, libc::LOCK_UN) } != 0 {
+                return Err(AppError::Config(format!(
+                    "Failed to release Codex launch lock: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+            Ok(())
+        }
         InternalCommand::CaptureCodexTemp {
             provider_id,
             codex_home,
+            auth_only,
         } => {
+            if auth_only {
+                return ProviderService::capture_codex_launch_auth(
+                    &crate::Database::init()?,
+                    &provider_id,
+                    &codex_home,
+                );
+            }
             let state = AppState::try_new()?;
             ProviderService::capture_codex_temp_launch_snapshot(&state, &provider_id, &codex_home)
         }

--- a/src-tauri/src/cli/commands/start.rs
+++ b/src-tauri/src/cli/commands/start.rs
@@ -29,6 +29,7 @@ Examples:
 const CODEX_START_AFTER_LONG_HELP: &str = "\
 Examples:
   cc-switch start codex demo
+  cc-switch start codex demo --shared-sessions
   cc-switch start codex demo --dry-run
   cc-switch start codex demo -- --model gpt-5.4";
 
@@ -54,6 +55,9 @@ pub enum StartCommand {
         /// Preview the resolved launch without starting Codex
         #[arg(long)]
         dry_run: bool,
+        /// Share persistent Codex history while keeping provider credentials isolated
+        #[arg(long)]
+        shared_sessions: bool,
         /// Native Codex CLI arguments to pass through after `--`
         #[arg(last = true, value_name = "NATIVE_ARGS")]
         native_args: Vec<OsString>,
@@ -70,8 +74,9 @@ pub fn execute(cmd: StartCommand) -> Result<(), AppError> {
         StartCommand::Codex {
             selector,
             dry_run,
+            shared_sessions,
             native_args,
-        } => start_codex(&selector, dry_run, &native_args),
+        } => start_codex(&selector, dry_run, shared_sessions, &native_args),
     }
 }
 
@@ -104,7 +109,12 @@ fn start_claude(selector: &str, dry_run: bool, native_args: &[OsString]) -> Resu
     handoff_claude_and_cleanup(&prepared, native_args)
 }
 
-fn start_codex(selector: &str, dry_run: bool, native_args: &[OsString]) -> Result<(), AppError> {
+fn start_codex(
+    selector: &str,
+    dry_run: bool,
+    shared_sessions: bool,
+    native_args: &[OsString],
+) -> Result<(), AppError> {
     start_with(
         selector,
         "Codex",
@@ -114,6 +124,12 @@ fn start_codex(selector: &str, dry_run: bool, native_args: &[OsString]) -> Resul
         },
         |provider| {
             ensure_codex_temp_launch_supported()?;
+            #[cfg(unix)]
+            if shared_sessions {
+                return crate::cli::codex_shared_launch::launch(provider, native_args, dry_run);
+            }
+            #[cfg(not(unix))]
+            let _ = shared_sessions;
             if dry_run {
                 let prepared = preview_codex_launch_with(
                     provider,

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -3,6 +3,8 @@ use clap_complete::Shell;
 use std::io::Write;
 
 mod claude_temp_launch;
+#[cfg(unix)]
+mod codex_shared_launch;
 mod codex_temp_launch;
 pub mod commands;
 pub mod editor;
@@ -848,10 +850,12 @@ mod tests {
             Some(Commands::Start(super::commands::start::StartCommand::Codex {
                 selector,
                 dry_run,
+                shared_sessions,
                 native_args,
             })) => {
                 assert_eq!(selector, "demo");
                 assert!(!dry_run);
+                assert!(!shared_sessions);
                 assert!(native_args.is_empty());
             }
             _ => panic!("expected start codex command"),
@@ -876,10 +880,12 @@ mod tests {
             Some(Commands::Start(super::commands::start::StartCommand::Codex {
                 selector,
                 dry_run,
+                shared_sessions,
                 native_args,
             })) => {
                 assert_eq!(selector, "demo");
                 assert!(dry_run);
+                assert!(!shared_sessions);
                 assert_eq!(
                     native_args,
                     vec![OsString::from("--model"), OsString::from("gpt-5.4")]
@@ -908,10 +914,12 @@ mod tests {
             Some(Commands::Start(super::commands::start::StartCommand::Codex {
                 selector,
                 dry_run,
+                shared_sessions,
                 native_args,
             })) => {
                 assert_eq!(selector, "demo");
                 assert!(!dry_run);
+                assert!(!shared_sessions);
                 assert_eq!(
                     native_args,
                     vec![

--- a/src-tauri/src/database/dao/providers.rs
+++ b/src-tauri/src/database/dao/providers.rs
@@ -8,6 +8,7 @@ use crate::error::AppError;
 use crate::provider::{Provider, ProviderMeta};
 use indexmap::IndexMap;
 use rusqlite::params;
+use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 
 impl Database {
@@ -460,6 +461,47 @@ impl Database {
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
         Ok(())
+    }
+
+    /// Shared Codex launches must not overwrite configuration edits or another
+    /// provider's login refresh when they capture credentials on exit.
+    pub(crate) fn update_codex_provider_auth(
+        &self,
+        provider_id: &str,
+        auth: &serde_json::Value,
+        expected_auth_source: &str,
+    ) -> Result<(), AppError> {
+        let mut conn = lock_conn!(self.conn);
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|err| AppError::Database(err.to_string()))?;
+        let settings: String = tx
+            .query_row(
+                "SELECT settings_config FROM providers WHERE id = ?1 AND app_type = 'codex'",
+                [provider_id],
+                |row| row.get(0),
+            )
+            .map_err(|err| AppError::Database(err.to_string()))?;
+        let settings: serde_json::Value =
+            serde_json::from_str(&settings).map_err(|err| AppError::Database(err.to_string()))?;
+        let current_auth = settings
+            .get("auth")
+            .filter(|auth| auth.is_object())
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        if format!("{:x}", Sha256::digest(current_auth.to_string().as_bytes()))
+            != expected_auth_source
+        {
+            return Ok(());
+        }
+        tx.execute(
+            "UPDATE providers SET settings_config = json_set(settings_config, '$.auth', json(?1))
+                 WHERE id = ?2 AND app_type = 'codex'",
+            params![auth.to_string(), provider_id],
+        )
+        .map_err(|err| AppError::Database(err.to_string()))?;
+        tx.commit()
+            .map_err(|err| AppError::Database(err.to_string()))
     }
 
     /// 添加自定义端点

--- a/src-tauri/src/services/provider/codex.rs
+++ b/src-tauri/src/services/provider/codex.rs
@@ -1,8 +1,35 @@
 use super::*;
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::Path;
 
 impl ProviderService {
+    /// Shared launches derive their routing/storage settings at startup. Only
+    /// login changes belong back in the provider record; never save AppState's
+    /// full snapshot while other providers may be finishing concurrently.
+    pub(crate) fn capture_codex_launch_auth(
+        db: &crate::Database,
+        provider_id: &str,
+        codex_home: &Path,
+    ) -> Result<(), AppError> {
+        let auth_path = codex_home.join("auth.json");
+        let auth = if auth_path.exists() {
+            read_json_file::<Value>(&auth_path)?
+        } else {
+            serde_json::json!({})
+        };
+        if !auth.is_object() {
+            return Err(AppError::Config("Codex auth.json must be an object".into()));
+        }
+        let source_path = codex_home.join(".auth-source");
+        let source =
+            fs::read_to_string(&source_path).map_err(|err| AppError::io(&source_path, err))?;
+        if format!("{:x}", Sha256::digest(auth.to_string().as_bytes())) == source {
+            return Ok(());
+        }
+        db.update_codex_provider_auth(provider_id, &auth, &source)
+    }
+
     pub(crate) fn capture_codex_temp_launch_snapshot(
         state: &AppState,
         provider_id: &str,

--- a/src-tauri/tests/start_codex_shared.rs
+++ b/src-tauri/tests/start_codex_shared.rs
@@ -1,0 +1,434 @@
+#![cfg(all(unix, feature = "cli"))]
+
+mod support;
+
+use cc_switch_lib::{AppState, Provider};
+use serde_json::json;
+use std::fs;
+use std::os::unix::{fs::PermissionsExt, process::CommandExt};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+struct Running(Option<Child>);
+
+impl Running {
+    fn finish(mut self) -> Output {
+        self.0.take().unwrap().wait_with_output().unwrap()
+    }
+}
+
+impl Drop for Running {
+    fn drop(&mut self) {
+        if let Some(child) = self.0.as_mut() {
+            unsafe {
+                libc::kill(-(child.id() as i32), libc::SIGKILL);
+            }
+            let _ = child.wait();
+        }
+    }
+}
+
+struct Fixture {
+    root: PathBuf,
+    work: PathBuf,
+    state: AppState,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        support::reset_test_fs();
+        let root = support::ensure_test_home().to_path_buf();
+        let state = AppState::try_new().unwrap();
+        for id in ["team", "plus"] {
+            let mut provider = Provider::with_id(
+                id.into(),
+                id.into(),
+                json!({
+                    "config": "model = 'original-model'\n", "auth": {"OPENAI_API_KEY": format!("original-{id}")}
+                }),
+                None,
+            );
+            provider.category = Some("official".into());
+            state.db.save_provider("codex", &provider).unwrap();
+        }
+        let work = root.join(".config/shared-launch-test");
+        fs::create_dir_all(work.join("bin")).unwrap();
+        fs::create_dir_all(root.join(".codex")).unwrap();
+        fs::write(root.join(".codex/config.toml"), "model = 'global-model'\n").unwrap();
+        fs::write(
+            root.join(".codex/auth.json"),
+            "{\"OPENAI_API_KEY\":\"global-key\"}",
+        )
+        .unwrap();
+        let stub = work.join("bin/codex");
+        fs::write(
+            &stub,
+            r#"#!/bin/sh
+trap 'exit 130' INT TERM HUP
+mkdir -p "$CODEX_HOME/sessions"
+printf '%s\n' "$FAKE_LABEL" > "$CODEX_HOME/sessions/$FAKE_LABEL.jsonl"
+if [ -f "$CODEX_HOME/auth.json" ]; then cp "$CODEX_HOME/auth.json" "$FAKE_OUTPUT.auth-before"; fi
+printf '{"OPENAI_API_KEY":"refreshed-%s"}\n' "$FAKE_LABEL" > "$CODEX_HOME/auth.json"
+# Native deletion can atomically replace this local title cache.
+printf '{}\n' > "$CODEX_HOME/session_index.jsonl.tmp"
+mv "$CODEX_HOME/session_index.jsonl.tmp" "$CODEX_HOME/session_index.jsonl"
+printf '%s' "$CODEX_HOME" > "$FAKE_OUTPUT"
+while [ ! -f "$FAKE_GATE" ]; do sleep 0.05; done
+if [ -n "$FAKE_BACKGROUND_PID" ]; then
+    sleep 30 </dev/null >/dev/null 2>&1 &
+    printf '%s' "$!" > "$FAKE_BACKGROUND_PID"
+fi
+exit 0
+"#,
+        )
+        .unwrap();
+        fs::set_permissions(stub, fs::Permissions::from_mode(0o755)).unwrap();
+        Self { root, work, state }
+    }
+
+    fn command(&self, id: &str, output: &str, shared: bool) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_cc-switch"));
+        command.args(["start", "codex", id]);
+        if shared {
+            command.arg("--shared-sessions");
+        }
+        command
+            .env(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    self.work.join("bin").display(),
+                    std::env::var("PATH").unwrap_or_default()
+                ),
+            )
+            .env("FAKE_LABEL", id)
+            .env("FAKE_OUTPUT", self.work.join(output))
+            .env("FAKE_GATE", self.work.join("gate"))
+            .env_remove("CC_SWITCH_DAEMON_SOCKET")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .process_group(0);
+        command
+    }
+
+    fn start(&self, id: &str, output: &str, shared: bool) -> Running {
+        Running(Some(self.command(id, output, shared).spawn().unwrap()))
+    }
+
+    fn started_home(&self, output: &str) -> PathBuf {
+        let path = self.work.join(output);
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            if let Ok(text) = fs::read_to_string(&path) {
+                if !text.is_empty() {
+                    return PathBuf::from(text);
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "Codex stub did not start: {}",
+                path.display()
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+fn success(output: Output) {
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn shared_start_keeps_two_providers_isolated_and_history_resumable_after_exit() {
+    let _guard = support::lock_test_mutex();
+    let fixture = Fixture::new();
+    let a = fixture.start("team", "a", true);
+    let a_home = fixture.started_home("a");
+    let b = fixture.start("plus", "b", true);
+    let b_home = fixture.started_home("b");
+    assert_ne!(a_home, b_home);
+    assert_eq!(
+        fs::read_to_string(b_home.join("sessions/team.jsonl")).unwrap(),
+        "team\n"
+    );
+    assert_eq!(
+        fs::read_to_string(a_home.join("sessions/plus.jsonl")).unwrap(),
+        "plus\n"
+    );
+    let duplicate = fixture.command("team", "duplicate", true).output().unwrap();
+    assert!(!duplicate.status.success());
+    assert!(!fixture.work.join("duplicate").exists());
+
+    // An edit made while both sessions run must survive the exit-time auth capture.
+    let mut edited = fixture
+        .state
+        .db
+        .get_provider_by_id("team", "codex")
+        .unwrap()
+        .unwrap();
+    edited.settings_config["config"] = json!("model = 'edited-while-running'\n");
+    fixture.state.db.save_provider("codex", &edited).unwrap();
+    fs::write(fixture.work.join("gate"), "exit both").unwrap();
+    success(a.finish());
+    success(b.finish());
+    for (id, home) in [("team", &a_home), ("plus", &b_home)] {
+        let saved = fixture
+            .state
+            .db
+            .get_provider_by_id(id, "codex")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            saved.settings_config["auth"]["OPENAI_API_KEY"],
+            format!("refreshed-{id}")
+        );
+        let expected = if id == "team" {
+            "model = 'edited-while-running'\n"
+        } else {
+            "model = 'original-model'\n"
+        };
+        assert_eq!(saved.settings_config["config"], expected);
+        assert!(
+            home.join("sessions/team.jsonl").exists(),
+            "stored rollout paths must survive exit"
+        );
+        let config: toml::Value = fs::read_to_string(home.join("config.toml"))
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_eq!(config["model_provider"].as_str(), Some("custom"));
+        assert_eq!(
+            Path::new(config["sqlite_home"].as_str().unwrap()),
+            fixture.root.join(".codex")
+        );
+    }
+    assert_eq!(
+        fs::read_to_string(fixture.root.join(".codex/config.toml")).unwrap(),
+        "model = 'global-model'\n"
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join(".codex/auth.json")).unwrap(),
+        "{\"OPENAI_API_KEY\":\"global-key\"}"
+    );
+    success(fixture.command("team", "again", true).output().unwrap());
+    assert_eq!(fixture.started_home("again"), a_home);
+    assert!(a_home.join("sessions/plus.jsonl").exists());
+}
+
+#[test]
+fn shared_start_dry_run_and_override_errors_do_not_create_launch_homes() {
+    let _guard = support::lock_test_mutex();
+    let fixture = Fixture::new();
+    let output = fixture
+        .command("team", "unused", true)
+        .arg("--dry-run")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("CODEX_HOME="));
+    assert!(!stdout.contains("original-team"));
+    assert!(!fixture.root.join(".codex/.cc-switch-launches").exists());
+    let output = fixture
+        .command("team", "unused", true)
+        .args(["--", "-c", "model_provider='other'"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(!fixture.root.join(".codex/.cc-switch-launches").exists());
+}
+
+#[test]
+fn shared_start_resolves_relative_sqlite_config_from_the_source_home() {
+    let _guard = support::lock_test_mutex();
+    let fixture = Fixture::new();
+    fs::write(
+        fixture.root.join(".codex/config.toml"),
+        "sqlite_home = 'relative-state'\n",
+    )
+    .unwrap();
+    fs::write(fixture.work.join("gate"), "exit").unwrap();
+    for (id, cwd) in [("team", &fixture.root), ("plus", &fixture.work)] {
+        success(
+            fixture
+                .command(id, id, true)
+                .current_dir(cwd)
+                .output()
+                .unwrap(),
+        );
+        let config: toml::Value = fs::read_to_string(fixture.started_home(id).join("config.toml"))
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_eq!(
+            Path::new(config["sqlite_home"].as_str().unwrap()),
+            fixture.root.join(".codex/relative-state")
+        );
+    }
+}
+
+#[test]
+fn shared_start_retains_refresh_after_kill_but_honors_explicit_credential_edits() {
+    let _guard = support::lock_test_mutex();
+    let fixture = Fixture::new();
+    let running = fixture.start("team", "killed", true);
+    fixture.started_home("killed");
+    unsafe { libc::kill(-(running.0.as_ref().unwrap().id() as i32), libc::SIGKILL) };
+    assert!(!running.finish().status.success());
+    fs::write(fixture.work.join("gate"), "exit").unwrap();
+    success(fixture.command("team", "recovered", true).output().unwrap());
+    let before: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(fixture.work.join("recovered.auth-before")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(before["OPENAI_API_KEY"], "refreshed-team");
+
+    let mut edited = fixture
+        .state
+        .db
+        .get_provider_by_id("team", "codex")
+        .unwrap()
+        .unwrap();
+    edited.settings_config["auth"] = json!({"OPENAI_API_KEY": "explicit-edit"});
+    fixture.state.db.save_provider("codex", &edited).unwrap();
+    success(fixture.command("team", "edited", true).output().unwrap());
+    let before: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(fixture.work.join("edited.auth-before")).unwrap())
+            .unwrap();
+    assert_eq!(before["OPENAI_API_KEY"], "explicit-edit");
+}
+
+#[test]
+fn shared_start_exit_preserves_credentials_edited_while_codex_runs() {
+    let _guard = support::lock_test_mutex();
+    let fixture = Fixture::new();
+    for (id, changed_in_codex) in [("team", false), ("plus", true)] {
+        let running = fixture.start(id, id, true);
+        let home = fixture.started_home(id);
+        if !changed_in_codex {
+            fs::write(
+                home.join("auth.json"),
+                format!(r#"{{"OPENAI_API_KEY":"original-{id}"}}"#),
+            )
+            .unwrap();
+        }
+        let mut edited = fixture
+            .state
+            .db
+            .get_provider_by_id(id, "codex")
+            .unwrap()
+            .unwrap();
+        edited.settings_config["auth"] = json!({"OPENAI_API_KEY": "edited-while-running"});
+        fixture.state.db.save_provider("codex", &edited).unwrap();
+        fs::write(fixture.work.join("gate"), "exit").unwrap();
+        success(running.finish());
+        fs::remove_file(fixture.work.join("gate")).unwrap();
+        assert_eq!(
+            fixture
+                .state
+                .db
+                .get_provider_by_id(id, "codex")
+                .unwrap()
+                .unwrap()
+                .settings_config["auth"]["OPENAI_API_KEY"],
+            "edited-while-running"
+        );
+    }
+}
+
+#[test]
+fn shared_start_interrupt_retains_history_and_releases_provider_lock() {
+    let _guard = support::lock_test_mutex();
+    let fixture = Fixture::new();
+    let running = fixture.start("team", "before-interrupt", true);
+    let home = fixture.started_home("before-interrupt");
+    unsafe {
+        libc::kill(-(running.0.as_ref().unwrap().id() as i32), libc::SIGINT);
+    }
+    assert!(!running.finish().status.success());
+    assert!(home.join("sessions/team.jsonl").exists());
+    fs::write(fixture.work.join("gate"), "exit").unwrap();
+    success(
+        fixture
+            .command("team", "after-interrupt", true)
+            .output()
+            .unwrap(),
+    );
+    assert_eq!(fixture.started_home("after-interrupt"), home);
+}
+
+#[test]
+fn shared_start_keeps_home_locked_when_only_the_supervisor_is_killed() {
+    let _guard = support::lock_test_mutex();
+    let fixture = Fixture::new();
+    let mut running = fixture.start("team", "orphan", true);
+    let home = fixture.started_home("orphan");
+    let supervisor = running.0.as_mut().unwrap();
+    unsafe { libc::kill(supervisor.id() as i32, libc::SIGKILL) };
+    assert!(!supervisor.wait().unwrap().success());
+    let duplicate = fixture.command("team", "duplicate", true).output().unwrap();
+    assert!(!duplicate.status.success());
+    assert!(!fixture.work.join("duplicate").exists());
+    assert!(fs::read_to_string(home.join("auth.json"))
+        .unwrap()
+        .contains("refreshed-team"));
+    fs::write(fixture.work.join("gate"), "exit surviving Codex").unwrap();
+    assert!(!running.finish().status.success());
+    success(
+        fixture
+            .command("team", "after-orphan", true)
+            .output()
+            .unwrap(),
+    );
+}
+
+#[test]
+fn shared_start_releases_lock_while_native_background_child_is_alive() {
+    let _guard = support::lock_test_mutex();
+    let fixture = Fixture::new();
+    fs::write(fixture.work.join("gate"), "exit").unwrap();
+    let pid_path = fixture.work.join("background-pid");
+    let output = fixture
+        .command("team", "first", true)
+        .env("FAKE_BACKGROUND_PID", &pid_path)
+        .output()
+        .unwrap();
+    struct Background(i32);
+    impl Drop for Background {
+        fn drop(&mut self) {
+            unsafe { libc::kill(self.0, libc::SIGKILL) };
+        }
+    }
+    let background = Background(fs::read_to_string(pid_path).unwrap().parse().unwrap());
+    success(output);
+    assert_eq!(unsafe { libc::kill(background.0, 0) }, 0);
+    success(fixture.command("team", "second", true).output().unwrap());
+    assert_eq!(unsafe { libc::kill(background.0, 0) }, 0);
+}
+
+#[test]
+fn ordinary_start_still_uses_and_removes_a_temporary_home() {
+    let _guard = support::lock_test_mutex();
+    let fixture = Fixture::new();
+    fs::write(fixture.work.join("gate"), "exit").unwrap();
+    success(
+        fixture
+            .command("team", "ordinary", false)
+            .args(["--", "--model", "another-model"])
+            .output()
+            .unwrap(),
+    );
+    let home = fixture.started_home("ordinary");
+    assert!(home.starts_with(std::env::temp_dir()));
+    assert!(!home.exists());
+    assert!(!fixture.root.join(".codex/.cc-switch-launches").exists());
+}


### PR DESCRIPTION
`cc-switch start codex` uses temporary homes, so parallel providers cannot share durable native session history. Add opt-in `--shared-sessions` to give each provider private credentials/configuration while sharing persistent history and Codex's session locks.

```sh
cc-switch start codex team --shared-sessions
cc-switch start codex plus --shared-sessions
```

Persistent provider homes keep recorded rollout paths valid after exit. Shared storage and the selected provider remain effective when resuming or loading project settings. Login capture updates only the selected provider's authentication; local refreshes survive forced termination, and explicit credential edits in cc-switch take precedence over exit capture and on the next launch.

Scope is limited to the Codex CLI launch path, an auth-only capture operation, focused tests, and documentation. Default temporary launches, TUI behavior, other apps, proxy routing, and the database schema retain their existing behavior.

Validation:
- The new module unit tests (4) and subprocess integration tests (9) passed, including concurrent launches, credential isolation, normal/interrupted/forced exits, restart, explicit credential edits, relative paths, native background children, launcher-only termination, and default launches.
- Native Codex 0.153.4 verified with isolated copies of real local sessions: listing, cross-provider continuation, active-writer exclusion, restart, rename, archive/unarchive, and deletion. Original session hashes remained unchanged.
- Local HTTP test providers verified actual request endpoints and corresponding fake credentials. Native configuration tests also covered trusted project overrides; interactive TUI resume was checked separately. Both the raw binary and the installed launcher retained provider exclusion after launcher-only SIGKILL.
- Rust CI passed: 4,329 library tests (2 ignored), 10 binary tests, the selected proxy integration tests, Linux/Windows library-only builds, and the Windows CLI build. Benchmark CI also passed. Local full-suite runs showed a failure in the unchanged `session_usage_codex::tests::test_incremental_resume_keeps_replay_prefix_alignment`; that test passed in isolation, alongside the new unit tests, and in CI. This local discrepancy remains recorded; statistics code is unchanged.
- `cargo fmt --check`, diff checks, and the library-only check/test compilation with warnings denied passed. Standard Clippy encounters the pre-existing `reversed_empty_ranges` error in `home_chart.rs`; Clippy with that existing lint allowed passes.

Three independent two-reviewer blind rounds were followed by two fresh single-reviewer rounds as findings converged. The final review found no actionable issues. Reviewers received the goal, acceptance criteria, and scope, without the implementation explanation or previous findings.

This option targets macOS/Linux. Only one shared launch per provider is allowed at a time, and native thread writer locks still apply. Older official history uses the existing optional migration. Native credential environment variables retain their existing precedence. Real Team/Plus OAuth refresh and upstream acceptance of cross-provider encrypted reasoning were not tested.

Refs #436
