### PR TITLE
feat(tui): configure per-model Codex reasoning levels

### DIFF
--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -2300,6 +2300,46 @@ pub mod texts {
         }
     }
 
+    pub fn tui_codex_reasoning_levels_header() -> &'static str {
+        if is_chinese() {
+            "档位"
+        } else {
+            "Levels"
+        }
+    }
+
+    pub fn tui_codex_reasoning_levels() -> &'static str {
+        if is_chinese() {
+            "推理档位"
+        } else {
+            "Reasoning Levels"
+        }
+    }
+
+    pub fn tui_codex_default_reasoning_header() -> &'static str {
+        if is_chinese() {
+            "默认"
+        } else {
+            "Default"
+        }
+    }
+
+    pub fn tui_codex_default_reasoning_level() -> &'static str {
+        if is_chinese() {
+            "默认推理档位"
+        } else {
+            "Default Reasoning Level"
+        }
+    }
+
+    pub fn tui_codex_reasoning_auto() -> &'static str {
+        if is_chinese() {
+            "自动"
+        } else {
+            "Auto"
+        }
+    }
+
     pub fn tui_codex_model_catalog_model_prompt() -> &'static str {
         if is_chinese() {
             "模型 ID"

--- a/src-tauri/src/cli/tui/app/form_handlers/provider.rs
+++ b/src-tauri/src/cli/tui/app/form_handlers/provider.rs
@@ -1206,6 +1206,45 @@ impl App {
             form::CodexModelCatalogField::ContextWindow => {
                 texts::tui_codex_model_catalog_context_prompt()
             }
+            form::CodexModelCatalogField::ReasoningLevels
+            | form::CodexModelCatalogField::DefaultReasoningLevel => {
+                let Some(FormState::ProviderAdd(provider)) = self.form.as_ref() else {
+                    return;
+                };
+                let Some(index) = row else { return };
+                let Some(model) = provider.codex_model_catalog.get(index) else {
+                    return;
+                };
+                let checked = form::CODEX_REASONING_LEVELS
+                    .map(|level| model.reasoning_levels.iter().any(|value| value == level));
+                self.overlay = if field == form::CodexModelCatalogField::ReasoningLevels {
+                    Overlay::CodexReasoningLevelsPicker {
+                        row: index,
+                        selected: 0,
+                        checked,
+                    }
+                } else {
+                    let options: Vec<String> = std::iter::once(String::new())
+                        .chain(
+                            form::CODEX_REASONING_LEVELS
+                                .iter()
+                                .zip(checked)
+                                .filter(|(_, enabled)| *enabled)
+                                .map(|(level, _)| (*level).to_string()),
+                        )
+                        .collect();
+                    let selected = options
+                        .iter()
+                        .position(|level| level == &model.default_reasoning_level)
+                        .unwrap_or(0);
+                    Overlay::CodexDefaultReasoningPicker {
+                        row: index,
+                        selected,
+                        options,
+                    }
+                };
+                return;
+            }
         };
         self.overlay = Overlay::TextInput(TextInputState {
             title: texts::tui_codex_model_catalog().to_string(),

--- a/src-tauri/src/cli/tui/app/overlay_handlers/dialogs.rs
+++ b/src-tauri/src/cli/tui/app/overlay_handlers/dialogs.rs
@@ -810,5 +810,9 @@ fn codex_model_catalog_field_prompt(field: form::CodexModelCatalogField) -> &'st
         form::CodexModelCatalogField::ContextWindow => {
             texts::tui_codex_model_catalog_context_prompt()
         }
+        form::CodexModelCatalogField::ReasoningLevels => texts::tui_codex_reasoning_levels(),
+        form::CodexModelCatalogField::DefaultReasoningLevel => {
+            texts::tui_codex_default_reasoning_level()
+        }
     }
 }

--- a/src-tauri/src/cli/tui/app/overlay_handlers/pickers.rs
+++ b/src-tauri/src/cli/tui/app/overlay_handlers/pickers.rs
@@ -78,6 +78,71 @@ fn session_project_option_index(
 }
 
 impl App {
+    fn handle_codex_reasoning_picker_key(&mut self, key: KeyEvent) -> Option<Action> {
+        let (selected, count) = match &mut self.overlay {
+            Overlay::CodexReasoningLevelsPicker {
+                selected, checked, ..
+            } => (selected, checked.len()),
+            Overlay::CodexDefaultReasoningPicker {
+                selected, options, ..
+            } => (selected, options.len()),
+            _ => return None,
+        };
+        match key.code {
+            KeyCode::Up => *selected = selected.saturating_sub(1),
+            KeyCode::Down => *selected = (*selected + 1).min(count.saturating_sub(1)),
+            KeyCode::Char(' ') => {
+                if let Overlay::CodexReasoningLevelsPicker {
+                    selected, checked, ..
+                } = &mut self.overlay
+                {
+                    if let Some(enabled) = checked.get_mut(*selected) {
+                        *enabled = !*enabled;
+                    }
+                }
+            }
+            KeyCode::Esc => self.overlay = Overlay::None,
+            KeyCode::Enter => {
+                if let Some(FormState::ProviderAdd(provider)) = self.form.as_mut() {
+                    match &self.overlay {
+                        Overlay::CodexReasoningLevelsPicker { row, checked, .. } => {
+                            if let Some(model) = provider.codex_model_catalog.get_mut(*row) {
+                                model.reasoning_levels = form::CODEX_REASONING_LEVELS
+                                    .iter()
+                                    .zip(checked)
+                                    .filter(|(_, enabled)| **enabled)
+                                    .map(|(level, _)| (*level).to_string())
+                                    .collect();
+                                if !model
+                                    .reasoning_levels
+                                    .contains(&model.default_reasoning_level)
+                                {
+                                    model.default_reasoning_level.clear();
+                                }
+                            }
+                        }
+                        Overlay::CodexDefaultReasoningPicker {
+                            row,
+                            selected,
+                            options,
+                        } => {
+                            if let (Some(model), Some(level)) = (
+                                provider.codex_model_catalog.get_mut(*row),
+                                options.get(*selected),
+                            ) {
+                                model.default_reasoning_level.clone_from(level);
+                            }
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+                self.overlay = Overlay::None;
+            }
+            _ => {}
+        }
+        Some(Action::None)
+    }
+
     pub(super) fn handle_picker_overlay_key(
         &mut self,
         key: KeyEvent,
@@ -90,6 +155,9 @@ impl App {
             return Some(action);
         }
         if let Some(action) = self.handle_claude_api_format_picker_key(key, data) {
+            return Some(action);
+        }
+        if let Some(action) = self.handle_codex_reasoning_picker_key(key) {
             return Some(action);
         }
         if let Some(action) = self.handle_user_agent_picker_key(key) {

--- a/src-tauri/src/cli/tui/app/tests.rs
+++ b/src-tauri/src/cli/tui/app/tests.rs
@@ -14832,6 +14832,200 @@ mod tests {
         assert_eq!(mode(&app), PromptCacheRoutingMode::Auto);
     }
 
+    fn codex_reasoning_form(app: &App) -> &ProviderAddFormState {
+        let Some(FormState::ProviderAdd(form)) = app.form.as_ref() else {
+            panic!("expected provider form");
+        };
+        form
+    }
+
+    fn codex_reasoning_app(inline: bool) -> App {
+        let provider = Provider::with_id(
+            "test".into(),
+            "Test".into(),
+            json!({
+                "auth": {"OPENAI_API_KEY": "fake-test-key"},
+                "config": "model_provider = \"test\"\nmodel = \"first\"\n[model_providers.test]\nname = \"Test\"\nbase_url = \"http://127.0.0.1:9/v1\"\nwire_api = \"responses\"\n",
+                "modelCatalog": {"models": [
+                    {"model": "first", "displayName": "First", "contextWindow": 128000,
+                     "supportsParallelToolCalls": true, "inputModalities": ["text", "image"],
+                     "baseInstructions": "Keep instructions.",
+                     "reasoningLevels": ["none", "high"], "defaultReasoningLevel": "high"},
+                    {"model": "second", "reasoningLevels": ["minimal", "ultra"], "defaultReasoningLevel": "ultra"}
+                ]}, "futureSetting": {"keep": true}
+            }),
+            None,
+        );
+        let mut form = ProviderAddFormState::from_provider(AppType::Codex, &provider);
+        if inline {
+            form.open_codex_local_routing_page();
+            form.codex_local_routing_field_idx = form
+                .codex_local_routing_fields()
+                .iter()
+                .position(|field| *field == CodexLocalRoutingField::ModelCatalog)
+                .unwrap();
+        } else {
+            form.open_codex_model_catalog_page();
+        }
+        form.codex_model_catalog_field = CodexModelCatalogField::ContextWindow;
+        let mut app = App::new(Some(AppType::Codex));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+        app.form = Some(FormState::ProviderAdd(form));
+        app
+    }
+
+    #[test]
+    fn codex_model_catalog_reasoning_pickers_roundtrip_each_model_on_both_pages() {
+        let _lang = use_test_language(Language::English);
+        for inline in [false, true] {
+            let mut app = codex_reasoning_app(inline);
+            let data = UiData::default();
+            let original = codex_reasoning_form(&app).to_provider_json_value();
+            app.on_key(key(KeyCode::Right), &data);
+            app.on_key(key(KeyCode::Char('?')), &data);
+            assert!(help_text(&app).contains("reasoning levels supported by this model"));
+            app.on_key(key(KeyCode::Esc), &data);
+            app.on_key(key(KeyCode::Enter), &data);
+            // Pick ultra before low: persistence must still follow canonical order.
+            for _ in 0..7 {
+                app.on_key(key(KeyCode::Down), &data);
+            }
+            app.on_key(key(KeyCode::Char(' ')), &data);
+            for _ in 0..5 {
+                app.on_key(key(KeyCode::Up), &data);
+            }
+            app.on_key(key(KeyCode::Char(' ')), &data);
+            app.on_key(key(KeyCode::Char('?')), &data);
+            assert!(help_text(&app).contains("Space toggles"));
+            app.on_key(key(KeyCode::Esc), &data);
+            assert!(matches!(
+                app.overlay,
+                Overlay::CodexReasoningLevelsPicker { selected: 2, .. }
+            ));
+            app.on_key(key(KeyCode::Enter), &data);
+            assert_eq!(
+                codex_reasoning_form(&app).codex_model_catalog[0].reasoning_levels,
+                ["none", "low", "high", "ultra"]
+            );
+            assert_eq!(
+                codex_reasoning_form(&app).codex_model_catalog[0].default_reasoning_level,
+                "high"
+            );
+
+            app.on_key(key(KeyCode::Right), &data);
+            app.on_key(key(KeyCode::Enter), &data);
+            let Overlay::CodexDefaultReasoningPicker {
+                options, selected, ..
+            } = &app.overlay
+            else {
+                panic!("expected default picker");
+            };
+            assert_eq!(options, &["", "none", "low", "high", "ultra"]);
+            assert_eq!(*selected, 3);
+            app.on_key(key(KeyCode::Up), &data);
+            app.on_key(key(KeyCode::Enter), &data);
+
+            let saved = codex_reasoning_form(&app).to_provider_json_value();
+            let mut expected = original;
+            expected["settingsConfig"]["modelCatalog"]["models"][0]["reasoningLevels"] =
+                json!(["none", "low", "high", "ultra"]);
+            expected["settingsConfig"]["modelCatalog"]["models"][0]["defaultReasoningLevel"] =
+                json!("low");
+            assert_eq!(
+                saved, expected,
+                "only this model's reasoning fields may change"
+            );
+            assert!(codex_reasoning_form(&app).has_unsaved_changes());
+            let provider: Provider = serde_json::from_value(saved).unwrap();
+            let reopened = ProviderAddFormState::from_provider(AppType::Codex, &provider);
+            assert_eq!(
+                reopened.codex_model_catalog,
+                codex_reasoning_form(&app).codex_model_catalog
+            );
+
+            app.on_key(key(KeyCode::Down), &data);
+            app.on_key(key(KeyCode::Enter), &data);
+            assert!(
+                matches!(&app.overlay, Overlay::CodexDefaultReasoningPicker { row: 1, options, .. }
+                if options == &["", "minimal", "ultra"])
+            );
+        }
+    }
+
+    #[test]
+    fn codex_model_catalog_reasoning_pickers_cancel_clear_and_restore_auto() {
+        for inline in [false, true] {
+            let mut app = codex_reasoning_app(inline);
+            let data = UiData::default();
+            let original = codex_reasoning_form(&app).to_provider_json_value();
+            app.on_key(key(KeyCode::Right), &data);
+            app.on_key(key(KeyCode::Enter), &data);
+            app.on_key(key(KeyCode::Char(' ')), &data);
+            app.on_key(key(KeyCode::Esc), &data);
+            assert_eq!(
+                codex_reasoning_form(&app).to_provider_json_value(),
+                original
+            );
+            app.on_key(key(KeyCode::Right), &data);
+            app.on_key(key(KeyCode::Enter), &data);
+            app.on_key(key(KeyCode::Up), &data);
+            app.on_key(key(KeyCode::Esc), &data);
+            assert_eq!(
+                codex_reasoning_form(&app).to_provider_json_value(),
+                original
+            );
+
+            app.on_key(key(KeyCode::Enter), &data);
+            app.on_key(key(KeyCode::Up), &data);
+            app.on_key(key(KeyCode::Up), &data);
+            app.on_key(key(KeyCode::Enter), &data);
+            assert!(
+                codex_reasoning_form(&app).to_provider_json_value()["settingsConfig"]
+                    ["modelCatalog"]["models"][0]
+                    .get("defaultReasoningLevel")
+                    .is_none()
+            );
+            // Restore high, then remove it from the supported levels.
+            app.on_key(key(KeyCode::Enter), &data);
+            for _ in 0..2 {
+                app.on_key(key(KeyCode::Down), &data);
+            }
+            app.on_key(key(KeyCode::Enter), &data);
+            app.on_key(key(KeyCode::Left), &data);
+            app.on_key(key(KeyCode::Enter), &data);
+            for _ in 0..4 {
+                app.on_key(key(KeyCode::Down), &data);
+            }
+            app.on_key(key(KeyCode::Char(' ')), &data);
+            app.on_key(key(KeyCode::Enter), &data);
+            assert_eq!(
+                codex_reasoning_form(&app).codex_model_catalog[0].reasoning_levels,
+                ["none"]
+            );
+            assert!(codex_reasoning_form(&app).codex_model_catalog[0]
+                .default_reasoning_level
+                .is_empty());
+            app.on_key(key(KeyCode::Enter), &data);
+            app.on_key(key(KeyCode::Char(' ')), &data);
+            app.on_key(key(KeyCode::Enter), &data);
+            let saved = codex_reasoning_form(&app).to_provider_json_value();
+            let first = &saved["settingsConfig"]["modelCatalog"]["models"][0];
+            assert!(first.get("reasoningLevels").is_none());
+            assert!(first.get("defaultReasoningLevel").is_none());
+            assert_eq!(
+                saved["settingsConfig"]["modelCatalog"]["models"][1],
+                original["settingsConfig"]["modelCatalog"]["models"][1]
+            );
+            app.on_key(key(KeyCode::Right), &data);
+            app.on_key(key(KeyCode::Enter), &data);
+            assert!(
+                matches!(&app.overlay, Overlay::CodexDefaultReasoningPicker { selected: 0, options, .. }
+                if options == &[""])
+            );
+        }
+    }
+
     #[test]
     fn provider_codex_local_routing_model_catalog_edits_inline_and_adds_models() {
         let mut app = App::new(Some(AppType::Codex));

--- a/src-tauri/src/cli/tui/app/types.rs
+++ b/src-tauri/src/cli/tui/app/types.rs
@@ -4687,6 +4687,16 @@ pub enum Overlay {
     ClaudeApiFormatPicker {
         selected: usize,
     },
+    CodexReasoningLevelsPicker {
+        row: usize,
+        selected: usize,
+        checked: [bool; 8],
+    },
+    CodexDefaultReasoningPicker {
+        row: usize,
+        selected: usize,
+        options: Vec<String>,
+    },
     UserAgentPicker {
         selected: usize,
     },
@@ -4932,6 +4942,8 @@ impl Overlay {
                 | Overlay::ProviderTestMenu { .. }
                 | Overlay::FailoverQueueManager { .. }
                 | Overlay::ClaudeApiFormatPicker { .. }
+                | Overlay::CodexReasoningLevelsPicker { .. }
+                | Overlay::CodexDefaultReasoningPicker { .. }
                 | Overlay::UserAgentPicker { .. }
                 | Overlay::ExternalEditorPicker { .. }
                 | Overlay::UsageQueryTemplatePicker { .. }
@@ -4979,6 +4991,8 @@ impl Overlay {
             | Overlay::ProviderTestMenu { .. }
             | Overlay::FailoverQueueManager { .. }
             | Overlay::ClaudeApiFormatPicker { .. }
+            | Overlay::CodexReasoningLevelsPicker { .. }
+            | Overlay::CodexDefaultReasoningPicker { .. }
             | Overlay::UserAgentPicker { .. }
             | Overlay::ExternalEditorPicker { .. }
             | Overlay::UsageQueryTemplatePicker { .. }

--- a/src-tauri/src/cli/tui/form.rs
+++ b/src-tauri/src/cli/tui/form.rs
@@ -391,23 +391,41 @@ pub enum CodexModelCatalogField {
     Model,
     DisplayName,
     ContextWindow,
+    ReasoningLevels,
+    DefaultReasoningLevel,
 }
 
 impl CodexModelCatalogField {
-    pub const ALL: [Self; 3] = [Self::Model, Self::DisplayName, Self::ContextWindow];
+    pub const ALL: [Self; 5] = [
+        Self::Model,
+        Self::DisplayName,
+        Self::ContextWindow,
+        Self::ReasoningLevels,
+        Self::DefaultReasoningLevel,
+    ];
 
     pub fn index(self) -> usize {
         match self {
             Self::Model => 0,
             Self::DisplayName => 1,
             Self::ContextWindow => 2,
+            Self::ReasoningLevels => 3,
+            Self::DefaultReasoningLevel => 4,
         }
     }
 
     pub fn from_index(index: usize) -> Self {
-        Self::ALL.get(index).copied().unwrap_or(Self::ContextWindow)
+        Self::ALL
+            .get(index)
+            .copied()
+            .unwrap_or(Self::DefaultReasoningLevel)
     }
 }
+
+// Keep the picker order aligned with upstream CodexFormFields.tsx.
+pub const CODEX_REASONING_LEVELS: [&str; 8] = [
+    "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CodexModelCatalogRow {

--- a/src-tauri/src/cli/tui/form/provider_state.rs
+++ b/src-tauri/src/cli/tui/form/provider_state.rs
@@ -1596,6 +1596,9 @@ impl ProviderAddFormState {
             CodexModelCatalogField::Model => row.model.clone(),
             CodexModelCatalogField::DisplayName => row.display_name.clone(),
             CodexModelCatalogField::ContextWindow => row.context_window.clone(),
+            // These fields use pickers instead of text input.
+            CodexModelCatalogField::ReasoningLevels
+            | CodexModelCatalogField::DefaultReasoningLevel => String::new(),
         }
     }
 
@@ -1669,6 +1672,11 @@ impl ProviderAddFormState {
         value: &str,
     ) -> bool {
         match (row, field) {
+            (
+                _,
+                CodexModelCatalogField::ReasoningLevels
+                | CodexModelCatalogField::DefaultReasoningLevel,
+            ) => false,
             (None, CodexModelCatalogField::Model) => self.upsert_codex_model_catalog_model(value),
             (None, _) => false,
             (Some(index), CodexModelCatalogField::Model) => {

--- a/src-tauri/src/cli/tui/help.rs
+++ b/src-tauri/src/cli/tui/help.rs
@@ -109,6 +109,12 @@ fn current_help_target(app: &App) -> HelpTarget {
                 provider_usage_query_overlay_target(app, UsageQueryField::Template)
             }
             Overlay::ProviderTemplatePicker { .. } => HelpTarget::ProviderTemplate,
+            Overlay::CodexReasoningLevelsPicker { .. } => HelpTarget::CodexModelCatalogField {
+                field: CodexModelCatalogField::ReasoningLevels,
+            },
+            Overlay::CodexDefaultReasoningPicker { .. } => HelpTarget::CodexModelCatalogField {
+                field: CodexModelCatalogField::DefaultReasoningLevel,
+            },
             Overlay::ClaudeApiFormatPicker { .. } => {
                 provider_field_overlay_target(app, ProviderAddField::ClaudeApiFormat)
             }
@@ -234,11 +240,19 @@ fn current_help_target(app: &App) -> HelpTarget {
 
     if matches!(provider.page, ProviderFormPage::CodexLocalRouting) {
         return match provider.focus {
-            FormFocus::Fields => provider
-                .selected_codex_local_routing_field()
-                .map_or(HelpTarget::Empty, |field| {
-                    HelpTarget::CodexLocalRoutingField { field }
-                }),
+            FormFocus::Fields => {
+                provider
+                    .selected_codex_local_routing_field()
+                    .map_or(HelpTarget::Empty, |field| {
+                        if field == CodexLocalRoutingField::ModelCatalog {
+                            HelpTarget::CodexModelCatalogField {
+                                field: provider.codex_model_catalog_field,
+                            }
+                        } else {
+                            HelpTarget::CodexLocalRoutingField { field }
+                        }
+                    })
+            }
             _ => HelpTarget::Empty,
         };
     }
@@ -996,6 +1010,20 @@ fn local_proxy_settings_field_help(field: LocalProxySettingsField) -> HelpConten
 
 fn codex_model_catalog_field_help(field: CodexModelCatalogField) -> HelpContent {
     let mut content = match field {
+        CodexModelCatalogField::ReasoningLevels => HelpContent::new(
+            texts::tui_codex_reasoning_levels(),
+            help_lines(
+                "选择此模型支持的推理档位。Space 勾选，Enter 应用，Esc 取消。全部取消表示沿用目录模板；移除默认档位后，默认值恢复为自动。",
+                "Choose the reasoning levels supported by this model. Space toggles, Enter applies, Esc cancels. Clear all to inherit the catalog template; removing the default level resets the default to Auto.",
+            ),
+        ),
+        CodexModelCatalogField::DefaultReasoningLevel => HelpContent::new(
+            texts::tui_codex_default_reasoning_level(),
+            help_lines(
+                "默认值只能从此模型已选的推理档位中选择。自动表示优先沿用模板默认值；若不在已选档位中，则使用最高的已选档位。",
+                "Choose a default from this model's selected reasoning levels. Auto keeps the template default when supported, otherwise it uses the highest selected level.",
+            ),
+        ),
         CodexModelCatalogField::Model => HelpContent::new(
             tr("模型 ID", "Model ID"),
             help_lines(

--- a/src-tauri/src/cli/tui/ui/forms/provider.rs
+++ b/src-tauri/src/cli/tui/ui/forms/provider.rs
@@ -1211,6 +1211,8 @@ fn render_codex_model_catalog_inline(
         Cell::from(cell_pad(texts::tui_codex_model_catalog_model_header())),
         Cell::from(cell_pad(texts::tui_codex_model_catalog_display_header())),
         Cell::from(cell_pad(texts::tui_codex_model_catalog_context_header())),
+        Cell::from(cell_pad(texts::tui_codex_reasoning_levels_header())),
+        Cell::from(cell_pad(texts::tui_codex_default_reasoning_header())),
     ])
     .style(Style::default().fg(theme.dim).add_modifier(Modifier::BOLD));
 
@@ -1229,6 +1231,12 @@ fn render_codex_model_catalog_inline(
         let model = bounded_trimmed_text_for_display(&row.model);
         let display_name = bounded_trimmed_text_for_display(&row.display_name);
         let context_window = codex_model_catalog_context_for_display(&row.context_window);
+        let levels = codex_model_catalog_reasoning_for_display(row);
+        let default = if row.default_reasoning_level.is_empty() {
+            texts::tui_codex_reasoning_auto().to_string()
+        } else {
+            bounded_trimmed_text_for_display(&row.default_reasoning_level)
+        };
         let cell = |value: &str, field: super::form::CodexModelCatalogField| {
             if active {
                 codex_model_catalog_cell(value, idx, selected_idx, field, selected_field, theme)
@@ -1246,15 +1254,25 @@ fn render_codex_model_catalog_inline(
                 &context_window,
                 super::form::CodexModelCatalogField::ContextWindow,
             ),
+            cell(
+                &levels,
+                super::form::CodexModelCatalogField::ReasoningLevels,
+            ),
+            cell(
+                &default,
+                super::form::CodexModelCatalogField::DefaultReasoningLevel,
+            ),
         ])
     });
 
     let table = Table::new(
         rows,
         [
-            Constraint::Percentage(45),
-            Constraint::Percentage(35),
+            Constraint::Percentage(24),
             Constraint::Percentage(20),
+            Constraint::Length(9),
+            Constraint::Fill(1),
+            Constraint::Length(8),
         ],
     )
     .header(header)
@@ -1313,6 +1331,8 @@ fn render_codex_model_catalog_form(
         Cell::from(cell_pad(texts::tui_codex_model_catalog_model_header())),
         Cell::from(texts::tui_codex_model_catalog_display_header()),
         Cell::from(texts::tui_codex_model_catalog_context_header()),
+        Cell::from(cell_pad(texts::tui_codex_reasoning_levels_header())),
+        Cell::from(cell_pad(texts::tui_codex_default_reasoning_header())),
     ])
     .style(Style::default().fg(theme.dim).add_modifier(Modifier::BOLD));
 
@@ -1331,6 +1351,12 @@ fn render_codex_model_catalog_form(
         let model = bounded_trimmed_text_for_display(&row.model);
         let display_name = bounded_trimmed_text_for_display(&row.display_name);
         let context_window = codex_model_catalog_context_for_display(&row.context_window);
+        let levels = codex_model_catalog_reasoning_for_display(row);
+        let default = if row.default_reasoning_level.is_empty() {
+            texts::tui_codex_reasoning_auto().to_string()
+        } else {
+            bounded_trimmed_text_for_display(&row.default_reasoning_level)
+        };
         Row::new(vec![
             codex_model_catalog_cell(
                 &model,
@@ -1356,21 +1382,51 @@ fn render_codex_model_catalog_form(
                 selected_field,
                 theme,
             ),
+            codex_model_catalog_cell(
+                &levels,
+                idx,
+                selected_idx,
+                super::form::CodexModelCatalogField::ReasoningLevels,
+                selected_field,
+                theme,
+            ),
+            codex_model_catalog_cell(
+                &default,
+                idx,
+                selected_idx,
+                super::form::CodexModelCatalogField::DefaultReasoningLevel,
+                selected_field,
+                theme,
+            ),
         ])
     });
 
     let table = Table::new(
         rows,
         [
-            Constraint::Percentage(45),
-            Constraint::Percentage(35),
+            Constraint::Percentage(24),
             Constraint::Percentage(20),
+            Constraint::Length(9),
+            Constraint::Fill(1),
+            Constraint::Length(8),
         ],
     )
     .header(header)
     .block(Block::default().borders(Borders::NONE));
 
     frame.render_widget(table, table_area);
+}
+
+fn codex_model_catalog_reasoning_for_display(row: &super::form::CodexModelCatalogRow) -> String {
+    if row.reasoning_levels.is_empty() {
+        return "-".to_string();
+    }
+    row.reasoning_levels
+        .iter()
+        .take(super::form::CODEX_REASONING_LEVELS.len())
+        .map(|level| bounded_trimmed_text_for_display(level))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn codex_model_catalog_context_for_display(raw: &str) -> String {

--- a/src-tauri/src/cli/tui/ui/overlay/pickers.rs
+++ b/src-tauri/src/cli/tui/ui/overlay/pickers.rs
@@ -13,6 +13,73 @@ const SESSION_PROJECT_PICKER_WIDTH: u16 = 86;
 const SESSION_PROJECT_PICKER_HEIGHT: u16 = 24;
 const SESSION_PROJECT_PICKER_WIDE_MIN_WIDTH: u16 = 64;
 
+pub(super) fn render_codex_reasoning_picker_overlay(
+    frame: &mut Frame<'_>,
+    content_area: Rect,
+    theme: &theme::Theme,
+    overlay: &Overlay,
+) {
+    let mut keys = vec![("↑↓", texts::tui_key_select())];
+    let (title, selected, items): (_, _, Vec<ListItem<'_>>) = match overlay {
+        Overlay::CodexReasoningLevelsPicker {
+            selected, checked, ..
+        } => {
+            keys.push(("Space", texts::tui_key_toggle()));
+            let items = form::CODEX_REASONING_LEVELS
+                .iter()
+                .zip(checked)
+                .map(|(level, enabled)| {
+                    let marker = if *enabled {
+                        texts::tui_marker_active()
+                    } else {
+                        texts::tui_marker_inactive()
+                    };
+                    ListItem::new(format!("{marker}  {level}"))
+                })
+                .collect();
+            (texts::tui_codex_reasoning_levels(), *selected, items)
+        }
+        Overlay::CodexDefaultReasoningPicker {
+            selected, options, ..
+        } => {
+            let items = options
+                .iter()
+                .map(|level| {
+                    ListItem::new(if level.is_empty() {
+                        texts::tui_codex_reasoning_auto()
+                    } else {
+                        level.as_str()
+                    })
+                })
+                .collect();
+            (texts::tui_codex_default_reasoning_level(), *selected, items)
+        }
+        _ => return,
+    };
+    keys.extend([
+        ("Enter", texts::tui_key_apply()),
+        ("Esc", texts::tui_key_cancel()),
+    ]);
+    let body_area = overlay_frame(
+        frame,
+        content_area,
+        theme,
+        title,
+        &keys,
+        OverlaySize::FitRows {
+            width: 58,
+            body_rows: items.len() as u16,
+        },
+        overlay_border_style(theme, false),
+    );
+    let mut state = ListState::default();
+    state.select(Some(selected.min(items.len().saturating_sub(1))));
+    let list = List::new(items)
+        .highlight_style(selection_style(theme))
+        .highlight_symbol(highlight_symbol(theme));
+    frame.render_stateful_widget(list, body_area, &mut state);
+}
+
 pub(super) fn render_claude_model_picker_overlay(
     frame: &mut Frame<'_>,
     app: &App,

--- a/src-tauri/src/cli/tui/ui/overlay/render.rs
+++ b/src-tauri/src/cli/tui/ui/overlay/render.rs
@@ -84,6 +84,15 @@ pub(crate) fn render_overlay(
                 *selected,
             )
         }
+        Overlay::CodexReasoningLevelsPicker { .. }
+        | Overlay::CodexDefaultReasoningPicker { .. } => {
+            super::pickers::render_codex_reasoning_picker_overlay(
+                frame,
+                content_area,
+                theme,
+                &app.overlay,
+            )
+        }
         Overlay::UserAgentPicker { selected } => super::pickers::render_user_agent_picker_overlay(
             frame,
             app,

--- a/src-tauri/src/cli/tui/ui/tests.rs
+++ b/src-tauri/src/cli/tui/ui/tests.rs
@@ -2828,6 +2828,79 @@ fn provider_passive_fields_bound_million_byte_classifiers_and_validation() {
 }
 
 #[test]
+fn codex_model_catalog_reasoning_fields_and_pickers_render_in_both_languages() {
+    let _lock = lock_env();
+    let _no_color = EnvGuard::remove("NO_COLOR");
+    for language in [Language::English, Language::Chinese] {
+        let _lang = use_test_language(language);
+        for inline in [false, true] {
+            let mut form = crate::cli::tui::form::ProviderAddFormState::new(AppType::Codex);
+            form.codex_local_routing_enabled = true;
+            form.upsert_codex_model_catalog_model("test-model");
+            form.codex_model_catalog[0].reasoning_levels = vec!["none".into(), "high".into()];
+            form.codex_model_catalog[0].default_reasoning_level = "high".into();
+            if inline {
+                form.open_codex_local_routing_page();
+            } else {
+                form.open_codex_model_catalog_page();
+            }
+            let mut app = App::new(Some(AppType::Codex));
+            app.route = Route::Providers;
+            app.focus = Focus::Content;
+            app.form = Some(FormState::ProviderAdd(form));
+            let data = minimal_data(&AppType::Codex);
+            for width in [80, 120] {
+                let all = all_text(&render_with_size(&app, &data, width, 30));
+                for label in [
+                    texts::tui_codex_reasoning_levels_header(),
+                    texts::tui_codex_default_reasoning_header(),
+                    "high",
+                ] {
+                    assert!(
+                        all.replace(' ', "").contains(&label.replace(' ', "")),
+                        "missing {label} at {width}: {all}"
+                    );
+                }
+            }
+            app.overlay = Overlay::CodexReasoningLevelsPicker {
+                row: 0,
+                selected: 4,
+                checked: [true, false, false, false, true, false, false, false],
+            };
+            let all = all_text(&render_with_size(&app, &data, 80, 30));
+            for label in [
+                texts::tui_codex_reasoning_levels(),
+                "Space",
+                "none",
+                "minimal",
+                "ultra",
+            ] {
+                assert!(
+                    all.replace(' ', "").contains(&label.replace(' ', "")),
+                    "missing {label}: {all}"
+                );
+            }
+            app.overlay = Overlay::CodexDefaultReasoningPicker {
+                row: 0,
+                selected: 2,
+                options: vec![String::new(), "none".into(), "high".into()],
+            };
+            let all = all_text(&render_with_size(&app, &data, 80, 30));
+            for label in [
+                texts::tui_codex_default_reasoning_level(),
+                texts::tui_codex_reasoning_auto(),
+                "high",
+            ] {
+                assert!(
+                    all.replace(' ', "").contains(&label.replace(' ', "")),
+                    "missing {label}: {all}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn codex_model_catalog_renders_only_the_selected_large_collection_window() {
     let _lock = lock_env();
     let _lang = use_test_language(Language::English);


### PR DESCRIPTION
Codex users could preserve per-model reasoning settings in imported catalogs but could not edit them in the TUI. Both model catalog entry points now expose supported reasoning levels and a default, using the existing selection dialogs and contextual help.

The options, ordering, unset behavior, and Auto default follow upstream. Cancel preserves the original values, and removing a selected default restores Auto. Changes are limited to the TUI and its tests; existing catalog generation is reused.

Validation:
- Library tests: 4,332 passed, 2 ignored; binary tests: 10 passed; formatting passed.
- Real TUI editing and saving at 80 columns, followed by native Codex 0.153.4 `model/list`, confirmed distinct levels and defaults for two models. All configuration was isolated and used fake credentials.
- Two independent blind reviews found no issues; each passed 14 model catalog tests.
- Clippy completed with the existing `reversed_empty_ranges` lint allowed.

Refs #441.
