### PR TITLE
fix(codex): respect user-owned model_catalog_json when generating catalog

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -898,8 +898,23 @@ fn set_codex_model_catalog_json_field(
 
     match catalog_path {
         Some(_path) => {
-            // 使用相对文件名而非绝对路径，保持与 Codex 自身引用方式一致
-            doc["model_catalog_json"] = toml_edit::value(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME);
+            // Only claim the pointer when it is absent or already cc-switch-owned.
+            // A user-managed external catalog file (custom filename or path) is
+            // left untouched, mirroring the None arm's ownership rule that
+            // `resolve_cc_switch_catalog_path` relies on.
+            let is_cc_switch_owned = doc
+                .get("model_catalog_json")
+                .and_then(|item| item.as_str())
+                .map(|path| {
+                    Path::new(path).file_name().and_then(|name| name.to_str())
+                        == Some(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME)
+                })
+                .unwrap_or(true);
+            if is_cc_switch_owned {
+                // 使用相对文件名而非绝对路径，保持与 Codex 自身引用方式一致
+                doc["model_catalog_json"] =
+                    toml_edit::value(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME);
+            }
         }
         None => {
             let should_remove = doc
@@ -3036,6 +3051,44 @@ name = "any"
                 .and_then(|value| value.get("model_catalog_json"))
                 .is_none(),
             "model_catalog_json should stay top-level"
+        );
+    }
+
+    #[test]
+    fn set_catalog_json_some_preserves_user_owned_catalog() {
+        // When cc-switch generates a catalog (Some arm), it must still respect a
+        // user-managed external catalog file instead of clobbering it with the
+        // cc-switch-owned filename. Only an absent or cc-switch-owned pointer is
+        // claimed; this mirrors the None arm's ownership rule.
+        let input = r#"model_provider = "custom"
+model = "glm-5"
+model_catalog_json = "/Users/me/.codex/my-custom-catalog.json"
+"#;
+        let catalog_path = Path::new("/tmp/cc-switch-model-catalog.json");
+        let result = set_codex_model_catalog_json_field(input, Some(catalog_path)).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+        assert_eq!(
+            parsed.get("model_catalog_json").and_then(|v| v.as_str()),
+            Some("/Users/me/.codex/my-custom-catalog.json"),
+            "Some arm should NOT clobber a user-owned catalog (full path)"
+        );
+    }
+
+    #[test]
+    fn set_catalog_json_some_preserves_user_owned_relative_filename() {
+        // A bare custom filename (no directory component) is also user-owned
+        // and must be preserved by the Some arm.
+        let input = r#"model_provider = "custom"
+model = "glm-5"
+model_catalog_json = "my-custom-catalog.json"
+"#;
+        let catalog_path = Path::new("/tmp/cc-switch-model-catalog.json");
+        let result = set_codex_model_catalog_json_field(input, Some(catalog_path)).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+        assert_eq!(
+            parsed.get("model_catalog_json").and_then(|v| v.as_str()),
+            Some("my-custom-catalog.json"),
+            "Some arm should NOT clobber a relative user-owned catalog"
         );
     }
 


### PR DESCRIPTION
## Summary

Port the user-owned model-catalog fix from the desktop upstream (farion1231/cc-switch#6087). When model mapping generates the Codex catalog, cc-switch-cli currently replaces any existing `model_catalog_json` value with `cc-switch-model-catalog.json`. This PR makes the write side preserve user-managed catalog pointers.

## Problem

`set_codex_model_catalog_json_field` in `src-tauri/src/codex_config.rs` has two arms:

- The `None` arm already checks ownership and only removes cc-switch-owned pointers.
- The `Some` arm unconditionally writes `CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME`, clobbering user paths such as `~/.codex/model-catalog.local.json`.

Starting the Codex local route with model mapping enabled therefore rewrites `config.toml`, breaking setups that depend on a user-managed catalog file. This builds on #265, which closed #260 by switching the same write to a relative filename.

## Fix

Mirror the `None` arm's ownership rule in the `Some` arm: claim the pointer only when it is absent or already cc-switch-owned (matched by filename); otherwise leave the user's catalog path untouched. The generated `cc-switch-model-catalog.json` file is still written, so model-mapping based proxy routing keeps working.

## Testing

- `cargo fmt --check` passes.
- `cargo test --lib`: 4334 passed, 0 failed, 2 ignored (CI-style sandbox environment).
- Added two unit tests covering the `Some` arm:
  - `set_catalog_json_some_preserves_user_owned_catalog` (absolute custom path)
  - `set_catalog_json_some_preserves_user_owned_relative_filename` (bare custom filename)
- Manually verified: with model mapping enabled and a user-owned `model_catalog_json`, enabling the Codex local route keeps the pointer in `config.toml` and multi-model routing continues to work.