### PR TITLE
feat(quota): show local reset times and remaining duration

### DIFF
--- a/src-tauri/src/cli/commands/provider_inspect.rs
+++ b/src-tauri/src/cli/commands/provider_inspect.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use crate::app_config::AppType;
 use crate::cli::i18n::texts;
 use crate::cli::provider_quota::{
-    display_usage_plan_name, provider_display_name, query_quota, quota_target_for_provider,
-    usage_value_summary, ProviderUsageQuota, QuotaTarget,
+    display_usage_plan_name, provider_display_name, query_quota, quota_reset_display,
+    quota_target_for_provider, usage_value_summary, ProviderUsageQuota, QuotaTarget,
 };
 use crate::cli::ui::{create_table, error, highlight, info, success, to_json, warning};
 use crate::error::AppError;
@@ -679,12 +679,25 @@ fn push_subscription_quota_lines(
             queried_at
         ));
     }
+    let now = chrono::Utc::now();
     for tier in &quota.tiers {
-        lines.push(format!(
+        let mut line = format!(
             "{}: {}",
             quota_tier_label(&tier.name),
             quota_percent_text(tier.utilization)
-        ));
+        );
+        if let Some(reset) = quota_reset_display(tier.resets_at.as_deref(), now) {
+            let local_time = reset
+                .at
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M %:z")
+                .to_string();
+            line.push_str(&format!("  {}", texts::tui_quota_resets_at(&local_time)));
+            if let Some(remaining) = reset.remaining {
+                line.push_str(&format!("  {}", texts::tui_quota_resets_in(&remaining)));
+            }
+        }
+        lines.push(line);
     }
     if let Some(extra) = quota.extra_usage.as_ref().filter(|extra| extra.is_enabled) {
         let mut parts = Vec::new();
@@ -1366,6 +1379,69 @@ base_url = "https://current.example.com/v1"
         .join("\n");
         assert!(expired.contains(texts::tui_quota_expired()));
         assert!(expired.contains("Error: expired"));
+    }
+
+    #[test]
+    fn provider_quota_text_shows_local_reset_time_without_changing_json() {
+        for language in [
+            crate::cli::i18n::Language::English,
+            crate::cli::i18n::Language::Chinese,
+        ] {
+            let _lang = crate::cli::i18n::use_test_language(language);
+            let resets_at = "2099-06-01T20:43:00+08:00";
+            let output = quota_output(ProviderUsageQuota::Subscription(subscription_quota(
+                CredentialStatus::Valid,
+                true,
+                vec![QuotaTier {
+                    name: "five_hour".to_string(),
+                    utilization: 0.0,
+                    resets_at: Some(resets_at.to_string()),
+                }],
+            )));
+            let local_time = chrono::DateTime::parse_from_rfc3339(resets_at)
+                .unwrap()
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M %:z")
+                .to_string();
+            let remaining = quota_reset_display(Some(resets_at), chrono::Utc::now())
+                .unwrap()
+                .remaining
+                .unwrap();
+            let joined = provider_quota_text_lines(&output).join("\n");
+            assert!(joined.contains(&format!(
+                "{}: 0%  {}  {}",
+                texts::tui_quota_tier_five_hour(),
+                texts::tui_quota_resets_at(&local_time),
+                texts::tui_quota_resets_in(&remaining),
+            )));
+            let json = serde_json::to_value(&output).unwrap();
+            assert_eq!(json["result"]["quota"]["tiers"][0]["resetsAt"], resets_at);
+        }
+    }
+
+    #[test]
+    fn provider_quota_text_omits_invalid_resets_and_elapsed_countdowns() {
+        let _lang = crate::cli::i18n::use_test_language(crate::cli::i18n::Language::English);
+        for resets_at in [None, Some("invalid"), Some("2000-01-01T00:00:00Z")] {
+            let output = quota_output(ProviderUsageQuota::Subscription(subscription_quota(
+                CredentialStatus::Valid,
+                true,
+                vec![QuotaTier {
+                    name: "seven_day".to_string(),
+                    utilization: 100.0,
+                    resets_at: resets_at.map(str::to_string),
+                }],
+            )));
+            let lines = provider_quota_text_lines(&output);
+            let tier = lines.iter().find(|line| line.starts_with("7d:")).unwrap();
+            assert!(tier.starts_with("7d: 100%"));
+            assert!(!tier.contains("resets in"));
+            if resets_at == Some("2000-01-01T00:00:00Z") {
+                assert!(tier.contains("reset:"));
+            } else {
+                assert_eq!(tier, "7d: 100%");
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/src/cli/i18n.rs
+++ b/src-tauri/src/cli/i18n.rs
@@ -1532,6 +1532,14 @@ pub mod texts {
         }
     }
 
+    pub fn tui_quota_resets_at(time: &str) -> String {
+        if is_chinese() {
+            format!("重置时间: {time}")
+        } else {
+            format!("reset: {time}")
+        }
+    }
+
     pub fn tui_quota_resets_in(time: &str) -> String {
         if is_chinese() {
             format!("{time} 后重置")

--- a/src-tauri/src/cli/provider_quota.rs
+++ b/src-tauri/src/cli/provider_quota.rs
@@ -47,6 +47,33 @@ pub(crate) enum ProviderUsageQuota {
     Script(UsageResult),
 }
 
+pub(crate) struct QuotaResetDisplay {
+    pub(crate) at: chrono::DateTime<chrono::FixedOffset>,
+    pub(crate) remaining: Option<String>,
+}
+
+pub(crate) fn quota_reset_display(
+    resets_at: Option<&str>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<QuotaResetDisplay> {
+    let at = chrono::DateTime::parse_from_rfc3339(resets_at?).ok()?;
+    let diff = at.signed_duration_since(now);
+    // Match upstream SubscriptionQuotaFooter.countdownStr: elapsed resets
+    // have no countdown, and future windows use whole minutes/hours/days.
+    let remaining = (diff > chrono::Duration::zero()).then(|| {
+        let minutes = diff.num_minutes();
+        let hours = minutes / 60;
+        if hours > 24 {
+            format!("{}d{}h", hours / 24, hours % 24)
+        } else if hours > 0 {
+            format!("{hours}h{}m", minutes % 60)
+        } else {
+            format!("{minutes}m")
+        }
+    });
+    Some(QuotaResetDisplay { at, remaining })
+}
+
 pub(crate) fn provider_display_name(app_type: &AppType, id: &str, provider: &Provider) -> String {
     let name = provider.name.trim();
     if !name.is_empty() {
@@ -209,6 +236,49 @@ mod tests {
 
     use super::*;
     use crate::provider::{AuthBinding, AuthBindingSource, ProviderMeta, UsageScript};
+
+    #[test]
+    fn quota_reset_countdown_matches_upstream_windows() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-09-12T12:00:00Z")
+            .unwrap()
+            .to_utc();
+        for (seconds, expected) in [
+            (1, "0m"),
+            (59, "0m"),
+            (60, "1m"),
+            (9_000, "2h30m"),
+            (86_400, "24h0m"),
+            (89_940, "24h59m"),
+            (90_000, "1d1h"),
+            (302_400, "3d12h"),
+        ] {
+            let resets_at = (now + chrono::Duration::seconds(seconds)).to_rfc3339();
+            let reset = quota_reset_display(Some(&resets_at), now).unwrap();
+            assert_eq!(reset.remaining.as_deref(), Some(expected), "{seconds}s");
+        }
+        let reset = quota_reset_display(Some("2026-09-12T20:43:00+08:00"), now).unwrap();
+        assert_eq!(reset.remaining.as_deref(), Some("43m"));
+        assert_eq!(reset.at.to_utc(), now + chrono::Duration::minutes(43));
+    }
+
+    #[test]
+    fn quota_reset_display_handles_missing_invalid_and_elapsed_times() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-09-12T12:00:00Z")
+            .unwrap()
+            .to_utc();
+        for resets_at in [
+            None,
+            Some(""),
+            Some("invalid"),
+            Some("2026-99-99T00:00:00Z"),
+        ] {
+            assert!(quota_reset_display(resets_at, now).is_none());
+        }
+        for resets_at in ["2026-09-12T12:00:00Z", "2026-09-11T12:00:00Z"] {
+            let reset = quota_reset_display(Some(resets_at), now).unwrap();
+            assert!(reset.remaining.is_none());
+        }
+    }
 
     fn test_provider(id: &str, name: &str, settings_config: Value) -> Provider {
         Provider::with_id(id.to_string(), name.to_string(), settings_config, None)

--- a/src-tauri/src/cli/tui/ui/providers.rs
+++ b/src-tauri/src/cli/tui/ui/providers.rs
@@ -567,6 +567,94 @@ mod tests {
     }
 
     #[test]
+    fn official_provider_list_shows_compact_reset_countdown() {
+        let _lock = super::super::tests::lock_env();
+        let _lang = crate::cli::i18n::use_test_language(crate::cli::i18n::Language::English);
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+        let mut data = current_official_claude_data();
+        let Some(ProviderUsageQuota::Subscription(mut quota)) =
+            data.quota.state_for("official").unwrap().quota.clone()
+        else {
+            panic!("expected subscription quota");
+        };
+        quota.tiers[0].resets_at =
+            Some((chrono::Utc::now() + chrono::Duration::seconds(12_630)).to_rfc3339());
+        quota.tiers[1].resets_at = Some("invalid".to_string());
+        let target =
+            data::quota_target_for_provider(&AppType::Claude, &data.providers.rows[0]).unwrap();
+        data.quota
+            .finish(target, ProviderUsageQuota::Subscription(quota));
+
+        let all = all_text(&super::super::tests::render_with_size(&app, &data, 220, 40));
+        assert!(all.contains("5h 42%  7d 70%"), "{all}");
+        assert!(all.contains("(5h 3h30m)"), "{all}");
+        assert!(all.contains("7d 70%"), "{all}");
+        assert!(!all.contains("invalid"), "{all}");
+        assert!(!all.contains(texts::tui_header_quota()), "{all}");
+    }
+
+    #[test]
+    fn provider_quota_keeps_values_and_refresh_status_visible_on_narrow_terminals() {
+        let _lock = super::super::tests::lock_env();
+        let _lang = crate::cli::i18n::use_test_language(crate::cli::i18n::Language::English);
+        let mut app = App::new(Some(AppType::Claude));
+        app.route = Route::Providers;
+        app.focus = Focus::Content;
+        let mut data = current_official_claude_data();
+        let Some(ProviderUsageQuota::Subscription(mut quota)) =
+            data.quota.state_for("official").unwrap().quota.clone()
+        else {
+            panic!("expected subscription quota");
+        };
+        for tier in &mut quota.tiers {
+            tier.resets_at = Some((chrono::Utc::now() + chrono::Duration::hours(3)).to_rfc3339());
+        }
+        let target =
+            data::quota_target_for_provider(&AppType::Claude, &data.providers.rows[0]).unwrap();
+        data.quota
+            .finish(target.clone(), ProviderUsageQuota::Subscription(quota));
+        data.quota.mark_loading(target.clone(), true);
+
+        let mut baseline = current_official_claude_data();
+        baseline.quota.mark_loading(target, true);
+        let labels = ["5h 42%  7d 70%", "s ago", texts::tui_quota_loading()];
+        let mut compared = [0; 3];
+        for width in [120, 140, 160, 180, 200, 220] {
+            let before = all_text(&super::super::tests::render_with_size(
+                &app, &baseline, width, 40,
+            ));
+            let all = all_text(&super::super::tests::render_with_size(
+                &app, &data, width, 40,
+            ));
+            let Some(before_row) = before
+                .lines()
+                .find(|line| line.contains("Claude Official") && line.contains("5h 42%"))
+            else {
+                continue;
+            };
+            let after_row = all
+                .lines()
+                .find(|line| line.contains("Claude Official") && line.contains("5h 42%"))
+                .unwrap();
+            for (index, label) in labels.iter().enumerate() {
+                if before_row.contains(label) {
+                    compared[index] += 1;
+                    assert!(
+                        after_row.contains(label),
+                        "width={width}, label={label}\n{all}"
+                    );
+                }
+            }
+        }
+        assert!(
+            compared.iter().all(|count| *count > 0),
+            "cover all quota/status fields: {compared:?}"
+        );
+    }
+
+    #[test]
     fn official_provider_list_shows_inline_quota_and_refresh_hint() {
         let _lock = super::super::tests::lock_env();
         let _no_color = super::super::tests::EnvGuard::remove("NO_COLOR");

--- a/src-tauri/src/cli/tui/ui/shared.rs
+++ b/src-tauri/src/cli/tui/ui/shared.rs
@@ -776,6 +776,8 @@ pub(super) fn quota_compact_line(
     }
 
     let mut spans = Vec::new();
+    let mut resets = Vec::new();
+    let now = chrono::Utc::now();
     for (idx, tier) in tiers.iter().enumerate() {
         if idx > 0 {
             spans.push(Span::raw("  "));
@@ -788,6 +790,12 @@ pub(super) fn quota_compact_line(
             quota_percent_text(tier.utilization),
             quota_utilization_style(theme, tier.utilization),
         ));
+        if let Some(remaining) =
+            crate::cli::provider_quota::quota_reset_display(tier.resets_at.as_deref(), now)
+                .and_then(|reset| reset.remaining)
+        {
+            resets.push(format!("{} {remaining}", quota_tier_label(&tier.name)));
+        }
     }
     if let Some(checked) = quota.queried_at.map(quota_relative_time_compact) {
         if !spans.is_empty() {
@@ -802,6 +810,13 @@ pub(super) fn quota_compact_line(
         spans.push(Span::styled(
             texts::tui_quota_loading().to_string(),
             Style::default().fg(theme.surface),
+        ));
+    }
+    // Preserve the full existing quota/status prefix on narrow terminals.
+    if !resets.is_empty() {
+        spans.push(Span::styled(
+            format!(" ({})", resets.join(", ")),
+            Style::default().fg(theme.comment),
         ));
     }
     Some(Line::from(spans))


### PR DESCRIPTION
`provider quota` now shows each valid reset timestamp in the local timezone, including its UTC offset, alongside the remaining duration. Previously this information was available only in `--json`. The existing compact TUI quota line also shows muted countdowns after the existing utilization and refresh status.

Keep the upstream quota data and query behavior unchanged. Countdown formatting follows upstream `SubscriptionQuotaFooter.countdownStr` (upstream checked after pulling, commit `1d5d90f4`). Missing or invalid timestamps add no reset text; elapsed timestamps retain their local reset time in CLI output without a future countdown. Raw JSON timestamps are preserved.

Validation:
- `cargo fmt --check` and `git diff --check`.
- `cargo test --lib quota -- --test-threads=1`: 33 passed in an isolated filesystem sandbox.
- Compact TUI rendering and narrow-terminal percentage and refresh-status visibility tests passed.
- Local-time output test passed under `TZ=Asia/Shanghai` and `TZ=America/New_York`.

- Two independent blind-review rounds followed by a fresh final review; no remaining actionable findings.

- Rust CI passed, including full unit/integration tests and Windows CLI compilation.

Fixes #445
