### PR TITLE
fix(sessions): allow Windows session cache synchronization

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -82,6 +82,12 @@ jobs:
           cargo check --lib --no-default-features
           cargo test --lib --no-default-features --no-run
 
+      - name: Test Windows session cache file synchronization
+        if: runner.os == 'Windows'
+        working-directory: src-tauri
+        # These tests use only their own temporary directories.
+        run: cargo test --lib --no-default-features session_manager::paged_manifest::tests::sync_private_file -- --nocapture
+
       - name: Check default Windows CLI build
         if: runner.os == 'Windows'
         working-directory: src-tauri

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ Request handling flows through `HandlerContext`, `ProviderRouter`, `RequestForwa
 ## Blind review protocol
 
 - After implementation and local validation are complete, send the full change set to two independent subagents for blind review.
+- Start each reviewer with fresh context, without inheriting the development conversation. Before review begins, tell the user the requirements, acceptance criteria, and task boundaries given to the reviewers.
 - For every reviewer in every round, including a later round reduced to one reviewer, provide the user's goal, intended behavior, acceptance criteria, and relevant constraints so they can judge whether the change actually satisfies the request. Do not disclose the implementation approach, fixes already made, or findings from any prior reviewer or round. Ask each reviewer to inspect all current modifications and report correctness, regression, security, performance, UX, and test-coverage issues.
 - Keep the two reviews independent. Reviewers must not receive or infer the other reviewer's findings before producing their own report.
 - Validate every finding against the code. Fix confirmed issues, then start a fresh two-reviewer blind round with new subagents under the same reviewer-context rules above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ Request handling flows through `HandlerContext`, `ProviderRouter`, `RequestForwa
 ## Blind review protocol
 
 - After implementation and local validation are complete, send the full change set to two independent subagents for blind review.
+- Start each reviewer with fresh context, without inheriting the development conversation. Before review begins, tell the user the requirements, acceptance criteria, and task boundaries given to the reviewers.
 - For every reviewer in every round, including a later round reduced to one reviewer, provide the user's goal, intended behavior, acceptance criteria, and relevant constraints so they can judge whether the change actually satisfies the request. Do not disclose the implementation approach, fixes already made, or findings from any prior reviewer or round. Ask each reviewer to inspect all current modifications and report correctness, regression, security, performance, UX, and test-coverage issues.
 - Keep the two reviews independent. Reviewers must not receive or infer the other reviewer's findings before producing their own report.
 - Validate every finding against the code. Fix confirmed issues, then start a fresh two-reviewer blind round with new subagents under the same reviewer-context rules above.

--- a/src-tauri/src/session_manager/paged_manifest.rs
+++ b/src-tauri/src/session_manager/paged_manifest.rs
@@ -2747,8 +2747,12 @@ fn sync_private_file(path: &Path) -> Result<(), ManifestError> {
         fs::set_permissions(path, fs::Permissions::from_mode(0o600))
             .map_err(|error| ManifestError::io(path, error))?;
     }
-    File::open(path)
-        .and_then(|file| file.sync_all())
+    // Windows FlushFileBuffers requires a handle with write access.
+    #[cfg(windows)]
+    let file = fs::OpenOptions::new().write(true).open(path);
+    #[cfg(not(windows))]
+    let file = File::open(path);
+    file.and_then(|file| file.sync_all())
         .map_err(|error| ManifestError::io(path, error))
 }
 
@@ -2783,6 +2787,32 @@ fn read_json_limited<T: DeserializeOwned>(path: &Path, max_bytes: u64) -> Result
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn sync_private_file_preserves_contents() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join(COORDINATOR_FILE);
+        let contents = b"{\"buildEpoch\":1}";
+        fs::write(&path, contents).expect("write coordinator");
+
+        sync_private_file(&path).expect("sync existing coordinator");
+
+        assert_eq!(fs::read(&path).expect("read coordinator"), contents);
+    }
+
+    #[test]
+    fn sync_private_file_does_not_create_missing_file() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join(COORDINATOR_FILE);
+
+        let error = sync_private_file(&path).expect_err("missing file must fail");
+
+        assert!(matches!(
+            error,
+            ManifestError::Io { source, .. } if source.kind() == std::io::ErrorKind::NotFound
+        ));
+        assert!(!path.exists());
+    }
 
     fn meta(provider: &str, id: &str, recency: i64) -> SessionMeta {
         SessionMeta {


### PR DESCRIPTION
Windows session scans can fail with `Access denied (os error 5)` while persisting `.coord.json`, even when the configuration directory is writable. Open the session-cache file with write access on Windows before syncing it, as required by `FlushFileBuffers`. Preserve the existing non-Windows path and do not create or truncate files during synchronization.

Add focused tests for preserving contents and rejecting missing files, and run them in the existing Windows CI job. Clarify fresh-context blind reviews in both repository guidance files. No other application behavior changes.

Validation:
- `cargo fmt --check`
- `cargo test --lib --no-default-features session_manager::paged_manifest::tests:: -- --test-threads=1`: 37 passed in an isolated filesystem sandbox on Linux.
- Workflow YAML parsing and matching guidance verified.
- Two independent fresh-context blind reviews: no actionable findings.
- Native Windows regression tests: 2 passed in CI; all Rust CI jobs passed.

Fixes #450
